### PR TITLE
MOS-640: Remove required from inputSettings

### DIFF
--- a/src/forms/Form/Col.tsx
+++ b/src/forms/Form/Col.tsx
@@ -151,6 +151,7 @@ const Col = (props: ColPropsTypes) => {
 						error={error}
 						onChange={onChange}
 						onBlur={onBlur}
+						required={currentField?.required}
 						key={`${name}_${i}`}
 					/>
 				), [value, error, onChange, onBlur, currentField]);


### PR DESCRIPTION
# What's include

- It was checked that inputSettings does not have the required property
- The verification was added in the Col component that required comes from currentField