### PR TITLE
MOS 637: Render "Cancel" button conditionally

### DIFF
--- a/src/forms/Form/Form.tsx
+++ b/src/forms/Form/Form.tsx
@@ -84,7 +84,7 @@ const Form = (props: FormProps) => {
 							description={description}
 							onSubmit={(e) => submit(e)}
 							submitButtonAttrs={submitButtonAttrs}
-							onCancel={(e) => cancel(e)}
+							onCancel={onCancel ? (e) => cancel(e) : null}
 							cancelButtonAttrs={cancelButtonAttrs}
 							sections={sections}
 							view={view}

--- a/src/forms/TopComponent/TopComponent.test.tsx
+++ b/src/forms/TopComponent/TopComponent.test.tsx
@@ -109,7 +109,7 @@ describe("TopComponent elements that are conditionally rendered", () => {
 		expect(activeCheckbox).toBe(null);
 	});
 
-	it("should display the 'Submit' and 'Cancel' buttons since its functions are defined", () => {
+	it("should display the 'Cancel' buttons since its function are defined", () => {
 		render(
 			<TopComponent
 				description='Description'
@@ -122,11 +122,10 @@ describe("TopComponent elements that are conditionally rendered", () => {
 			/>
 		);
 
-		expect(getByText("Save")).toBeDefined();
 		expect(getByText("Cancel")).toBeDefined();
 	});
 
-	it("should not display checkbox if show active is false", () => {
+	it("should not display the 'Cancel' button since its functions is not implemented", () => {
 		render(
 			<TopComponent
 				description='Description'
@@ -139,7 +138,6 @@ describe("TopComponent elements that are conditionally rendered", () => {
 			/>
 		);
 
-		expect(queryByText("Save")).toBe(null);
 		expect(queryByText("Cancel")).toBe(null);
 	});
 });

--- a/src/forms/TopComponent/TopComponent.test.tsx
+++ b/src/forms/TopComponent/TopComponent.test.tsx
@@ -45,22 +45,24 @@ const TopComponentExample = () => {
 	);
 };
 
+const { getByText, getAllByText, getByTestId, queryByTestId, queryByText } = screen;
+
 describe("TopComponent", () => {
 	beforeEach(() => {
 		render(<TopComponentExample />);
 	});
 
 	it("should display TopComponent content", () => {
-		expect(screen.getByText("Description")).toBeTruthy();
-		expect(screen.getByText("Form title")).toBeTruthy();
-		expect(screen.getAllByText("Account Profile")).toBeTruthy();
-		expect(screen.getByTestId("tooltip-test-id")).toBeTruthy();
-		expect(screen.getByTestId("checkbox-test-id")).toBeTruthy();
+		expect(getByText("Description")).toBeTruthy();
+		expect(getByText("Form title")).toBeTruthy();
+		expect(getAllByText("Account Profile")).toBeTruthy();
+		expect(getByTestId("tooltip-test-id")).toBeTruthy();
+		expect(getByTestId("checkbox-test-id")).toBeTruthy();
 	});
 
 	it("should trigger cancel and save onClick callback", () => {
-		const saveButton = screen.getByText("Save");
-		const cancelButton = screen.getByText("Cancel");
+		const saveButton = getByText("Save");
+		const cancelButton = getByText("Cancel");
 
 		fireEvent.click(saveButton);
 		fireEvent.click(cancelButton);
@@ -84,7 +86,7 @@ describe("TopComponent elements that are conditionally rendered", () => {
 			/>
 		);
 
-		const helpIcon = screen.queryByTestId("tooltip-test-id");
+		const helpIcon = queryByTestId("tooltip-test-id");
 
 		expect(helpIcon).toBe(null);
 	});
@@ -102,8 +104,42 @@ describe("TopComponent elements that are conditionally rendered", () => {
 			/>
 		);
 
-		const activeCheckbox = screen.queryByTestId("checkbox-test-id");
+		const activeCheckbox = queryByTestId("checkbox-test-id");
 
 		expect(activeCheckbox).toBe(null);
+	});
+
+	it("should display the 'Submit' and 'Cancel' buttons since its functions are defined", () => {
+		render(
+			<TopComponent
+				description='Description'
+				title='Form title'
+				onCancel={cancelCallback}
+				onSubmit={saveCallback}
+				sections={sections}
+				showActive={false}
+				view='DESKTOP'
+			/>
+		);
+
+		expect(getByText("Save")).toBeDefined();
+		expect(getByText("Cancel")).toBeDefined();
+	});
+
+	it("should not display checkbox if show active is false", () => {
+		render(
+			<TopComponent
+				description='Description'
+				title='Form title'
+				onCancel={null}
+				onSubmit={null}
+				sections={sections}
+				showActive={false}
+				view='DESKTOP'
+			/>
+		);
+
+		expect(queryByText("Save")).toBe(null);
+		expect(queryByText("Cancel")).toBe(null);
 	});
 });

--- a/src/forms/TopComponent/TopComponent.tsx
+++ b/src/forms/TopComponent/TopComponent.tsx
@@ -63,15 +63,19 @@ const TopComponent = (props: TopComponentProps): ReactElement => {
 	const buttons = useMemo(
 		() => (
 			<>
-				<Button
-					color="gray"
-					variant="outlined"
-					disabled={cancelButtonAttrs?.disabled}
-					label={cancelButtonAttrs?.label ? cancelButtonAttrs.label : "Cancel"}
-					onClick={onCancel}
-					muiAttrs={{ disableRipple: true }}
-				></Button>
-				{submitButton}
+				{onCancel && (
+					<Button
+						color="gray"
+						variant="outlined"
+						disabled={cancelButtonAttrs?.disabled}
+						label={
+							cancelButtonAttrs?.label ? cancelButtonAttrs.label : "Cancel"
+						}
+						onClick={onCancel}
+						muiAttrs={{ disableRipple: true }}
+					></Button>
+				)}
+				{onSubmit && submitButton}
 			</>
 		),
 		[onCancel, cancelButtonAttrs, submitButton]

--- a/src/forms/TopComponent/TopComponent.tsx
+++ b/src/forms/TopComponent/TopComponent.tsx
@@ -75,7 +75,7 @@ const TopComponent = (props: TopComponentProps): ReactElement => {
 						muiAttrs={{ disableRipple: true }}
 					></Button>
 				)}
-				{onSubmit && submitButton}
+				{submitButton}
 			</>
 		),
 		[onCancel, cancelButtonAttrs, submitButton]


### PR DESCRIPTION
## What's included?
- Adjustment to the TopComponent that will only render the Cancel button if its respective function is passed
- Unit tests for that case

# Notes
The Save button will always be rendered since the `submit` function is defined inside the Form component. In any case, the condition was set to only show the button if the function is passed, this is in case you want to use the TopComponent independently, if that scenario it's not possible, we should remove that condition.