### PR TITLE
Fixed unit test for MenuFormFieldCard

### DIFF
--- a/src/forms/FormFieldImageUpload/ImageUploadCanvas/ImageUploadCanvas.tsx
+++ b/src/forms/FormFieldImageUpload/ImageUploadCanvas/ImageUploadCanvas.tsx
@@ -71,8 +71,10 @@ const ImageUploadCanvas = (props: ImageUploadCanvasProps): ReactElement => {
 		canvasRef.current.addEventListener("mousemove", setMousePosition, false);
 
 		return () => {
-			canvasRef.current.removeEventListener("mousemove", setMousePosition);
-			window.cancelAnimationFrame(animationFrameId)
+			if (canvasRef.current) {
+				canvasRef.current.removeEventListener("mousemove", setMousePosition);
+				window.cancelAnimationFrame(animationFrameId);
+			}
 		}
 
 	}, [isFocus])

--- a/src/forms/MenuFormFieldCard/MenuFormFieldCard.tsx
+++ b/src/forms/MenuFormFieldCard/MenuFormFieldCard.tsx
@@ -37,7 +37,6 @@ const MenuFormFieldCard = (props: MenuFormFieldCardProps): ReactElement => {
 			></Button>
 			<StyledMenu
 				anchorEl={anchorEl}
-				getContentAnchorEl={null}
 				anchorOrigin={{
 					vertical: "bottom",
 					horizontal: "left",

--- a/src/forms/MenuFormFieldCard/MenuFormFieldCardTypes.ts
+++ b/src/forms/MenuFormFieldCard/MenuFormFieldCardTypes.ts
@@ -1,24 +1,24 @@
 export type Options = {
-  /**
-   * Name of the menu option.
-   */
-  label: string;
-  /**
-   * Callback function that will be triggered
-   * when the option is clicked.
-   */
-  action: () => void;
+	/**
+	 * Name of the menu option.
+	 */
+	label: string;
+	/**
+	 * Callback function that will be triggered
+	 * when the option is clicked.
+	 */
+	action: () => void;
 };
 
 export interface MenuFormFieldCardProps {
-  /**
-   * Used for adding or overriding styles.
-   */
-  className?: string;
-  /**
-   * List of menu options that can be executed by the component.
-   */
-  options?: Options[];
+	/**
+	 * Used for adding or overriding styles.
+	 */
+	className?: string;
+	/**
+	 * List of menu options that can be executed by the component.
+	 */
+	options?: Options[];
 	/**
 	 * Disables the options icon
 	 */


### PR DESCRIPTION
# What's included?
- Deleted "getContentAnchorEl" prop from MenuFormFieldCard.tsx that was causing an issue when running unit tests (this prop doesn't even exist anymore on newest mui version).
- Updated return statement of useEffect in ImageUploadCanvas causing issues when running unit tests related to an unmounted ref.