### PR TITLE
Added trim to postalCode to prevent empty spaces before and after

### DIFF
--- a/src/forms/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
+++ b/src/forms/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
@@ -205,7 +205,7 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 		listOfAddresses[addressIdx].address2 = state?.data?.address2;
 		listOfAddresses[addressIdx].address3 = state?.data?.address3;
 		listOfAddresses[addressIdx].city = state?.data?.city;
-		listOfAddresses[addressIdx].postalCode = state?.data?.postalCode;
+		listOfAddresses[addressIdx].postalCode = state?.data?.postalCode.trim();
 		listOfAddresses[addressIdx].country = state?.data?.country;
 		listOfAddresses[addressIdx].state = state?.data?.states;
 		listOfAddresses[addressIdx].types = state?.data?.type;
@@ -227,7 +227,7 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 			address2: state?.data?.address2,
 			address3: state?.data?.address3,
 			city: state?.data?.city,
-			postalCode: state?.data?.postalCode,
+			postalCode: state?.data?.postalCode.trim(),
 			country: state?.data?.country,
 			state: state?.data?.states,
 			types: state?.data?.type,


### PR DESCRIPTION
# What's included?
- Updated postal code with trim function to prevent users from writing empty spaces before and after it. 