### PR TITLE
MOS-658-Fixed button styles

### DIFF
--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -194,7 +194,7 @@ const WhiteOnBlack = styled(ButtonWrapper)`
 const textButtonStyles = {
 	opacity: (disabled: boolean) => disabled ? 1 : 0.5,
 	fontSize: (smallText: boolean) => smallText ? "14px" : "14px",
-	lineHeight: 1.5
+	lineHeight: 1.715
 }
 
 export const types = {

--- a/src/components/DataViewPrimaryFilter.jsx
+++ b/src/components/DataViewPrimaryFilter.jsx
@@ -13,10 +13,6 @@ const LabelWrapper = styled.div`
 	display: flex;
 	align-items: center;
 
-	& > .icon {
-		font-size: 20px;
-	}
-
 	& > .dropdownIcon {
 		color: ${theme.colors.gray600};
 		margin-left: 4px;
@@ -37,9 +33,10 @@ const LabelWrapper = styled.div`
 		background-color: ${theme.colors.blue}45;
 	}
 
-	& > .filterLabel {
+	& > .filter {
 		font-weight: ${theme.fontWeight.normal};
 		margin-right: 8px;
+		text-transform: capitalize;
 	}
 
 	&.type_optional > * {
@@ -78,9 +75,8 @@ function DataViewPrimaryFilter(props) {
 				type_${props.type}
 			`}
 		>
-			<BodyText className="filterLabel">{props.label}:</BodyText>
-			<BodyText className="filterValue">{props.value || "Any"}</BodyText>
-			<ExpandMoreIcon className="icon dropdownIcon"/>
+			<BodyText className="filter">{props.label}:</BodyText>
+			<BodyText className="filter">{props.value || "Any"}</BodyText>
 			{
 				props.type === "optional" &&
 				<CloseIcon
@@ -98,6 +94,8 @@ function DataViewPrimaryFilter(props) {
 			size="small"
 			onClick={props.onClick}
 			label={label}
+			iconPosition="right"
+			mIcon={ExpandMoreIcon}
 		/>
 	)
 }

--- a/src/components/internal/DataViewColumnControl.jsx
+++ b/src/components/internal/DataViewColumnControl.jsx
@@ -25,11 +25,12 @@ export function DataViewColumnControl(props) {
 			<Button
 				color="black"
 				label={t("mosaic:DataView.columns")}
-				variant="outlined"
+				variant="icon"
 				size="small"
 				mIcon={SettingsIcon}
 				onClick={gearClick}
 				iconPosition="left"
+				tooltip="Update columns and their order."
 			/>
 			{
 				props.onChange !== undefined &&


### PR DESCRIPTION
# What's include

- Small buttons are exactly 30px height
- The right icons of the filters are 16px size
- Aditional filters have text-transform: Capitalize and non bold
- Columns button is an icon button and size small. Also has  a tooltip with text “Update columns and their order.”