### PR TITLE
MOS-69: Load more button for categories disappears when clicking clear

### DIFF
--- a/src/components/internal/DataViewFilterMultiselectDropdownContent.jsx
+++ b/src/components/internal/DataViewFilterMultiselectDropdownContent.jsx
@@ -209,7 +209,6 @@ function DataViewFilterMultiselectDropdownContent(props) {
 			selected : [],
 			comparison : "in",
 			keyword : undefined,
-			skip : 0,
 		});
 	}
 	

--- a/src/components/internal/DataViewFilterMultiselectDropdownContent.jsx
+++ b/src/components/internal/DataViewFilterMultiselectDropdownContent.jsx
@@ -210,7 +210,6 @@ function DataViewFilterMultiselectDropdownContent(props) {
 			comparison : "in",
 			keyword : undefined,
 			skip : 0,
-			hasMore : false
 		});
 	}
 	


### PR DESCRIPTION
## What's included?

- Fix: Load more button for categories disappears when clicking clear