### PR TITLE
MOS-683: Actions need to accept an array

### DIFF
--- a/src/components/DataView/DataViewTypes.ts
+++ b/src/components/DataView/DataViewTypes.ts
@@ -103,7 +103,7 @@ interface ActionAdditional {
 	onClick: DataViewActionOnClick
 	/** A value or function controlling whether or not to display this action. */
 	// show?: boolean | DataViewActionShow
-	show?: boolean | DataViewActionShow | DataViewActionShow[] | boolean[] | [DataViewActionShow | boolean];
+	show?: boolean | DataViewActionShow | DataViewActionShow[] | boolean[] | [DataViewActionShow | boolean] | (DataViewActionShow | boolean)[];
 }
 
 export type DataViewAction = Omit<ButtonProps, "onClick" | "attrs"> & ActionAdditional;

--- a/src/components/DataView/tests/bulkActionsUtils.test.ts
+++ b/src/components/DataView/tests/bulkActionsUtils.test.ts
@@ -14,7 +14,7 @@ describe("filterAction helper function", () => {
 			color: "blue",
 			name: "edit",
 			onClick: onClick,
-			show: [undefined, undefined]
+			show: undefined
 		}	
 
 		expect(filterAction(action, rowArgs)).toBe(true);
@@ -27,6 +27,30 @@ describe("filterAction helper function", () => {
 			name: "edit",
 			onClick: onClick,
 			show: false
+		}
+
+		expect(filterAction(action, rowArgs)).toBe(false);
+	});
+
+	it("should return true if all the elements of action.show are true", () => {
+		const action: DataViewAdditionalAction = {
+			label: "Action label",
+			color: "blue",
+			name: "edit",
+			onClick: onClick,
+			show: [true, true, () => true]
+		}
+
+		expect(filterAction(action, rowArgs)).toBe(true);
+	});
+
+	it("should return false if at least one element of action.show is false", () => {
+		const action: DataViewAdditionalAction = {
+			label: "Action label",
+			color: "blue",
+			name: "edit",
+			onClick: onClick,
+			show: [true, () => false, true]
 		}
 
 		expect(filterAction(action, rowArgs)).toBe(false);

--- a/src/components/DataView/tests/bulkActionsUtils.test.ts
+++ b/src/components/DataView/tests/bulkActionsUtils.test.ts
@@ -1,0 +1,49 @@
+import { filterAction } from "../utils/bulkActionsUtils";
+import { DataViewAdditionalAction } from "../DataViewTypes";
+
+const onClick = jest.fn();
+
+const rowArgs = {
+	row: { id: "5a00d073b082d3e151c153b6", title: "Accesibility" }
+};
+
+describe("filterAction helper function", () => {
+	it("should return true when action.show is undefined", () => {
+		const action: DataViewAdditionalAction = {
+			label: "Action label",
+			color: "blue",
+			name: "edit",
+			onClick: onClick,
+			show: [undefined, undefined]
+		}	
+
+		expect(filterAction(action, rowArgs)).toBe(true);
+	});
+
+	it("should return action.show if it's a boolean", () => {
+		const action: DataViewAdditionalAction = {
+			label: "Action label",
+			color: "blue",
+			name: "edit",
+			onClick: onClick,
+			show: false
+		}
+
+		expect(filterAction(action, rowArgs)).toBe(false);
+	});
+
+	it("should throw an error when the show attribute of an action is neither a function or boolean", () => {
+		const showFn = jest.fn();
+		const action: DataViewAdditionalAction = {
+			label: "Action label",
+			color: "blue",
+			name: "edit",
+			onClick: onClick,
+			show: (args) => showFn(args)
+		}
+
+		filterAction(action, rowArgs)
+
+		expect(showFn).toHaveBeenCalledWith(rowArgs);
+	});
+});

--- a/src/components/DataView/utils/bulkActionsUtils.ts
+++ b/src/components/DataView/utils/bulkActionsUtils.ts
@@ -12,17 +12,21 @@ type FilterActionArgs = RowArgs | CheckedArgs;
 type Action = DataViewAction | DataViewAdditionalAction | DataViewBulkAction;
 
 export const filterAction = (action: Action, args: FilterActionArgs) => {
+	if (action.show === undefined) {
+		return true;
+	} 
+
 	const shows = isArray(action.show) ? action.show : [action.show];
 
-	for (const show of shows) {
-		if (show === undefined) {
-			return true;
-		} else if (typeof show === "boolean") {
+	const isValid = shows.every(show => {
+		if (typeof show === "boolean") {
 			return show;
 		} else if (typeof show === "function") {
 			return show(args);
 		} else {
 			throw new Error(`Action ${action.name}.show must be boolean or a function`);
 		}
-	}
+	});
+
+	return isValid;
 };

--- a/src/components/DataView/utils/bulkActionsUtils.ts
+++ b/src/components/DataView/utils/bulkActionsUtils.ts
@@ -1,3 +1,5 @@
+import { isArray } from "lodash";
+
 import { DataViewActionsButtonRowProps } from "../DataViewActionsButtonRow";
 import { DataViewAction, DataViewAdditionalAction, DataViewBulkAction, DataViewBulkActionsButtonsRowProps } from "../DataViewTypes";
 
@@ -10,13 +12,17 @@ type FilterActionArgs = RowArgs | CheckedArgs;
 type Action = DataViewAction | DataViewAdditionalAction | DataViewBulkAction;
 
 export const filterAction = (action: Action, args: FilterActionArgs) => {
-	if (action.show === undefined) {
-		return true;
-	} else if (typeof action.show === "boolean") {
-		return action.show;
-	} else if (typeof action.show === "function") {
-		return action.show(args);
-	} else {
-		throw new Error(`Action ${action.name}.show must be boolean or a function`);
+	const shows = isArray(action.show) ? action.show : [action.show];
+
+	for (const show of shows) {
+		if (show === undefined) {
+			return true;
+		} else if (typeof show === "boolean") {
+			return show;
+		} else if (typeof show === "function") {
+			return show(args);
+		} else {
+			throw new Error(`Action ${action.name}.show must be boolean or a function`);
+		}
 	}
-}
+};


### PR DESCRIPTION
## What's included?
- Actions show attribute accepts and processes an array.
- Adds the type to the show actions attribute of: `(DataViewActionShow | boolean)[]`
- Unit tests to the filterAction helper function