### PR TITLE
MOS-618: Fix input settings from documentation

### DIFF
--- a/src/Forms/Form/Form.stories.mdx
+++ b/src/Forms/Form/Form.stories.mdx
@@ -174,87 +174,6 @@ const App = (props) => {
 }
 ```
 
-## Types
-
-### MosaicLabelValue (Type)
-* **label** - `string` required
-* **value** - `string` required
-
-### MosaicObject (Type)
-* **[key: string]** - `unknown` required
-
-### MenuItemProps (Type)
-* **label** - `string | JSX Element` required
-* **color** - `"red" | "blue" ` optional
-* **disabled** - `boolean` optional
-* **selected** - `boolean` optional
-* **onClick** - `(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void` required
-* **mIcon** - `MosaicMIcon` optional
-* **attrs** - `MosaicObject` optional
-
-### ButtonAttrs (Type)
-* **label** - `string | JSX Element` optional
-* **className** - `string` optional
-* **href** - `string` optional
-* **color** - `"black" | "blue" | "lightBlue" | "red" | "yellow" | "teal" | "gray"` required
-* **mIcon** - `MosaicMIcon` optional - (Any Icon from MUI library).
-* **variant** - `"icon" | "outlined" | "contained" | "text"` required
-* **size** - `"small" | "medium" | "large"` optional
-* **iconPosition** - `"left" | "right"` optional
-* **disabled** - `boolean` optional
-* **fullWidth** - `boolean` optional
-* **tooltip** - `string | JSX Element` optional
-* **popover** - `JSX Element` optional
-* **menuItems** - `MenuItemProps[]` optional
-* **menuContent** - `JSX Element` optional
-* **mIconColor** - `string` optional
-* **onClick** - `(event: React.MouseEvent<HTMLButtonElement>) => void` optional
-* **attrs** - `MosaicObject` optional
-* **muiAttrs** - `MosaicObject` optional
-
-## Validators
-All of the following default validators return string (with the error message) or undefined (when no error was found). I
-
-### validateEmail
-* Receives: string
-* Error message returned: "The value is not a valid e-mail"
-* Ways of declaring:
-	* "validateEmail"
-	* { fn: "validateEmail", options: undefined }
-
-### required
-* Receives: string | string[]
-* Error message returned: "This field is required, please fill it"
-* Ways of declaring:
-	* "required"
-	* { fn: "required", options: undefined }
-	* As a boolean prop for all fields (see [Generic Field Props subsection](#generic-field-props-fielddef))
-
-### validateNumber
-* Receives: string
-* Error message returned: "The value is not a number"
-* Ways of declaring:
-	* "validateNumber"
-	* { fn: "validateNumber", options: undefined }
-
-### validateURL
-* Receives: string
-* Error message returned: "The value is not a valid URL"
-* Ways of declaring:
-	* "validateURL"
-	* { fn: "validateURL", options: undefined }
-
-### validateDateRange
-- This is the only validator that requires to be added to 2 fields in order to work: the fields serving as start and end date respectively.
-- The startDate field will add the name of the endDate field linked to in the options attribute. 
-- The endDate field will add the name of the startDate field linked to in the options attribute. 
-
-* Receives: value: `string`, data: `object` (see data attribute on [State](#state)), options: `MosaicObject`
-* Error message returned: "Start date should happen before the end date"
-* Ways of declaring:
-	* { fn: "validateDateRange", options: { endDateName: "nameOfField" } }
-	* { fn: "validateDateRange", options: { startDateName: "nameOfField" } }
-
 ## Form Fields
 - All fields share a series of props that help the form identify and interact with each field.
 
@@ -281,13 +200,13 @@ All of the following default validators return string (with the error message) o
 	* **col** - `number` optional - Defines the column where the field will appear (begins at 0).
 * **validators** - `array` of `string | { fn: string; options: any } | (() => string | undefined | JSX Element))` optional - Validators to be executed when an onBlur occurs on the Field or when an onSubmit occurs on the Form (see the [Validators section](#validators) for more information about default and custom validators).
 * **id** - `string` optional - Follows the same rules as any other html element id.
-* **defaultValue** - `<U>` optional - Value to be used in case no initial value is loaded from a data base. This value should be of the same type as from its corresponding field (see onChange return value of each specific field).
+* **defaultValue** - `<U>` optional - Value to be used in case no initial value is loaded from a data base. This value should be of the same type as from its corresponding field (see data of each specific field).
 * **pairedFields** - `array` of `string` optional - Array of field names to be linked to this field.
 
 ## FormFieldAddress
 - Countries, states and cities information retrieved from: [Countries States Cities Database](https://github.com/dr5hn/countries-states-cities-database)
 - [**Playground**](/?path=/story/formfields-formfieldaddress--playground)
-- Default Value: `object`
+- Data: `object`
 	* **address1** - `string` required - Main address.
 	* **address2** - `string` optional - Additional address.
 	* **address3** - `string` optional - Additional address.
@@ -296,9 +215,7 @@ All of the following default validators return string (with the error message) o
 	* **postalCode** - `string` required - Postal code of the address.
 	* **state** - `object` required - Must follow the format given on [Countries States Cities Database](https://github.com/dr5hn/countries-states-cities-database).
 	* **types** - `array` of `string` required - Could be one of the following: Physical, Billing, Shipping.
-
-### Props (Input Settings)
-This component doesn't require any additional props.
+- inputSettings: This component doesn't require any additional props.
 
 ### How to use in a form?
 ```ts
