### PR TITLE
MOS-619 Updated scripts to publish types-only to npm

### DIFF
--- a/dev/publish
+++ b/dev/publish
@@ -4,9 +4,9 @@ set -e
 npm version $1
 npm publish --access public
 
-# # publish types-only repo
-# cd types-only
-# npm --no-git-tag-version version $1
-# npm publish
+# publish types-only repo
+cd types-only
+npm --no-git-tag-version version $1
+npm publish
 
-# cd ..
+cd ..

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"start": "npm run storybook",
 		"build": "npm run build:types && npm run build:rollup && npm run build:storybook",
 		"build:storybook": "build-storybook -c .storybook -o docs",
-		"build:types": "tsc --project src/tsconfig.types.json",
+		"build:types": "rm -rf ./dist/types/* rm -rf ./types-only/types/* && tsc --project src/tsconfig.types.json && cp -a ./dist/types/. ./types-only/types",
 		"build:rollup": "rollup -c",
 		"docker": "./dev/build && ./dev/run || true",
 		"publish": "./dev/publish",

--- a/types-only/.npmrc
+++ b/types-only/.npmrc
@@ -1,2 +1,0 @@
-@simpleview:registry=https://npm.pkg.github.com
-//https://npm.pkg.github.com/:_authToken=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

--- a/types-only/package.json
+++ b/types-only/package.json
@@ -7,9 +7,6 @@
 		"url": "git://github.com/simpleviewinc/sv-mosaic.git",
 		"directory": "types-only"
 	},
-	"publishConfig": {
-		"registry": "https://npm.pkg.github.com"
-	},
 	"scripts": {
 		"publish": "../dev/publish"
 	}


### PR DESCRIPTION
# What's included?
- Updates on main package.json to create and copy types to types-only folder.
- Updates on types-only package.json to publish directly to npm (previously was github packages).
- Uncommented publish script for types-only.