### PR TITLE
MOS-652: Fix additional actions in the Saved Views drawer

### DIFF
--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -12,6 +12,10 @@ const DrawerContent = styled.div`
 	font-size: 14px;
 `
 
+const MUIDrawerStyled = styled(MUIDrawer)`
+	z-index: 1000;
+`
+
 function Drawer(props) {
 	const [state, setState] = useState({
 		open: false
@@ -34,15 +38,13 @@ function Drawer(props) {
 	}
 
 	return (
-		<MUIDrawer
+		<MUIDrawerStyled
 			anchor="right"
 			open={props.open}
 			onClose={props.onClose}
 			SlideProps={{
 				onExited
 			}}
-			//TODO: MOVE TO STYLED COMPONENT 
-			style={{ zIndex: 99999 }}
 		>
 			{
 				state.open &&
@@ -50,7 +52,7 @@ function Drawer(props) {
 					{props.children}
 				</DrawerContent>
 			}
-		</MUIDrawer>
+		</MUIDrawerStyled>
 	)
 }
 

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -13,7 +13,7 @@ const DrawerContent = styled.div`
 `
 
 const MUIDrawerStyled = styled(MUIDrawer)`
-	z-index: 1000;
+	z-index: 2000;
 `
 
 function Drawer(props) {

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -13,7 +13,7 @@ const DrawerContent = styled.div`
 `
 
 const MUIDrawerStyled = styled(MUIDrawer)`
-	z-index: 2000;
+	z-index: 1100;
 `
 
 function Drawer(props) {

--- a/src/forms/Form/Form.styled.ts
+++ b/src/forms/Form/Form.styled.ts
@@ -11,7 +11,7 @@ export const StyledDisabledForm = styled.div`
 	height: 100%;
 	width: 100%;
 	background-color: black;
-	z-index: 999999;
+	z-index: 1000;
 	display: block;
 	position: absolute;
 	opacity: 30%;

--- a/src/forms/TopComponent/Views/DesktopView.tsx
+++ b/src/forms/TopComponent/Views/DesktopView.tsx
@@ -22,7 +22,7 @@ const DesktopViewColumn = styled(StyledColumn)`
   justify-content: space-between;
   padding: 24px 20px 0px 20px;
   top: 0;
-  z-index: 99999;
+  z-index: 1000;
 
   @media (min-width: ${BIG_SCREEN_BREAKPOINT}) {
     box-shadow: 0px 1px 10px #0000001a;

--- a/src/forms/TopComponent/Views/MobileView.tsx
+++ b/src/forms/TopComponent/Views/MobileView.tsx
@@ -22,7 +22,7 @@ const MobileActionsRow = styled(Row)`
   position: sticky;
   position: -webkit-sticky;
   top: 0;
-  z-index: 9999;
+  z-index: 1000;
 
   svg {
     align-self: center;

--- a/src/forms/TopComponent/Views/ResponsiveView.tsx
+++ b/src/forms/TopComponent/Views/ResponsiveView.tsx
@@ -17,7 +17,7 @@ import { BaseTopComponentProps, TopComponentProps } from "../TopComponentTypes";
 
 const ResponsiveViewColumn = styled(StyledColumn)`
   padding: 20px 20px 0px 20px;
-  z-index: 9999;
+  z-index: 1000;
 `;
 
 const ResponsiveActionsRow = styled(Row)`

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -54,7 +54,7 @@ export default {
 		label : "#3B424E", //Same as gray700
 		almostBlack : "#1A1A1A",
 		errorBackground: "#B100000D",
-		white: '#FFFFFF'
+		white: "#FFFFFF"
 	},
 	borders : {
 		black : "1px solid #0A1323",


### PR DESCRIPTION
## What's included?

- The additional actions displayed on the Saved Views drawer are now shown. The problem was the `z-index` of the Drawer, the actions were being displayed correctly but behind the drawer

## Screenshots
![image](https://user-images.githubusercontent.com/87880265/169405931-66edb34c-f0bd-4900-90f3-464952d633e2.png)
