### PR TITLE
MOS-645: Solves Autocomplete MUI warning

### DIFF
--- a/src/forms/Form/Form.stories.tsx
+++ b/src/forms/Form/Form.stories.tsx
@@ -38,7 +38,7 @@ const deleteTableRow = () => {
 	alert("Delete button clicked");
 };
 
-let externalOptions = [
+const externalOptions = [
 	{
 		category: "Category 1",
 		label: "Option 1",

--- a/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.styled.tsx
+++ b/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.styled.tsx
@@ -79,8 +79,9 @@ export const StyledPopper = styled(Popper)`
     color: ${theme.colors.gray700};
 
     &[aria-selected='true'] {
-      color: ${theme.colors.black};
-      font-weight: ${theme.fontWeight.semiBold};
+			color: ${({ value }) => value ? theme.colors.gray700 : theme.colors.black };
+			font-weight: ${({ value }) => value ? null : theme.fontWeight.semiBold};
+			background-color: white;
     }
 
     &:hover {

--- a/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
+++ b/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
@@ -7,7 +7,7 @@ import {
 	SingleDropdownWrapper,
 } from "./FormFieldDropdownSingleSelection.styled";
 import { MosaicFieldProps } from "@root/components/Field";
-import { DropdownSingleSelectionDef } from "./FormFieldDropdownSingleSelectionTypes";
+import { CustomPopperProps, DropdownSingleSelectionDef } from "./FormFieldDropdownSingleSelectionTypes";
 
 // Components
 import InputWrapper from "../../components/InputWrapper";
@@ -59,6 +59,10 @@ const DropdownSingleSelection = (props: MosaicFieldProps<DropdownSingleSelection
 		return option.value === value.value
 	}
 
+	const CustomPopper = (props: CustomPopperProps) => {
+		return <StyledPopper value={value === ""} {...props} />;
+	};
+
 	return (
 		<>
 			{!fieldDef?.disabled ?
@@ -74,7 +78,7 @@ const DropdownSingleSelection = (props: MosaicFieldProps<DropdownSingleSelection
 						onChange={(_event, option) => onDropDownChange(option)}
 						error={(fieldDef?.required && error) ? error : undefined}
 						renderInput={renderInput}
-						PopperComponent={StyledPopper}
+						PopperComponent={CustomPopper}
 						popupIcon={<ExpandMoreIcon />}
 						onBlur={(e) => onBlur && onBlur(e.target.value)}
 						open={isOpen}

--- a/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
+++ b/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
@@ -51,6 +51,14 @@ const DropdownSingleSelection = (props: MosaicFieldProps<DropdownSingleSelection
 		return option.value === value;
 	});
 
+	const getOptionSelected = (option, value) => {
+		if (value.value === "") {
+			return true;
+		}
+
+		return option.value === value.value
+	}
+
 	return (
 		<>
 			{!fieldDef?.disabled ?
@@ -62,6 +70,7 @@ const DropdownSingleSelection = (props: MosaicFieldProps<DropdownSingleSelection
 						data-testid="autocomplete-test-id"
 						options={fieldDef?.inputSettings?.options}
 						getOptionLabel={(option) => option?.label ? option.label : ""}
+						getOptionSelected={getOptionSelected}
 						onChange={(_event, option) => onDropDownChange(option)}
 						error={(fieldDef?.required && error) ? error : undefined}
 						renderInput={renderInput}

--- a/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelectionTypes.tsx
+++ b/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelectionTypes.tsx
@@ -1,3 +1,4 @@
+import { PopperProps } from "@material-ui/core/Popper";
 import { MosaicLabelValue } from "@root/types";
 
 export type DropdownSingleSelectionDef = {
@@ -12,3 +13,7 @@ export type DropdownSingleSelectionDef = {
 	 */
 	options: MosaicLabelValue[],
 }
+
+export type CustomPopperProps = {
+	value: string;
+} & PopperProps;


### PR DESCRIPTION
## What's included?

- Solves Autocomplete MUI warning of
- 
![image](https://user-images.githubusercontent.com/87880265/167013065-de6465ba-3995-4149-ad6a-799b6693e50c.png)

## How to test it?

- Open any component that uses the FormFieldDropdownSingleSelection, inspect the browser console and no warning should appear.
