### PR TITLE
MOS-679: Allow filter single select to require a value

### DIFF
--- a/src/components/FilterSingleSelect/FilterSingleSelect.stories.tsx
+++ b/src/components/FilterSingleSelect/FilterSingleSelect.stories.tsx
@@ -51,10 +51,9 @@ export const Playground = (): ReactElement => {
 			label="Testing"
 			type="primary"
 			data={state}
-			args={{ getOptions, getSelected }}
+			args={{ getOptions, getSelected, required }}
 			onRemove={onRemove}
 			onChange={onChange}
-			required={required}
 		/>
 	)
 }

--- a/src/components/FilterSingleSelect/FilterSingleSelect.tsx
+++ b/src/components/FilterSingleSelect/FilterSingleSelect.tsx
@@ -17,7 +17,7 @@ export default function FilterSingleSelect(props: FilterSingleSelectProps): Reac
 		options: []
 	});
 
-	if (props.required && !props.data.value) throw new Error("Invalid use-case, a value is required but none was provided")
+	if (props.args.required && !props.data.value) throw new Error("Invalid use-case, a value is required but none was provided")
 
 	const value = props.data.value;
 

--- a/src/components/FilterSingleSelect/FilterSingleSelectTypes.ts
+++ b/src/components/FilterSingleSelect/FilterSingleSelectTypes.ts
@@ -14,8 +14,8 @@ export interface FilterSingleSelectProps extends DataViewFilterProps {
 			hasMore?: boolean
 		}
 		getSelected(id: string): MosaicLabelValue
+		required?: boolean
 	},
-	required?: boolean
 }
 
 export interface FilterSingleSelectContentProps {


### PR DESCRIPTION
# What's include:

- Changed required prop to send inside to args prop on FilterSingleSelect component