### PR TITLE
Mos 61 limit dropdown text

### DIFF
--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -12,13 +12,13 @@ export const ButtonWrapper = styled.span`
   }
 
   & > button {
-    font-family: ${theme.fontFamily};
-    text-transform: none;
-    font-size: 14px;
-    font-weight: ${theme.fontWeight.medium};
-    min-width: auto;
-    line-height: 1.715;
-	  letter-spacing: 1px;
+	font-family: ${theme.fontFamily};
+	text-transform: none;
+	font-size: 14px;
+	font-weight: ${theme.fontWeight.medium};
+	min-width: auto;
+	line-height: 1.715;
+	letter-spacing: 1px;
   }
 
   &.normalButton > button {

--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -18,7 +18,7 @@ export const ButtonWrapper = styled.span`
     font-weight: ${theme.fontWeight.medium};
     min-width: auto;
     line-height: 1.715;
-	letter-spacing: 1px;
+	  letter-spacing: 1px;
   }
 
   &.normalButton > button {

--- a/src/components/internal/DataViewViewControls.jsx
+++ b/src/components/internal/DataViewViewControls.jsx
@@ -16,16 +16,18 @@ const ViewSpan = styled.span`
 	& > .icon {
 		margin-right: 3px;
 	}
-`
 
-const TitleButton = styled(Button)`
-	max-width: 300px;
-	& > button > span {
+	& > p {
+		margin: 0;
 		overflow: hidden;
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
 		-webkit-box-orient: vertical; 
 	}
+`
+
+const TitleButton = styled(Button)`
+	max-width: 300px;
 `
 
 function DataViewViewControls(props) {
@@ -52,7 +54,10 @@ function DataViewViewControls(props) {
 	
 	const ViewLabel = (
 		<ViewSpan>
-			<ViewQuiltIcon className="icon"/> {props.savedView.label}
+			<ViewQuiltIcon className="icon"/> 
+			<p>
+				{props.savedView.label}
+			</p>
 		</ViewSpan>
 	)
 	

--- a/src/components/internal/DataViewViewControls.jsx
+++ b/src/components/internal/DataViewViewControls.jsx
@@ -18,6 +18,16 @@ const ViewSpan = styled.span`
 	}
 `
 
+const TitleButton = styled(Button)`
+	max-width: 300px;
+	& > button > span {
+		overflow: hidden;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical; 
+	}
+`
+
 function DataViewViewControls(props) {
 	const [state, setState] = useState({
 		viewOpen : false,
@@ -85,7 +95,7 @@ function DataViewViewControls(props) {
 						color="blue"
 						menuItems={saveMenuItems}
 					/>
-					<Button
+					<TitleButton
 						mIcon={ExpandMoreIcon}
 						iconPosition="right"
 						label={ViewLabel}


### PR DESCRIPTION
# What's include:
- Limited the dropdown’s text of the Dataview title to 300px and 2 lines max, whatever exceeds must show “…”
- Added p tag to button label