### PR TITLE
Mos 684:  Record actions not working as expected on DataView's grid

### DIFF
--- a/src/components/DataView/DataViewDisplayGrid.jsx
+++ b/src/components/DataView/DataViewDisplayGrid.jsx
@@ -241,7 +241,7 @@ function DataViewDisplayGrid(props) {
 										<DataViewActionsButtonRow
 											primaryActions={props.primaryActions}
 											additionalActions={props.additionalActions}
-											originalRowData={row}
+											originalRowData={ row }
 										/>
 									</div>
 								</div>

--- a/src/components/DataView/DataViewDisplayGrid.jsx
+++ b/src/components/DataView/DataViewDisplayGrid.jsx
@@ -241,7 +241,7 @@ function DataViewDisplayGrid(props) {
 										<DataViewActionsButtonRow
 											primaryActions={props.primaryActions}
 											additionalActions={props.additionalActions}
-											row={row}
+											originalRowData={row}
 										/>
 									</div>
 								</div>


### PR DESCRIPTION
# What's include

-  Fixed up row Data View action buttons when they are as grid