### PR TITLE
MOS-788: Fields with no value should return undefined

### DIFF
--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -22,6 +22,14 @@ async function runValidators(
 	return;
 }
 
+const isValidValue = (value: any) => {
+	if (value === "" || value?.length === 0) {
+		return false
+	}
+
+	return true;
+}
+
 export const formActions = {
 	init({ fields }) {
 		return async function (_dispatch, _getState, extraArgs): Promise<void> {
@@ -38,7 +46,7 @@ export const formActions = {
 			await dispatch({
 				type: "FIELD_ON_CHANGE",
 				name,
-				value
+				value: isValidValue(value) ? value : undefined
 			});
 
 			if (validate) {


### PR DESCRIPTION
What's included?
- Fields return undefined when its value is an empty object, an empty array, or an empty string.