### PR TITLE
MOS-701: Sections refactor

### DIFF
--- a/src/forms/Form/Col.tsx
+++ b/src/forms/Form/Col.tsx
@@ -35,6 +35,9 @@ interface ColPropsTypes {
 	fieldsDef: FieldDef[];
 	dispatch: any;
 	colsInRow?: number;
+	colIdx?: number;
+	rowIdx?: number;
+	sectionIdx?: number;
 }
 
 const Col = (props: ColPropsTypes) => {
@@ -44,6 +47,9 @@ const Col = (props: ColPropsTypes) => {
 		fieldsDef,
 		dispatch,
 		colsInRow,
+		colIdx,
+		rowIdx,
+		sectionIdx
 	} = props;
 
 	const componentMap = useMemo(() => ({
@@ -108,6 +114,10 @@ const Col = (props: ColPropsTypes) => {
 						return field === fieldDef.name;
 					}
 				);
+				
+				if (!currentField) {
+					throw new Error(`No field declared for field name '${field}' in section ${sectionIdx}, row ${rowIdx}, column ${colIdx}.`);
+				}
 
 				const { type, ...fieldProps } = currentField;
 

--- a/src/forms/Form/Form.stories.tsx
+++ b/src/forms/Form/Form.stories.tsx
@@ -628,8 +628,9 @@ export const FormWithLayout = (): ReactElement => {
 				[["check"], ["toggleSwitch"], ["color"]],
 				// row 2
 				[[], [], []],
-				[[]],
 				// row 3
+				[[]],
+				// row 4
 				[[], ["textEditor"]]
 			]
 		},
@@ -645,7 +646,7 @@ export const FormWithLayout = (): ReactElement => {
 				// row 3
 				[[], []]
 			]
-		}
+		},
 	], [fields]);
 
 	useEffect(() => {

--- a/src/forms/Form/Form.tsx
+++ b/src/forms/Form/Form.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { memo, useEffect, useMemo } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { StyledDisabledForm, StyledForm } from "./Form.styled";
 import { FormProps } from "./FormTypes";
 import { formActions } from "./formActions";
@@ -29,6 +29,12 @@ const Form = (props: FormProps) => {
 	} = props;
 
 	const { view } = useWindowResizer(type);
+	const sectionsRef = useRef<HTMLDivElement[]>([]);
+	const [sectionsRefs, setSectionsRefs] = useState<HTMLDivElement[]>([]);
+
+	useEffect(() => {
+		setSectionsRefs(sectionsRef.current);
+	}, []);
 
 	useEffect(() => {
 		let isMounted = true;
@@ -106,15 +112,17 @@ const Form = (props: FormProps) => {
 							sections={sections}
 							view={view}
 							buttons={filteredButtons}
+							sectionsRefs={sectionsRefs}
 						/>
 					}
 					{view === "BIG_DESKTOP" && sections ? (
 						<Row>
 							{sections &&
-								<FormNav sections={sections} />
+								<FormNav sectionsRefs={sectionsRefs} sections={sections} />
 							}
 							<FormContent view={view} sections={sections}>
 								<FormLayout
+									ref={sectionsRef}
 									state={state}
 									dispatch={dispatch}
 									fields={fields}
@@ -125,6 +133,7 @@ const Form = (props: FormProps) => {
 					) : (
 						<FormContent view={view} sections={sections}>
 							<FormLayout
+								ref={sectionsRef}
 								state={state}
 								dispatch={dispatch}
 								fields={fields}

--- a/src/forms/Form/FormLayout.tsx
+++ b/src/forms/Form/FormLayout.tsx
@@ -1,6 +1,6 @@
 import { FieldDef } from "@root/components/Field";
 import * as React from "react";
-import { useMemo, memo } from "react";
+import { useMemo, memo, forwardRef, RefObject } from "react";
 import { SectionDef } from "./FormTypes";
 import { generateLayout } from "./formUtils";
 
@@ -14,8 +14,9 @@ interface FormLayoutProps {
   sections: SectionDef[];
 }
 
-const FormLayout = (props: FormLayoutProps) => {
+const FormLayout = forwardRef((props: FormLayoutProps, ref) => {
 	const { state, dispatch, fields, sections } = props;
+	const sectionRef = ref as RefObject<HTMLDivElement>;
 
 	const layout = useMemo(() => {
 		return generateLayout({ sections, fields });
@@ -25,17 +26,21 @@ const FormLayout = (props: FormLayoutProps) => {
 		<>
 			{layout?.map((section, i) => (
 				<Section
-					key={i}
+					ref={el => sectionRef.current[i] = el} 
+					key={`section-${i}`}
 					title={section.title}
+					sectionIdx={i}
 					description={section.description}
 					fieldsDef={fields}
-					fieldsLayoutPos={section.fields}
+					rows={section.fields}
 					state={state}
 					dispatch={dispatch}
 				/>
 			))}
 		</>
 	);
-};
+});
+
+FormLayout.displayName = "FormLayout";
 
 export default memo(FormLayout);

--- a/src/forms/Form/FormTypes.tsx
+++ b/src/forms/Form/FormTypes.tsx
@@ -7,7 +7,7 @@ import { MosaicObject } from "@root/types";
 export interface SectionDef extends Section {
 	title?: string;
 	description?: string | JSX.Element;
-	fields: (string | FieldDef)[][][];
+	fields: string[][][];
 	children?: ReactNode;
 }
 

--- a/src/forms/Form/Row.tsx
+++ b/src/forms/Form/Row.tsx
@@ -12,27 +12,34 @@ const StyledRow = styled.div`
 `;
 
 interface RowPropTypes {
-	row: (string | FieldDef)[][];
+	row: string[][];
 	state: any;
 	fieldsDef: FieldDef[];
 	dispatch: any;
+	rowIdx?: number;
+	sectionIdx?: number;
 }
 
 const Row = (props: RowPropTypes) => {
-	const { row, state, fieldsDef, dispatch } = props;
+	const { row, rowIdx, state, fieldsDef, dispatch, sectionIdx } = props;
 
 	return (
 		<StyledRow>
-			{row.map((col, i) => (
-				<Col
-					key={i}
-					col={col}
-					state={state}
-					fieldsDef={fieldsDef}
-					dispatch={dispatch}
-					colsInRow={row.length}
-				/>
-			))}
+			{row.map((col, i) => {
+				return (
+					<Col
+						key={`col-${i}`}
+						colIdx={i}
+						rowIdx={rowIdx}
+						sectionIdx={sectionIdx}
+						col={col}
+						state={state}
+						fieldsDef={fieldsDef}
+						dispatch={dispatch}
+						colsInRow={row.length}
+					/>
+				)
+			})}
 		</StyledRow>
 	);
 };

--- a/src/forms/Form/Section.tsx
+++ b/src/forms/Form/Section.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { memo } from "react";
+import { memo, forwardRef } from "react";
 import theme from "@root/theme";
 import styled from "styled-components";
 import { FieldDef } from "@root/components/Field";
@@ -8,6 +8,7 @@ import { FieldDef } from "@root/components/Field";
 import Row from "./Row";
 
 const StyledSection = styled.div`
+	scroll-margin-top: 60px;
 	display: flex;
 	flex-direction: column;
 	width: calc(100% - 4px); //LAYOUT: Could be reused.
@@ -44,42 +45,48 @@ const StyledTitle = styled.h1`
 
 interface SectionPropTypes {
 	title: string;
+	sectionIdx: number;
 	description: string | JSX.Element;
 	fieldsDef: FieldDef[];
-	fieldsLayoutPos: (string | FieldDef)[][][]
+	rows: string[][][];
 	dispatch: any;
 	state: any;
 }
 
-const Section = (props: SectionPropTypes) => {
+const Section = forwardRef((props: SectionPropTypes, ref) => {
 	const {
 		title,
 		description,
 		fieldsDef,
-		fieldsLayoutPos,
+		rows,
 		dispatch,
-		state,
+		sectionIdx,
+		state
 	} = props;
 
 	return (
-		<StyledSection hasTitle={title} className='section' id={title}>
+		<StyledSection ref={ref} hasTitle={title} id={sectionIdx}>
 			{title && <StyledTitle>{title}</StyledTitle>}
 			{description && <StyledDescription>{description}</StyledDescription>}
-			{fieldsLayoutPos &&
+			{rows && (
 				<StyledRows hasTitle={title}>
-					{fieldsLayoutPos.map((row, i) => (
+					{rows.map((row, i) => (
 						<Row
-							key={i}
+							key={`row-${i}`}
 							row={row}
+							rowIdx={i}
+							sectionIdx={sectionIdx}
 							state={state}
 							fieldsDef={fieldsDef}
 							dispatch={dispatch}
 						/>
 					))}
 				</StyledRows>
-			}
+			)}
 		</StyledSection>
 	);
-};
+});
+
+Section.displayName = "Section";
 
 export default memo(Section);

--- a/src/forms/FormNav/FormNav.styled.tsx
+++ b/src/forms/FormNav/FormNav.styled.tsx
@@ -21,34 +21,37 @@ export const NavItems = styled.div`
 export const LinksWrapper = styled.div`
   margin-right: 40px;
 
+  &.highlight > a {
+    color: ${theme.colors.almostBlack};
+    border-bottom: 4px solid #FCB731;
+    font-weight: ${theme.fontWeight.medium};
+  }
+
   a {
-    border-bottom: ${(pr) =>
-		pr.idx === pr.selectedTabIdx ? "4px solid #FCB731" : ""};
-    color: ${(pr) =>
-		pr.idx === pr.selectedTabIdx
-			? theme.colors.almostBlack
-			: theme.colors.gray600};
+    color: ${theme.colors.gray600}
     display: inline-block;
     font-family: ${theme.fontFamily};
     font-size: 14px;
-    font-weight: ${(pr) =>
-		pr.idx === pr.selectedTabIdx ? theme.fontWeight.medium : ""};
     text-align: center;
     text-decoration: none;
     padding-bottom: 12px;
   }
 
   @media (min-width: 1718px) {
-    background-color: ${(pr) =>
-		pr.idx === pr.selectedTabIdx ? theme.colors.gray200 : ""};
     margin-right: 0;
+
+    &.highlight > a {
+      border-bottom: none;
+      border-left: 4px solid #FCB731;
+  	}
+
+    &.highlight {
+      background-color: ${theme.colors.gray200};
+    }
 
     a {
       border-bottom: 0px;
-      border-left: ${(pr) =>
-		pr.idx === pr.selectedTabIdx
-			? "4px solid #FCB731"
-			: "4px solid transparent"};
+      border-left: 4px solid transparent;
       padding: 16px 0 16px 24px;
     }
   }
@@ -58,7 +61,7 @@ export const Section = styled.div`
   height: 100vh;
   padding-top: 130px;
 
-  @media (max-width: 1075px){
+  @media (max-width: 1075px) {
     padding-top: 210px;
   }
 `;
@@ -78,7 +81,7 @@ export const FormNavRow = styled.div`
   position: relative;
 
   &:after {
-    content: '';
+    content: "";
     position: absolute;
     z-index: 1;
     top: 0;
@@ -119,7 +122,7 @@ export const FormNavRow = styled.div`
       display: none;
     }
 
-	height: 100%;
+    height: 100%;
   }
 `;
 

--- a/src/forms/FormNav/FormNav.test.tsx
+++ b/src/forms/FormNav/FormNav.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import * as React from "react";
+import { ReactElement, useEffect, useRef, useState } from "react";
 import FormNav from "./FormNav";
 
 afterEach(cleanup);
@@ -19,9 +20,32 @@ const sections = [
 	},
 ];
 
+const FormNavExample = (): ReactElement => {
+	const sectionsRef = useRef([]);
+	const [sectionsRefs, setSectionsRefs] = useState<HTMLDivElement[] | []>([]);
+
+	useEffect(() => {
+		setSectionsRefs(sectionsRef.current);
+	}, []);
+
+	return (
+		<>
+			<FormNav sections={sections} sectionsRefs={sectionsRefs}/>
+			{sections.map((section, i) => (
+				<section key={i} ref={el => sectionsRef.current[i] = el} >
+					{section.id}
+				</section>
+			))}
+		</>
+	);
+};
+
+const scrollIntoViewMock = jest.fn();
+
+
 describe("FormNav component", () => {
 	beforeEach(() => {
-		render(<FormNav sections={sections} />);
+		render(<FormNavExample />);
 	});
 
 	it("should render FormNav with the list of sections", () => {
@@ -31,19 +55,10 @@ describe("FormNav component", () => {
 	});
 
 	it("should navigate to the selected section", () => {
-		const url = "http://dummy.com";
-		const sectionLink = screen.getByText("Account Information");
-		global.window = Object.create(window);
-		Object.defineProperty(window, "location", {
-			value: {
-				href: url,
-			},
-			writable: true,
-		});
-		window.location.replace = jest.fn();
+		window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
 
-		fireEvent.click(sectionLink);
+		fireEvent.click(screen.getByText("Account Profile"));
 
-		expect(window.location.replace).toHaveBeenCalled();
+		expect(scrollIntoViewMock).toHaveBeenCalled();
 	});
 });

--- a/src/forms/FormNav/FormNav.tsx
+++ b/src/forms/FormNav/FormNav.tsx
@@ -104,7 +104,7 @@ const FormNav = (props: FormNavProps): ReactElement => {
 			window.removeEventListener("scroll", navHighlighterDebounced);
 			navHighlighterDebounced.cancel();
 		};
-	}, []);
+	}, [sectionsRefs]);
 
 	return (
 		<FormNavWrapper className="form-nav-wrapper">

--- a/src/forms/FormNav/FormNav.tsx
+++ b/src/forms/FormNav/FormNav.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState, useRef, useEffect, ReactElement } from "react";
+import { useState, useRef, useEffect, ReactElement, memo } from "react";
 import { debounce } from "lodash";
 import {
 	FormNavWrapper,
@@ -137,4 +137,4 @@ const FormNav = (props: FormNavProps): ReactElement => {
 	);
 };
 
-export default FormNav;
+export default memo(FormNav);

--- a/src/forms/FormNav/FormNavTypes.tsx
+++ b/src/forms/FormNav/FormNavTypes.tsx
@@ -5,4 +5,5 @@ export interface Section {
 
 export interface FormNavProps {
   sections: Section[];
+	sectionsRefs?: HTMLDivElement[] | []
 }

--- a/src/forms/FormNav/FormNavTypes.tsx
+++ b/src/forms/FormNav/FormNavTypes.tsx
@@ -5,5 +5,5 @@ export interface Section {
 
 export interface FormNavProps {
   sections: Section[];
-	sectionsRefs?: HTMLDivElement[] | []
+  sectionsRefs?: HTMLDivElement[] | []
 }

--- a/src/forms/TopComponent/TopComponent.tsx
+++ b/src/forms/TopComponent/TopComponent.tsx
@@ -25,6 +25,7 @@ const TopComponent = (props: TopComponentProps): ReactElement => {
 		tooltipInfo,
 		sections,
 		view = "RESPONSIVE",
+		sectionsRefs
 	} = props;
 
 	// State variables
@@ -120,11 +121,13 @@ const TopComponent = (props: TopComponentProps): ReactElement => {
 					buttons={buttons}
 					sections={sections}
 					view={view}
+					sectionsRefs={sectionsRefs}
 				/>
 			);
 		if (view === "DESKTOP" || view === "BIG_DESKTOP")
 			return (
 				<DesktopView
+					sectionsRefs={sectionsRefs}
 					title={title}
 					description={description}
 					showActive={showActive}

--- a/src/forms/TopComponent/Views/DesktopView.tsx
+++ b/src/forms/TopComponent/Views/DesktopView.tsx
@@ -52,6 +52,7 @@ const DesktopActionsRow = styled(FlexContainer)`
 type DesktopViewProps = {
 	sections: TopComponentProps["sections"];
 	checkbox: JSX.Element;
+	sectionsRefs?: any[];
 } & BaseTopComponentProps;
 
 const DesktopView = (props: DesktopViewProps): ReactElement => {
@@ -65,6 +66,7 @@ const DesktopView = (props: DesktopViewProps): ReactElement => {
 		sections,
 		checkbox,
 		view,
+		sectionsRefs
 	} = props;
 
 	return (
@@ -85,7 +87,7 @@ const DesktopView = (props: DesktopViewProps): ReactElement => {
 			</FlexContainer>
 			{(view !== "BIG_DESKTOP" && sections) && (
 				<FlexContainer>
-					<FormNav sections={sections} />
+					<FormNav sectionsRefs={sectionsRefs} sections={sections} />
 				</FlexContainer>
 			)}
 		</DesktopViewColumn>

--- a/src/forms/TopComponent/Views/ResponsiveView.tsx
+++ b/src/forms/TopComponent/Views/ResponsiveView.tsx
@@ -30,6 +30,7 @@ const ResponsiveActionsRow = styled(Row)`
 type ResponsiveViewProps = {
 	sections: TopComponentProps["sections"];
 	checkbox: JSX.Element;
+	sectionsRefs?: any[];
 } & BaseTopComponentProps;
 
 const ResponsiveDrawer = (props: ResponsiveViewProps): ReactElement => {
@@ -42,6 +43,7 @@ const ResponsiveDrawer = (props: ResponsiveViewProps): ReactElement => {
 		buttons,
 		sections,
 		checkbox,
+		sectionsRefs,
 		view
 	} = props;
 
@@ -66,7 +68,7 @@ const ResponsiveDrawer = (props: ResponsiveViewProps): ReactElement => {
 				)}
 			</ResponsiveActionsRow>
 			{sections &&
-				<FormNav sections={sections} />
+				<FormNav sectionsRefs={sectionsRefs} sections={sections} />
 			}
 		</ResponsiveViewColumn>
 	);


### PR DESCRIPTION
## What's included?
- Replace the use of classes to select a section with refs
- Display the right scroll button conditionally
- Use the section index instead of the title to get its id
- Replace `window.replace` with `scrollIntoView` using a ref
- CSS logic refactored
- Rename **fieldsLayoutPos** to **rows**
- Update the typeDef for the “fields” from  (string | FieldDef)[ ][ ][ ] to string[ ][ ][ ].
- Debouncing scroll listener function
- Throwing an error message to indicate that an undefined field was declared. “No field declared for field name 'X' at row 1, column 10 in section 0.”
