### PR TITLE
MOS-147: MultiSelect getSelected array.length > 1

### DIFF
--- a/src/components/DataView/example/MultiSelectHelper.ts
+++ b/src/components/DataView/example/MultiSelectHelper.ts
@@ -60,7 +60,9 @@ class MultiSelectHelper {
 			sort : { name : this.sortColumn, dir : "asc" }
 		});
 		
-		return results.map(val => this.mapOptions(val));
+		return results.length >= 1 
+			? results.map(val => this.mapOptions(val))
+			: [];
 	}
 }
 


### PR DESCRIPTION
# What's include:
- MultiSelect getSelected should not be called unless array.length > 1