@@ -326,21 +243,16 @@ const fields = useMemo(
 - Used for very long lists. 
 - Have the ability to type and search.
 - [**Playground**](/?path=/story/formfields-formfieldadvancedselection--playground)
-- Default Value: `array` of `string` - Array of values of the selected options.
-
-### Props (Input Settings)
-* **createNewOption** - `(filter: string) => Promise<string>` optional -  Function used to insert more options either on the local options array, or on the DB.
-* **getSelected** - `(options: string[]) => Promise<{label: string, value: string, category: string}[]>` optional -  Function used to get the full info (label, value, category) of all selected options.
-
-This prop only applies when getting options locally.
-* **checkboxOptions** - `object` optional -  Function used to get the full info (label, value, category) of all selected options.
+- Data: `array` of `string` - Array of values of the selected options.
+- inputSettings:
+	* **createNewOption** - `(filter: string) => Promise<string>` optional -  Function used to insert more options either on the local options array, or on the DB.
+	* **getSelected** - `(options: string[]) => Promise<{label: string, value: string, category: string}[]>` optional -  Function used to get the full info (label, value, category) of all selected options.
+	* **checkboxOptions** - `object` optional -  Function used to get the full info (label, value, category) of all selected options. This prop only applies when getting options locally.
 	* **label** - `string` required -  Text users will see to identify the option.
 	* **value** - `string` required -  Value that will be saved to the DB when the option gets selected.
 	* **category** - `string` SOON TO BE DEPRECATED - Category in which the option belongs to.
-
-These props only apply when getting options from a DB. 
-* **getOptions** - `({filter?: string, limit?: number, offset?: number}) => Promise<{label: string, value: string, category: string}[]>` required - Function to get the next set of options.
-* **getOptionsLimit** - `number | string` optional - When defined, limits the amount of options to get from the DB.
+	* **getOptions** - `({filter?: string, limit?: number, offset?: number}) => Promise<{label: string, value: string, category: string}[]>` required - Function to get the next set of options. This prop only applies when getting options from a DB.
+	* **getOptionsLimit** - `number | string` optional - When defined, limits the amount of options to get from the DB. This prop only applies when getting options from a DB.
 
 ### How to use in a form?
 ```ts
@@ -394,10 +306,9 @@ const fields = useMemo(
 ## FormFieldCheckbox
 - A group of checkbox buttons that allows users to select multiple items from a list of possible options.
 - [**Playground**](/?path=/story/formfields-formfieldcheckbox--playground)
-- Default Value: `array` of `string` - Array of values of the selected options.
-
-### Props (Input Settings)
-* **options** - `array` of `MosaicLabelValue` required - Array of options to be rendered containing their corresponding label and value.
+- Data: `array` of `string` - Array of values of the selected options.
+- inputSettings:
+	* **options** - `array` of `MosaicLabelValue` required - Array of options to be rendered containing their corresponding label and value.
 
 ### How to use in a form?
 ```ts
@@ -423,15 +334,13 @@ const fields = useMemo(
 );
 ```
 
-
 ## FormFieldChipSingleSelect
 - The `FormFieldChipSingleSelect` component is built over a wrapper for [Material-UI Autocomplete](https://material-ui.com/components/autocomplete/) but with SimpleView brand colors.
 - [**Playground**](/?path=/story/formfields-formfieldchipsingleselect--playground)
-- Default Value: `string` - Value of the selected option.
-
-### Props (Input Settings)
-* **options** - `array` of `{ label: string, value: string, selected?: boolean }` required - Array of options to be rendered containing their corresponding label, value, and indicator of whether its selected or not.
-* **onSelect** - `(...args) => void` optional - Callback to be executed when an option gets selected.
+- Data: `string` - Value of the selected option.
+- inputSettings:
+	* **options** - `array` of `{ label: string, value: string, selected?: boolean }` required - Array of options to be rendered containing their corresponding label, value, and indicator of whether its selected or not.
+	* **onSelect** - `(...args) => void` optional - Callback to be executed when an option gets selected.
 
 ### How to use in a form?
 ```ts
@@ -458,12 +367,12 @@ const fields = useMemo(
 );
 ```
 
-
 ## FormFieldColorPicker
 - The color picker component allows users to select from pre-defined colors (swatches) or custom colors using a HSB selection interface.
 - The implementation of this component is based on the following package: [React Color](https://casesandberg.github.io/react-color/)
 - [**Playground**](/?path=/story/formfields-formfieldcolorpicker--playground)
-- Default Value: `ColorResult` - Object containing all the different variants for the color selected.
+- Data: `ColorResult` - Object containing all the different variants for the color selected.
+- inputSettings: This component doesn't require any additional props.
 
 ### ColorResult (Type)
 * **hex** - `string`
@@ -478,8 +387,6 @@ const fields = useMemo(
 	* **g** - `number`
 	* **b** - `number`
 
-### Props (Input Settings)
-This component doesn't require any additional props.
 
 ### How to use in a form?
 ```ts
@@ -501,10 +408,9 @@ const fields = useMemo(
 ## FormFieldDateField
 - It allows the user to view and pick dates from a calendar widget or manually type the date in the text field.
 - [**Playground**](/?path=/story/formfields-formfielddatefield--playground)
-- Default Value: `string` - Date in UTC format transformed to string.
-
-### Props (Input Settings)
-* **showTime** - `boolean` optional - When true a time field will appear next to the date field.
+- Data: `string` - Date in UTC format transformed to string.
+- inputSettings:
+	* **showTime** - `boolean` optional - When true a time field will appear next to the date field.
 
 ### How to use in a form?
 ```ts
@@ -530,12 +436,11 @@ const fields = useMemo(
 - All possible options are exposed up front for comparison.
 - Users can only make a single selection from the list of possible options.
 - [**Playground**](/?path=/story/formfields-formfieldradio--playground)
-- Default Value: `string` - Value of the selected option.
-
-#### Props (Input Settings)
-* **options** - `array` of `object` optional - Predefined set of mutually exclusive options.
-	* **label** - `string` required - Description of the option.
-	* **value** - `string` required - Value of the option, this is stored in the Form state.
+- Data: `string` - Value of the selected option.
+- inputSettings:
+	* **options** - `array` of `object` optional - Predefined set of mutually exclusive options.
+		* **label** - `string` required - Description of the option.
+		* **value** - `string` required - Value of the option, this is stored in the Form state.
 
 #### How to use in a form?
 ```ts
@@ -575,16 +480,14 @@ const fields = useMemo(
 - Text input fields are used to enter text information, numbers, e-mail addresses, or passwords. 
 - A text field consists of a label and a line with variations in width.
 - [**Playground**](/?path=/story/formfields-formfieldtext--playground)
-- Default Value: `string` - Value of the input typed.
-
-#### Props (Input Settings)
-
-* **maxCharacters** - `number` optional - Defines the limit of characters that are allow to type in the input element.
-* **multiline** - `boolean` optional - When is enabled the text field will expand its height.
-* **placeholder** - `string` optional - The hint displayed in the input before the user enters a value.
-* **prefixElement** - `JSX.Element` optional - Icon at the beginning of the text field.
-* **size** - `Size | string` optional - Size of the field. Could be either one of the predefined sizes (see [Generic Field Props subsection](#generic-field-props-fielddef)), or a custom size. This property can be internally overwritten if the field is placed inside of a row with other fields.
-* **type** - `string` optional - Type of the input element. It should be a [valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).
+- Data: `string` - Value of the input typed.
+- inputSettings:
+	* **maxCharacters** - `number` optional - Defines the limit of characters that are allow to type in the input element.
+	* **multiline** - `boolean` optional - When is enabled the text field will expand its height.
+	* **placeholder** - `string` optional - The hint displayed in the input before the user enters a value.
+	* **prefixElement** - `JSX.Element` optional - Icon at the beginning of the text field.
+	* **size** - `Size | string` optional - Size of the field. Could be either one of the predefined sizes (see [Sizes section](#sizes-type)), or a custom size. This property can be internally overwritten if the field is placed inside of a row with other fields.
+	* **type** - `string` optional - Type of the input element. It should be a [valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).
 
 #### How to use in a form?
 
@@ -615,13 +518,11 @@ const fields = useMemo(
 ## FormFieldTextArea
 - A text area is a multi-line plain-text editing control, is useful when you want to allow users to enter a sizeable amount of free-form text, but defining a specific height and width.
 - [**Playground**](/?path=/story/formfields-formfieldtextarea--playground)
-- Default Value: `string` - Value of the input typed.
-
-#### Props (Input Settings)
-
-* **maxCharacters** - `number` optional - Defines the limit of characters that are allow to type in the input element.
-* **placeholder** - `string` optional - The hint displayed in the input before the user enters a value.
-* **size** - `Size | string` optional - Size of the field. Could be either one of the predefined sizes (see [Generic Field Props subsection](#generic-field-props-fielddef)), or a custom size. This property can be internally overwritten if the field is placed inside of a row with other fields.
+- Data: `string` - Value of the input typed.
+- inputSettings:
+	* **maxCharacters** - `number` optional - Defines the limit of characters that are allow to type in the input element.
+	* **placeholder** - `string` optional - The hint displayed in the input before the user enters a value.
+	* **size** - `Size | string` optional - Size of the field. Could be either one of the predefined sizes (see [Sizes section](#sizes-type)), or a custom size. This property can be internally overwritten if the field is placed inside of a row with other fields.
 
 #### How to use in a form?
 
@@ -651,15 +552,12 @@ const fields = useMemo(
 - The text editor is a text area with added capabilities for use in various publishers, allowing the users to format their input in a text area.
 - This implementation is based on the [React Jodit WYSIWYG Editor](https://www.npmjs.com/package/jodit-react) package.
 - [**Playground**](/?path=/story/formfields-formfieldtexteditor--playground)
-- Default Value: `string` - Value of the input typed.
-
-
-#### Props (Input Settings)
-
-* **direction** - `"rtl" | "ltr" | ""` optional - Defines the starting point at which the typed words will be displayed, "lrt" starts from the left moving to the right and "rlt" vice versa. Default is "rlt".
-* **language** - `string` optional - Defines the language in which the assistive elements of the text editor will be displayed. For example the placeholder and the character and word counter
-* **maxCharacters** - `number` optional - Defines the limit of characters that are allow to type in the input element.
-* **spellcheck** - `boolean` optional - If it's enabled the text editor will mark misspellings.
+- Data: `string` - Value of the input typed.
+- inputSettings:
+	* **direction** - `"rtl" | "ltr" | ""` optional - Defines the starting point at which the typed words will be displayed, "lrt" starts from the left moving to the right and "rlt" vice versa. Default is "rlt".
+	* **language** - `string` optional - Defines the language in which the assistive elements of the text editor will be displayed. For example the placeholder and the character and word counter
+	* **maxCharacters** - `number` optional - Defines the limit of characters that are allow to type in the input element.
+	* **spellcheck** - `boolean` optional - If it's enabled the text editor will mark misspellings.
 
 #### How to use in a form?
 
@@ -688,20 +586,18 @@ const fields = useMemo(
 - Tables are used in some cases inside the form after selecting a list of elements or by using arrays
 - The data table component allows for customization with additional functionality, as needed by your product’s users.
 - [**Playground**](/?path=/story/formfields-formfieldtable--playground)
-- Default Value: `array` of `object` - Rows of the table.
+- Data: `array` of `object` - Rows of the table.
 	* **id** - `string` required - Unique identifier. Used as an identifier for the draggable item.
 	* **items** - `string[]` - Data that is shown in the table.
-
-#### Props (Input Settings)
-
-* **handleAddElement** - `() => void` required - Function used to create a new row in the table.
-* **handleEdit** - `(rowIndex: number) => void` required - Function that defines how the clicked row should be editted.
-* **handleDelete** - `() => void` required - Function that will be executed when clicking on the trash icon. It can be used to show some kind of confirmation before removing the row.
-* **extraActions** - `array` of `object` optional - Possible actions that the table could execute and display.
-	* **label** - `string` - Describes the action.
-	* **icon** - `MosaicMIcon` - MUI icon.
-	* **actionFnc** - `actionFnc: (rowIndex: number) => void;` - Function that is executed when the corresponding icon is clicked.
-* **headers** - `string[]` required - Array of the table headers.
+- inputSettings:
+	* **handleAddElement** - `() => void` required - Function used to create a new row in the table.
+	* **handleEdit** - `(rowIndex: number) => void` required - Function that defines how the clicked row should be editted.
+	* **handleDelete** - `() => void` required - Function that will be executed when clicking on the trash icon. It can be used to show some kind of confirmation before removing the row.
+	* **extraActions** - `array` of `object` optional - Possible actions that the table could execute and display.
+		* **label** - `string` - Describes the action.
+		* **icon** - `MosaicMIcon` - MUI icon.
+		* **actionFnc** - `actionFnc: (rowIndex: number) => void;` - Function that is executed when the corresponding icon is clicked.
+	* **headers** - `string[]` required - Array of the table headers.
 
 #### How to use in a form?
 
@@ -794,11 +690,9 @@ const fields = useMemo(
 - Toggles should be used to turn on or off a preference, notification, or feature
 - Should be used when an instant response is required/desired
 - [**Playground**](/?path=/story/formfields-formfieldtoggleswitch--playground)
-- Default Value: `boolean` - Defines whether the switch is checked or not.
-
-#### Props (Input Settings)
-
-* **toggleLabel** - `string` optional - This label is placed at the right of the switch.
+- Data: `boolean` - Defines whether the switch is checked or not.
+- inputSettings:
+	* **toggleLabel** - `string` optional - This label is placed at the right of the switch.
 
 #### How to use in a form?
 
@@ -823,7 +717,7 @@ const fields = useMemo(
 ## FormFieldAddress
 - Countries, states and cities information retrieved from: [Countries States Cities Database](https://github.com/dr5hn/countries-states-cities-database)
 - [**Playground**](/?path=/story/formfields-formfieldaddress--playground)
-- Default Value: `object`
+- Data: `object`
 	* **address1** - `string` required - Main address.
 	* **address2** - `string` optional - Additional address.
 	* **address3** - `string` optional - Additional address.
@@ -832,9 +726,7 @@ const fields = useMemo(
 	* **postalCode** - `string` required - Postal code of the address.
 	* **state** - `object` required - Must follow the format given on [Countries States Cities Database](https://github.com/dr5hn/countries-states-cities-database).
 	* **types** - `array` of `string` required - Could be one of the following: Physical, Billing, Shipping.
-
-### Props (Input Settings)
-This component doesn't require any additional props.
+-inputSettings: This component doesn't require any additional props.
 
 ### How to use in a form?
 ```ts
@@ -851,351 +743,19 @@ const fields = useMemo(
 	[]
 );
 ```
-<!-- ### Example
-<Preview withSource='none'>
-  <addressStories.Playground />
-</Preview> -->
-
-
-## FormFieldAdvancedSelection
-- Allow users to select one or more options from a modal menu. 
-- Used for very long lists. 
-- Have the ability to type and search.
-- [**Playground**](/?path=/story/formfields-formfieldadvancedselection--playground)
-- Default Value: `array` of `string` - Array of values of the selected options.
-
-### Props (Input Settings)
-* **createNewOption** - `(filter: string) => Promise<string>` optional -  Function used to insert more options either on the local options array, or on the DB.
-* **getSelected** - `(options: string[]) => Promise<{label: string, value: string, category: string}[]>` optional -  Function used to get the full info (label, value, category) of all selected options.
-
-This prop only applies when getting options locally.
-* **checkboxOptions** - `object` optional -  Function used to get the full info (label, value, category) of all selected options.
-	* **label** - `string` required -  Text users will see to identify the option.
-	* **value** - `string` required -  Value that will be saved to the DB when the option gets selected.
-	* **category** - `string` SOON TO BE DEPRECATED - Category in which the option belongs to.
-
-These props only apply when getting options from a DB. 
-* **getOptions** - `({filter?: string, limit?: number, offset?: number}) => Promise<{label: string, value: string, category: string}[]>` required - Function to get the next set of options.
-* **getOptionsLimit** - `number | string` optional - When defined, limits the amount of options to get from the DB.
-
-### How to use in a form?
-```ts
-//Option recommended when getting options locally.
-const fields = useMemo(
-	() => 
-		[
-			//...other fields
-			{
-				//...all generic field props,
-				type: 'advancedSelection',
-				inputSettings: {
-					createNewOption: myCreateOptionFn,
-					getSelected: myGetSelectedFn,
-					checkboxOptions: [
-						{
-							label: 'Option1',
-							value: 'value1',
-							category: 'Category1',
-						}
-					]
-				}
-			},
-			//...other fields
-		],
-	[]
-);
-
-//Option recommended when getting options from a database.
-const fields = useMemo(
-	() => 
-		[
-			//...other fields
-			{
-				//...all generic field props,
-				type: 'advancedSelection',
-				inputSettings: {
-					createNewOption: myCreateOptionFn,
-					getSelected: myGetSelectedFn,
-					getOptions: myGetOptionsFn,
-					getOptionsLimit: 5,
-				}
-			},
-			//...other fields
-		],
-	[]
-);
-```
-
-
-## FormFieldCheckbox
-- A group of checkbox buttons that allows users to select multiple items from a list of possible options.
-- [**Playground**](/?path=/story/formfields-formfieldcheckbox--playground)
-- Default Value: `array` of `string` - Array of values of the selected options.
-
-### Props (Input Settings)
-* **options** - `array` of `MosaicLabelValue` required - Array of options to be rendered containing their corresponding label and value.
-
-### How to use in a form?
-```ts
-const fields = useMemo(
-	() => 
-		[
-			//...other fields
-			{
-				//...all generic field props,
-				type: 'checkbox',
-				inputSettings: {
-					options: [
-						{
-							label: 'Option1',
-							value: 'value1',
-						}
-					]
-				}
-			},
-			//...other fields
-		],
-	[]
-);
-```
-
-
-## FormFieldChipSingleSelect
-- The `FormFieldChipSingleSelect` component is built over a wrapper for [Material-UI Autocomplete](https://material-ui.com/components/autocomplete/) but with SimpleView brand colors.
-- [**Playground**](/?path=/story/formfields-formfieldchipsingleselect--playground)
-- Default Value: `string` - Value of the selected option.
-
-### Props (Input Settings)
-* **options** - `array` of `{ label: string, value: string, selected?: boolean }` required - Array of options to be rendered containing their corresponding label, value, and indicator of whether its selected or not.
-* **onSelect** - `(...args) => void` optional - Callback to be executed when an option gets selected.
-
-### How to use in a form?
-```ts
-const fields = useMemo(
-	() => 
-		[
-			//...other fields
-			{
-				//...all generic field props,
-				type: 'chip',
-				inputSettings: {
-					options: [
-						{
-							label: 'Option1',
-							value: 'value1',
-							selected: false,
-						}
-					]
-				}
-			},
-			//...other fields
-		],
-	[]
-);
-```
-
-
-## FormFieldColorPicker
-- The color picker component allows users to select from pre-defined colors (swatches) or custom colors using a HSB selection interface.
-- The implementation of this component is based on the following package: [React Color](https://casesandberg.github.io/react-color/)
-- [**Playground**](/?path=/story/formfields-formfieldcolorpicker--playground)
-- Default Value: `ColorResult` - Object containing all the different variants for the color selected.
-
-### ColorResult (Type)
-* **hex** - `string`
-* **hsl** - `object`
-	* **a** - `number | undefined`
-	* **h** - `number`
-	* **s** - `number`
-	* **l** - `number`
-* **rgb** - `object`
-	* **a** - `number | undefined`
-	* **r** - `number`
-	* **g** - `number`
-	* **b** - `number`
-
-### Props (Input Settings)
-This component doesn't require any additional props.
-
-### How to use in a form?
-```ts
-const fields = useMemo(
-	() => 
-		[
-			//...other fields
-			{
-				//...all generic field props,
-				type: 'color',
-			},
-			//...other fields
-		],
-	[]
-);
-```
-
-## FormFieldDateField
-- It allows the user to view and pick dates from a calendar widget or manually type the date in the text field.
-- [**Playground**](/?path=/story/formfields-formfielddatefield--playground)
-- Default Value: `string` - Date in UTC format transformed to string.
-
-### Props (Input Settings)
-* **showTime** - `boolean` optional - When true a time field will appear next to the date field.
-
-### How to use in a form?
-```ts
-const fields = useMemo(
-	() => 
-		[
-			//...other fields
-			{
-				//...all generic field props,
-				type: 'date',
-				inputSettings: {
-					showTime: false,
-				}
-			},
-			//...other fields
-		],
-	[]
-);
-```
-
-## FormFieldRadio
-- A group of radio buttons allows users to select a single item from a list of possible options.
-- All possible options are exposed up front for comparison.
-- Users can only make a single selection from the list of possible options.
-- [**Playground**](/?path=/story/formfields-formfieldradio--playground)
-- Default Value: `string` - Value of the selected option.
-
-#### Props (Input Settings)
-* **options** - `array` of `object` optional - Predefined set of mutually exclusive options.
-	* **label** - `string` required - Description of the option.
-	* **value** - `string` required - Value of the option, this is stored in the Form state.
-
-#### How to use in a form?
-```ts
-const fields = useMemo(
-		() =>
-			[
-				//...other fields
-				{
-					//...all generic field props,
-					type: "radio",
-					inputSettings: {
-						options: [
-							{
-								label: "Label 1",
-								value: "label_1",
-							},
-							{
-								label: "Label 2",
-								value: "label_2",
-							},
-							{
-								label: "Label 3",
-								value: "label_3",
-							},
-						]
-					},
-					helperText: 'Helper text',
-					instructionText: 'Instruction text'
-				}
-				//...other fields
-			] as FieldDef<FormFieldRadioDef>[],
-		[]
-	);
-```
-
-## FormFieldText
-- Text input fields are used to enter text information, numbers, e-mail addresses, or passwords. 
-- A text field consists of a label and a line with variations in width.
-- [**Playground**](/?path=/story/formfields-formfieldtext--playground)
-- Default Value: `string` - Value of the input typed.
-
-#### Props (Input Settings)
-
-* **maxCharacters** - `number` optional - Defines the limit of characters that are allow to type in the input element.
-* **multiline** - `boolean` optional - When is enabled the text field will expand its height.
-* **placeholder** - `string` optional - The hint displayed in the input before the user enters a value.
-* **prefixElement** - `JSX.Element` optional - Icon at the beginning of the text field.
-* **size** - `Size | string` optional - Size of the field. Could be either one of the predefined sizes (see [Generic Field Props subsection](#generic-field-props-fielddef)), or a custom size. This property can be internally overwritten if the field is placed inside of a row with other fields.
-* **type** - `string` optional - Type of the input element. It should be a [valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).
-
-#### How to use in a form?
-
-```ts
-const fields = useMemo(
-	() =>
-		[
-			//...other fields
-			{
-				//...all generic field props,
-				type: "text",
-				maxCharacters: 20,
-				size: Sizes.md,
-				inputSettings: {
-					prefixElement: <AccountCircle />,
-					maxCharacters: 20,
-					size: Sizes.md,
-					placeholder: 'placeholder',
-					multiline: true
-				},
-			},
-			//...other fields
-		] as FieldDef<TextFieldDef>[],
-	[]
-);
-```
-
-## FormFieldTextArea
-- A text area is a multi-line plain-text editing control, is useful when you want to allow users to enter a sizeable amount of free-form text, but defining a specific height and width.
-- [**Playground**](/?path=/story/formfields-formfieldtextarea--playground)
-- Default Value: `string` - Value of the input typed.
-
-#### Props (Input Settings)
-
-* **maxCharacters** - `number` optional - Defines the limit of characters that are allow to type in the input element.
-* **placeholder** - `string` optional - The hint displayed in the input before the user enters a value.
-* **size** - `Size | string` optional - Size of the field. Could be either one of the predefined sizes (see [Generic Field Props subsection](#generic-field-props-fielddef)), or a custom size. This property can be internally overwritten if the field is placed inside of a row with other fields.
-
-#### How to use in a form?
-
-```ts
-const fields = useMemo(
-	() =>
-		[
-			//...other fields
-			{
-				//...all generic field props
-				type: "textArea",
-				maxCharacters: 20,
-				size: Sizes.md,
-				inputSettings: {
-					maxCharacters: 20,
-					size: Sizes.md,
-					placeholder: "placeholder"
-				},
-			},
-			//...other fields
-		] as FieldDef<TextAreaDef>[],
-    []
-  );
-```
 
 ## FormFieldDropdownSingleSelection
 - `Dropdown Single Selection` is a simple wrapper for [Material-UI Autocomplete](https://material-ui.com/components/autocomplete/#autocomplete) but with our brand colors.
 - [**Playground**](/?path=/docs/formfields-formfielddropdownsingleselection--playground)
-- Default Value: `string` - String of the selected options
+- Data: `string` - String of the selected options
+- inputSettings:
+	* **placeholder** - `string` Optional - Example text shown inside of the text field portion of the dropdown.
+	* **size** - `Sizes | string` Optional - Size of the field. Could be either one of the predefined sizes (see [Sizes section](#sizes-type)), or a custom size. This property can be internally overwritten if the field is placed inside of a row with other fields.
+	* **options** - `array` of `object` Required - Array of options to be displayed on the options.
+		* **title** - `string` - Title of the option.
+		* **value** - `any` - Value of the option.
 
-#### Props (Input Settings)
-* **placeholder** - `string` Optional - Example text shown inside of the text field portion of the dropdown.
-* **size** - `Sizes | string` Optional - Size of the field. Could be either one of the predefined sizes (see [Generic Field Props subsection](#generic-field-props-fielddef)), or a custom size. This property can be internally overwritten if the field is placed inside of a row with other fields.
-* **options** - `array` of `object` Required - Array of options to be displayed on the options.
-	* **title** - `string` - Title of the option.
-	* **value** - `any` - Value of the option.
-
-	#### How to use in a form?
-
+#### How to use in a form?
 ```ts
 const fields = useMemo(
 	() =>
@@ -1225,7 +785,7 @@ const fields = useMemo(
 ## FormFieldImageUpload
 - `Image Upload` This component helps upload images to the assets library, The setup supports images, videos, or documents 
 - [**Playground**](/?path=/docs/formfields-formfieldimageupload--playground)
-- Default Value: `object` Optional - Object of the value arguments
+- Data: `object` Optional - Object of the value arguments
 	* **imgName** `string` Optional - Image name
 	* **size** `number` Optional - Image size
 	* **type** `string` Optional - Image type
@@ -1234,10 +794,9 @@ const fields = useMemo(
 	* **imgCoords** `object` Optional - Image coordinates
 		* **x** `number` - X image coordinates
 		* **y** `number` - Y image coordinates
-
-#### Props (Input Settings)
-* **handleSetFocus** - `() => void` Optional - Callback executed when the set focus button is clicked.
-* **options** - `array` of `object` Optional - List of menu options that can be executed by the component.
+- inputSettings:
+	* **handleSetFocus** - `() => void` Optional - Callback executed when the set focus button is clicked.
+	* **options** - `array` of `object` Optional - List of menu options that can be executed by the component.
 
 #### How to use in a form?
 ```ts
@@ -1270,194 +829,19 @@ const fields = useMemo(
 );
 ```
 
-## FormFieldTextEditor
-- The text editor is a text area with added capabilities for use in various publishers, allowing the users to format their input in a text area.
-- This implementation is based on the [React Jodit WYSIWYG Editor](https://www.npmjs.com/package/jodit-react) package.
-- [**Playground**](/?path=/story/formfields-formfieldtexteditor--playground)
-- Default Value: `string` - Value of the input typed.
-
-
-#### Props (Input Settings)
-
-* **direction** - `"rtl" | "ltr" | ""` optional - Defines the starting point at which the typed words will be displayed, "lrt" starts from the left moving to the right and "rlt" vice versa. Default is "rlt".
-* **language** - `string` optional - Defines the language in which the assistive elements of the text editor will be displayed. For example the placeholder and the character and word counter
-* **maxCharacters** - `number` optional - Defines the limit of characters that are allow to type in the input element.
-* **spellcheck** - `boolean` optional - If it's enabled the text editor will mark misspellings.
-
-#### How to use in a form?
-
-```ts
-const fields = useMemo(
-	() =>
-		[
-			//...other fields
-			{
-				//...all generic field props
-				type: "textEditor",
-				inputSettings: {
-					spellcheck: true,
-					direction: "rlt",
-					language: "en",
-					maxCharacters: 20,
-				},
-			},
-			//...other fields
-		] as FieldDef<TextEditorDef>[],
-	[]
-);
-```
-
-## FormFieldTable
-- Tables are used in some cases inside the form after selecting a list of elements or by using arrays
-- The data table component allows for customization with additional functionality, as needed by your product’s users.
-- [**Playground**](/?path=/story/formfields-formfieldtable--playground)
-- Default Value: `array` of `object` - Rows of the table.
-	* **id** - `string` required - Unique identifier. Used as an identifier for the draggable item.
-	* **items** - `string[]` - Data that is shown in the table.
-
-#### Props (Input Settings)
-
-* **handleAddElement** - `() => void` required - Function used to create a new row in the table.
-* **handleEdit** - `(rowIndex: number) => void` required - Function that defines how the clicked row should be editted.
-* **handleDelete** - `() => void` required - Function that will be executed when clicking on the trash icon. It can be used to show some kind of confirmation before removing the row.
-* **extraActions** - `array` of `object` optional - Possible actions that the table could execute and display.
-	* **label** - `string` - Describes the action.
-	* **icon** - `MosaicMIcon` - MUI icon.
-	* **actionFnc** - `actionFnc: (rowIndex: number) => void;` - Function that is executed when the corresponding icon is clicked.
-* **headers** - `string[]` required - Array of the table headers.
-
-#### How to use in a form?
-
-```ts
-const possibleTableRows = [
-	{
-		id: "1",
-		items: ["John", "john@email.com", "01/01/2021", "3231-962-7516"],
-	},
-	{
-		id: "2",
-		items: ["Sally", "sally@email.com", "12/24/2020", "011-962-111"],
-	},
-	{
-		id: "3",
-		items: ["Maria", "maria@email.com", "12/01/2020", "788-962-7516"],
-	}
-];
-
-const addTableRow = (): void => {
-	const tableDataLength = dataState.table ? dataState.table.length : 0;
-
-	if (tableDataLength === 0) {
-		dispatch(
-			formActions.setFieldValue({
-				name: "table"
-				value: [possibleTableRows[0]],
-			})
-		);
-	} else if (tableDataLength >= possibleTableRows.length) {
-		alert("There are no more elements to add");
-	} else {
-		let index;
-
-		for (let i = 0; i < possibleTableRows.length; i++) {
-			const element = possibleTableRows[i];
-			const isRepeatedRow = dataState.table.includes(element);
-			if (!isRepeatedRow) {
-				index = i;
-				break;
-			}
-		}
-
-		dispatch(
-			formActions.setFieldValue({
-				name,
-				value: [...dataState.table, possibleTableRows[index]],
-			})
-		);
-	}
-};
-
-const fields = useMemo(
-	() =>
-		[
-			//...other fields
-			{
-				//...all generic field props
-				inputSettings: {
-					handleAddElement: addTableRow,
-					handleEdit: (rowIndex: number): void => { 
-						alert(`Edit button clicked of row with index ${rowIndex}`);
-					},
-					handleDelete: (rowIndex: number): void => { 
-						alert(`This will be executed when removing the row: ${rowIndex}`);
-					},
-					extraActions: [
-						{
-							label: "Menu action",
-							actionFnc: (rowIndex: number): void => { alert(`Menu actions for row ${rowIndex}`) },
-							icon: MenuIcon,
-						},
-						{
-							label: "Translate",
-							actionFnc: (rowIndex: number): void => { alert(`Translate row ${rowIndex}`) },
-							icon: TranslateIcon,
-						},
-					],
-					headers: ["Header 1", "Header 2", "Header 3"],
-				},
-			//...other fields
-			},
-		] as FieldDef<TableDef>[],
-	[addTableRow]
-);
-```
-
-## FormFieldToggleSwitch
-- Toggle Switch allow users to switch between two possible states. They are commonly used to turn a specific setting on or off
-- Toggles should be used to turn on or off a preference, notification, or feature
-- Should be used when an instant response is required/desired
-- [**Playground**](/?path=/story/formfields-formfieldtoggleswitch--playground)
-- Default Value: `boolean` - Defines whether the switch is checked or not.
-
-#### Props (Input Settings)
-
-* **toggleLabel** - `string` optional - This label is placed at the right of the switch.
-
-#### How to use in a form?
-
-```ts
-const fields = useMemo(
-	() =>
-		[
-			//...other fields
-			{
-				//...all generic field props
-				type: "toggleSwitch",
-				inputSettings: {
-					toggleLabel: "Toggle label"
-				},
-			},
-			//...other fields
-		] as FieldDef<FormFieldToggleSwitchDef>[],
-	[]
-);
-```
-
----
 ## FormFieldImageVideoLinkDocument
 - `Image Video Link Document Browsing` This component is helpful when the user needs browse an asset from the established assets library for their content.
 The setup supports images, videos, documents or links. 
 - [**Playground**](/?path=/docs/formfields-formfieldimagevideolinkdocumentbrowsing--playground)
-- Default Value: `array` of `string` - Array of values of the selected options 
-
-#### Props (Input Settings)
-* **handleRemove** - `() => void` Optional - Callback executed when the remove button is clicked. This function should empty the assetProperties array to go the set up stage.
-* **handleSetDocument** - `() => Promise<void>` Optional - Callback executed when the document icon clicked. It should fill the assetProperties array with the document properties.
-* **handleSetImage** - `() => Promise<void>` Required - Callback executed when the image icon clicked. It should fill the assetProperties array with the document properties.
-* **handleSetVideo** - `() => Promise<void>` Optional - Callback executed when the video icon is clicked. It should fill the assetProperties array with the document properties.
-* **handleSetLink** - `() => Promise<void>` Optional - Callback executed when the link icon is clicked. It should fill the assetProperties array with the document properties.
-* **options** - `array` of `object` Optional - List of menu options that can be executed by the component.
-* **src** - `string` Optional - If the asset contains an image, its source should be passed via this src prop.
+- Data: `array` of `string` - Array of values of the selected options 
+- inputSettings:
+	* **handleRemove** - `() => void` Optional - Callback executed when the remove button is clicked. This function should empty the assetProperties array to go the set up stage.
+	* **handleSetDocument** - `() => Promise<void>` Optional - Callback executed when the document icon clicked. It should fill the assetProperties array with the document properties.
+	* **handleSetImage** - `() => Promise<void>` Required - Callback executed when the image icon clicked. It should fill the assetProperties array with the document properties.
+	* **handleSetVideo** - `() => Promise<void>` Optional - Callback executed when the video icon is clicked. It should fill the assetProperties array with the document properties.
+	* **handleSetLink** - `() => Promise<void>` Optional - Callback executed when the link icon is clicked. It should fill the assetProperties array with the document properties.
+	* **options** - `array` of `object` Optional - List of menu options that can be executed by the component.
+	* **src** - `string` Optional - If the asset contains an image, its source should be passed via this src prop.
 
 #### How to use in a form?
 ```ts
@@ -1503,16 +887,15 @@ const fields = useMemo(
 ## FormFieldMapCoordinates
 - `Map Coordinates` This component is helpful when the user needs browse coordinates in a map.
 - [**Playground**](/?path=/docs/formfields-formfieldmapcoordinates--playground)
-- Default Value: `object` - Object of the value arguments
+- Data: `object` - Object of the value arguments
 	* **lat** - `number` - Latitude
 	* **lng** - `number` - longitude
-
-#### Props (Input Settings)
-* **address** - `object` Optional - Address object used to set lat and lng values when using the autocoordinates feature (please see Address section).
-* **apiKey** - `string` Required - Google Maps API key needed to consume the Maps JavaScript API and Places API.
-* **mapPosition** - `object` Optional - Latitude and longitude object.
-	* **lat** - `number` - Latitude
-	* **lng** - `number` - longitude
+- inputSettings:
+	* **address** - `object` Optional - Address object used to set lat and lng values when using the autocoordinates feature (please see Address section).
+	* **apiKey** - `string` Required - Google Maps API key needed to consume the Maps JavaScript API and Places API.
+	* **mapPosition** - `object` Optional - Latitude and longitude object.
+		* **lat** - `number` - Latitude
+		* **lng** - `number` - longitude
 	
 #### How to use in a form?
 ```ts
@@ -1550,13 +933,12 @@ const fields = useMemo(
 ## FormFieldPhoneSelectionDropdown
 - `FormFieldPhoneSelectionDropdown` component is built over [React-Phone-Input-2](https://www.npmjs.com/package/react-phone-input-2) but with SimpleView brand colors. The phone selection dropdown is useful when you want to allow users to enter the information of phone numbers, is conformed with the selection of the country in the dropdown that contains the country flag, and automatically the prefix and number or characters placeholder are showed. 
 - [**Playground**](/?path=/docs/formfields-formfieldphoneselectiondropdown--playground)
-- Default Value: `string` - String of the selected options
-
-#### Props (Input Settings)
-* **autoFormat** - `boolean` Optional - Phone formatting according to the country selected.
-* **country** - `string` Optional - Initial country. It must be a country code (e.g., us, mx, etc.)
-* **placeholder** - `string` Optional - Example text shown inside of the input field portion of the dropdown
-* **value** - `string` Optional - Input state value.
+- Data: `string` - String of the selected options
+- inputSettings:
+	* **autoFormat** - `boolean` Optional - Phone formatting according to the country selected.
+	* **country** - `string` Optional - Initial country. It must be a country code (e.g., us, mx, etc.)
+	* **placeholder** - `string` Optional - Example text shown inside of the input field portion of the dropdown
+	* **value** - `string` Optional - Input state value.
 
 #### How to use in a form?
 ```ts
@@ -1583,3 +965,90 @@ const fields = useMemo(
 <Preview withSource='none'>
   <stories.Playground />
 </Preview>
+
+## Types
+
+### MosaicLabelValue (Type)
+* **label** - `string` required
+* **value** - `string` required
+
+### MosaicObject (Type)
+* **[key: string]** - `unknown` required
+
+### MenuItemProps (Type)
+* **label** - `string | JSX Element` required
+* **color** - `"red" | "blue" ` optional
+* **disabled** - `boolean` optional
+* **selected** - `boolean` optional
+* **onClick** - `(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void` required
+* **mIcon** - `MosaicMIcon` optional
+* **attrs** - `MosaicObject` optional
+
+### ButtonAttrs (Type)
+* **label** - `string | JSX Element` optional
+* **className** - `string` optional
+* **href** - `string` optional
+* **color** - `"black" | "blue" | "lightBlue" | "red" | "yellow" | "teal" | "gray"` required
+* **mIcon** - `MosaicMIcon` optional - (Any Icon from MUI library).
+* **variant** - `"icon" | "outlined" | "contained" | "text"` required
+* **size** - `"small" | "medium" | "large"` optional
+* **iconPosition** - `"left" | "right"` optional
+* **disabled** - `boolean` optional
+* **fullWidth** - `boolean` optional
+* **tooltip** - `string | JSX Element` optional
+* **popover** - `JSX Element` optional
+* **menuItems** - `MenuItemProps[]` optional
+* **menuContent** - `JSX Element` optional
+* **mIconColor** - `string` optional
+* **onClick** - `(event: React.MouseEvent<HTMLButtonElement>) => void` optional
+* **attrs** - `MosaicObject` optional
+* **muiAttrs** - `MosaicObject` optional
+
+### Sizes (Type)
+* **xs** = 100px
+* **sm** = 280px
+* **md** = 450px
+* **lg** = 620px
+
+## Validators
+All of the following default validators return string (with the error message) or undefined (when no error was found). I
+
+### validateEmail
+* Receives: string
+* Error message returned: "The value is not a valid e-mail"
+* Ways of declaring:
+	* "validateEmail"
+	* { fn: "validateEmail", options: undefined }
+
+### required
+* Receives: string | string[]
+* Error message returned: "This field is required, please fill it"
+* Ways of declaring:
+	* "required"
+	* { fn: "required", options: undefined }
+	* As a boolean prop for all fields (see [Generic Field Props subsection](#generic-field-props-fielddef))
+
+### validateNumber
+* Receives: string
+* Error message returned: "The value is not a number"
+* Ways of declaring:
+	* "validateNumber"
+	* { fn: "validateNumber", options: undefined }
+
+### validateURL
+* Receives: string
+* Error message returned: "The value is not a valid URL"
+* Ways of declaring:
+	* "validateURL"
+	* { fn: "validateURL", options: undefined }
+
+### validateDateRange
+- This is the only validator that requires to be added to 2 fields in order to work: the fields serving as start and end date respectively.
+- The startDate field will add the name of the endDate field linked to in the options attribute. 
+- The endDate field will add the name of the startDate field linked to in the options attribute. 
+
+* Receives: value: `string`, data: `object` (see data attribute on [State](#state)), options: `MosaicObject`
+* Error message returned: "Start date should happen before the end date"
+* Ways of declaring:
+	* { fn: "validateDateRange", options: { endDateName: "nameOfField" } }
+	* { fn: "validateDateRange", options: { startDateName: "nameOfField" } }


### PR DESCRIPTION
Fixed next issues in the Form documentation

- Take validators and types to the end of documentation.
- Remove “Props (Input settings)” subsection and replace as bullet point under description subsection.
- Rename “Default settings” to data