### PR TITLE
Mos-761: Text default comparison not functional

### DIFF
--- a/src/components/DataView/DataView.test.tsx
+++ b/src/components/DataView/DataView.test.tsx
@@ -12,7 +12,7 @@ describe("DataViewFilterText component", () => {
 				label = "Title with Comparisons"
 				type = "optional"
 				data = {{}}
-				comparisonDefault = "" 
+				comparisonDefault = ""
 				args = {{
 					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"]
 				}}
@@ -32,7 +32,7 @@ describe("DataViewFilterText component", () => {
 				label = "Title with Comparisons"
 				type = "optional"
 				data = {{}}
-				comparisonDefault = "not_equals" 
+				comparisonDefault = "not_equals"
 				args = {{
 					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"]
 				}}
@@ -63,5 +63,43 @@ describe("DataViewFilterText component", () => {
 		fireEvent.click(titleWithComparisonsButton);
 		const filter = await screen.findByText("Equals");
 		expect(filter).toBeTruthy()
+	})
+
+	it("Should throw an error when the developer has passed an invalid comparisonDefault prop", async () => {
+		/* await act(async () => {
+			try {
+				render(
+					<DataViewFilterText
+						label = "Title with Comparisons"
+						type = "optional"
+						data = {{}}
+						comparisonDefault = "invalid_comparison"
+						args = {{
+							comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"]
+						}}
+						onRemove = {jest.fn()}
+						onChange = {jest.fn()}
+					/>
+				);
+			} catch (e) {
+				expect(e.message).toEqual("The selected comparison is not a valid comparison");
+			}
+		}) */
+
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		jest.spyOn(console, "error").mockImplementation(() => {});
+		expect(() => render(
+			<DataViewFilterText
+				label = "Title with Comparisons"
+				type = "optional"
+				data = {{}}
+				comparisonDefault = "invalid_comparison"
+				args = {{
+					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"]
+				}}
+				onRemove = {jest.fn()}
+				onChange = {jest.fn()}
+			/>
+		)).toThrow("The selected comparison is not a valid comparison");
 	})
 });

--- a/src/components/DataView/DataView.test.tsx
+++ b/src/components/DataView/DataView.test.tsx
@@ -86,8 +86,7 @@ describe("DataViewFilterText component", () => {
 			}
 		}) */
 
-		// eslint-disable-next-line @typescript-eslint/no-empty-function
-		jest.spyOn(console, "error").mockImplementation(() => {});
+		jest.spyOn(console, "error").mockImplementation(jest.fn());
 		expect(() => render(
 			<DataViewFilterText
 				label = "Title with Comparisons"

--- a/src/components/DataView/DataView.test.tsx
+++ b/src/components/DataView/DataView.test.tsx
@@ -12,9 +12,9 @@ describe("DataViewFilterText component", () => {
 				label = "Title with Comparisons"
 				type = "optional"
 				data = {{}}
-				comparisonDefault = ""
 				args = {{
-					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"]
+					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"],
+					comparisonDefault: ""
 				}}
 				onRemove = {jest.fn()}
 				onChange = {jest.fn()}
@@ -32,9 +32,9 @@ describe("DataViewFilterText component", () => {
 				label = "Title with Comparisons"
 				type = "optional"
 				data = {{}}
-				comparisonDefault = "not_equals"
 				args = {{
-					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"]
+					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"],
+					comparisonDefault: "not_equals"
 				}}
 				onRemove = {jest.fn()}
 				onChange = {jest.fn()}
@@ -66,35 +66,15 @@ describe("DataViewFilterText component", () => {
 	})
 
 	it("Should throw an error when the developer has passed an invalid comparisonDefault prop", async () => {
-		/* await act(async () => {
-			try {
-				render(
-					<DataViewFilterText
-						label = "Title with Comparisons"
-						type = "optional"
-						data = {{}}
-						comparisonDefault = "invalid_comparison"
-						args = {{
-							comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"]
-						}}
-						onRemove = {jest.fn()}
-						onChange = {jest.fn()}
-					/>
-				);
-			} catch (e) {
-				expect(e.message).toEqual("The selected comparison is not a valid comparison");
-			}
-		}) */
-
-		jest.spyOn(console, "error").mockImplementation(jest.fn());
+		jest.spyOn(console, "error").mockImplementation(() => jest.fn());
 		expect(() => render(
 			<DataViewFilterText
 				label = "Title with Comparisons"
 				type = "optional"
 				data = {{}}
-				comparisonDefault = "invalid_comparison"
 				args = {{
-					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"]
+					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"],
+					comparisonDefault: "invalid_comparison"
 				}}
 				onRemove = {jest.fn()}
 				onChange = {jest.fn()}

--- a/src/components/DataView/DataViewFilters.tsx
+++ b/src/components/DataView/DataViewFilters.tsx
@@ -197,7 +197,6 @@ function DataViewFilters(props: DataViewFiltersProps) {
 									type={filter.type}
 									args={filter.args || {}}
 									data={props.filter[filter.name] || {}}
-									comparisonDefault={filter.comparisonDefault}
 									onRemove={onRemove(filter.name)}
 									onChange={filter.onChange}
 								/>

--- a/src/components/DataView/DataViewFilters.tsx
+++ b/src/components/DataView/DataViewFilters.tsx
@@ -190,14 +190,14 @@ function DataViewFilters(props: DataViewFiltersProps) {
 					{
 						active.map(filter => {
 							const Component = filter.component;
-							const filterData = props.filter[filter.name] || ((filter.comparisonDefault && filter.name === "title_with_comparisons") ? {comparison: filter.comparisonDefault} : {})
 							return (
 								<Component
 									key={filter.name}
 									label={filter.label}
 									type={filter.type}
 									args={filter.args || {}}
-									data={filterData}
+									data={props.filter[filter.name] || {}}
+									comparisonDefault={filter.comparisonDefault}
 									onRemove={onRemove(filter.name)}
 									onChange={filter.onChange}
 								/>

--- a/src/components/DataView/DataViewTypes.ts
+++ b/src/components/DataView/DataViewTypes.ts
@@ -56,7 +56,6 @@ export interface DataViewFilterDef {
 	component: React.Component
 	column?: string
 	onChange: DataViewFilterOnChange
-	comparisonDefault?: string
 }
 
 export interface DataViewFilterProps {

--- a/src/components/DataView/example/DataViewKitchenSink.tsx
+++ b/src/components/DataView/example/DataViewKitchenSink.tsx
@@ -602,8 +602,7 @@ function DataViewKitchenSink(): ReactElement {
 				label: filter.label,
 				component: filter.component,
 				type: filter.type,
-				args: filter.args,
-				comparisonDefault,
+				args: {...filter.args, comparisonDefault},
 				onChange: function (value) {
 					filterChange(filter.name, value);
 				}

--- a/src/components/DataView/example/DataViewKitchenSink.tsx
+++ b/src/components/DataView/example/DataViewKitchenSink.tsx
@@ -403,7 +403,7 @@ function DataViewKitchenSink(): ReactElement {
 	const optionalFilters = boolean("optionalFilters", true);
 	const sticky = boolean("sticky", true);
 	const locale: string = select("locale", { en: "en", es: "es", cimode: "cimode", de: "de" }, "en");
-	const comparisonDefault: string = select("Title comparisonDefault", { "Equals": "equals", "Not Equals": "not_equals", "Contains": "contains", "Not Contains": "not_contains", "Exists": "exists", "Not Exists": "not_exists" }, "contains");
+	const comparisonDefault: string = select("ComparisonDefault for text filter", { "Equals": "equals", "Not Equals": "not_equals", "Contains": "contains", "Not Contains": "not_contains", "Exists": "exists", "Not Exists": "not_exists", "Invalid Comparison": "invalid_comparison" }, "contains");
 	const displayList = boolean("displayList", true);
 	const displayGrid = boolean("displayGrid", true);
 	const validFilters = filters.filter(val => (val.type === "primary" && primaryFilters) || (val.type === "optional" && optionalFilters));

--- a/src/components/DataViewFilterText/DataViewFilterText.tsx
+++ b/src/components/DataViewFilterText/DataViewFilterText.tsx
@@ -33,7 +33,6 @@ type Comparison = "contains" | "not_contains" | "equals" | "not_equals" | "exist
 export interface DataViewFilterTextProps {
 	label?: any;
 	data?: any;
-	comparisonDefault?: any;
 	type?: any;
 	args?: any;
 	onRemove?: any;
@@ -119,13 +118,23 @@ function DataViewFilterText(props: DataViewFilterTextProps) {
 	// 	throwOnInvalid : true
 	// });
 
-	if (props.comparisonDefault && validComparisons.find( validComparison => validComparison.value === props.comparisonDefault) === undefined)
-		throw new Error("The selected comparison is not a valid comparison")
+	if (props.args.comparisonDefault && validComparisons.find( validComparison => validComparison.value === props.args.comparisonDefault) === undefined)
+		throw new Error("The selected comparison is not a valid comparison");
+
+	const getComparison = () => {
+		if (props.args && props.args.comparisons) {
+			if (props.data.comparison) {
+				return props.data.comparison;
+			} else if (props.args.comparisonDefault) {
+				return props.args.comparisonDefault;
+			}
+		} else {
+			return "equals";
+		}
+	};
 
 	const [anchorEl, setAnchorEl] = useState(null);
-	const comparison = props.args && props.args.comparisons
-		? props.data.comparison || (props.comparisonDefault || "equals")
-		: props.data.comparison || "equals";
+	const comparison = getComparison();
 	const value = props.data.value || "";
 
 	const onClick = function(event) {

--- a/src/components/DataViewFilterText/DataViewFilterText.tsx
+++ b/src/components/DataViewFilterText/DataViewFilterText.tsx
@@ -125,12 +125,11 @@ function DataViewFilterText(props: DataViewFilterTextProps) {
 		if (props.args && props.args.comparisons) {
 			if (props.data.comparison) {
 				return props.data.comparison;
-			} else if (props.args.comparisonDefault) {
+			} else if (props.args.comparisonDefault && props.args.comparisons.includes(props.args.comparisonDefault)) {
 				return props.args.comparisonDefault;
 			}
-		} else {
-			return "equals";
 		}
+		return "equals";
 	};
 
 	const [anchorEl, setAnchorEl] = useState(null);

--- a/src/components/DataViewFilterText/DataViewFilterText.tsx
+++ b/src/components/DataViewFilterText/DataViewFilterText.tsx
@@ -119,8 +119,13 @@ function DataViewFilterText(props: DataViewFilterTextProps) {
 	// 	throwOnInvalid : true
 	// });
 
+	if (props.comparisonDefault && validComparisons.find( validComparison => validComparison.value === props.comparisonDefault) === undefined)
+		throw new Error("The selected comparison is not a valid comparison")
+
 	const [anchorEl, setAnchorEl] = useState(null);
-	const comparison = props.data.comparison || (props.comparisonDefault || "equals");
+	const comparison = props.args && props.args.comparisons
+		? props.data.comparison || (props.comparisonDefault || "equals")
+		: props.data.comparison || "equals";
 	const value = props.data.value || "";
 
 	const onClick = function(event) {

--- a/src/components/DataViewFilterText/DataViewFilterText.tsx
+++ b/src/components/DataViewFilterText/DataViewFilterText.tsx
@@ -127,6 +127,8 @@ function DataViewFilterText(props: DataViewFilterTextProps) {
 				return props.data.comparison;
 			} else if (props.args.comparisonDefault && props.args.comparisons.includes(props.args.comparisonDefault)) {
 				return props.args.comparisonDefault;
+			} else {
+				return props.args.comparisons[0];
 			}
 		}
 		return "equals";


### PR DESCRIPTION
# What's include:
- Refactor to send comparisonDefault prop to DataViewFilterText component
- Unit test case to check it throw an error when developer send an invalid comparison