### PR TITLE
MOS-767: Migrate FormField stories to v6

### DIFF
--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -1,1076 +1,1116 @@
-// // import * as React from "react";
-// // import { ReactElement, useEffect, useMemo, useState, useCallback } from "react";
-// // import { boolean, object, text, withKnobs } from "@storybook/addon-knobs";
+import * as React from "react";
+import { useEffect, useMemo, useState, useCallback, ReactElement } from "react";
 
-// // // Utils
-// // import { checkboxOptions } from "@root/forms/FormFieldCheckbox/FormFieldCheckboxUtils"
-// // import { useTable, headers } from "@root/forms/FormFieldTable/tableUtils";
-// // import { useForm, formActions } from "@root/components/Form";
-// // import { useImageVideoLinkDocumentBrowsing, imageVideoSrc } from "@root/forms/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsingUtils";
-// // import { validateEmail, validateSlow, required, validateNumber, validateURL } from "./validators";
-// // import { menuOptions } from "@root/forms/MenuFormFieldCard/MenuFormFieldUtils";
-// // import { onCancel, renderButtons } from "@root/utils/storyUtils";
+// Utils
+import { checkboxOptions } from "@root/forms/FormFieldCheckbox/FormFieldCheckboxUtils";
+import { useTable, headers } from "@root/forms/FormFieldTable/tableUtils";
+import Form, { useForm, formActions } from "@root/components/Form";
+import {
+	useImageVideoLinkDocumentBrowsing,
+	imageVideoSrc,
+} from "@root/forms/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsingUtils";
+import {
+	validateEmail,
+	validateSlow,
+	required,
+	validateNumber,
+	validateURL,
+} from "./validators";
+import { menuOptions } from "@root/forms/MenuFormFieldCard/MenuFormFieldUtils";
+import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
 
-// // Components
-// import Drawer from "@root/components/Drawer";
-// import HomeIcon from "@mui/icons-material/Home";
+// Components
+import Drawer from "@root/components/Drawer";
+import HomeIcon from "@mui/icons-material/Home";
 
-// // // Types
-// // import { TextFieldDef } from "@root/forms/FormFieldText/FormFieldTextTypes";
-// // import { FieldDef } from "@root/components/Field";
-// // import { AdvancedSelectionDef, additionalOptions } from "@root/forms/FormFieldAdvancedSelection";
-// // import { TableDef } from "@root/forms/FormFieldTable";
-// // import { ImageUploadDef } from "@root/forms/FormFieldImageUpload";
-// // import { MapCoordinatesDef } from "@root/forms/FormFieldMapCoordinates";
-// // import { ImageVideoDocumentLinkBrowsingDef } from "@root/forms/FormFieldImageVideoLinkDocumentBrowsing";
-// // import { FormFieldToggleSwitchDef } from "@root/forms/FormFieldToggleSwitch";
-// // import { FormFieldRadioDef } from "@root/forms/FormFieldRadio";
-// // import { DropdownSingleSelectionDef } from "@root/forms/FormFieldDropdownSingleSelection";
-// // import { FormFieldChipSingleSelectDef } from "@root/forms/FormFieldChipSingleSelect";
-// // import { FormFieldCheckboxDef } from "@root/forms/FormFieldCheckbox";
-// // import { TextAreaDef } from "@root/forms/FormFieldTextArea";
-// // import { ButtonProps } from "@root/components/Button";
-// import { NavWrapper } from "@root/components/LeftNav/NavWrapper";
+// Types
+import { TextFieldDef } from "@root/forms/FormFieldText/FormFieldTextTypes";
+import { FieldDef } from "@root/components/Field";
+import {
+	AdvancedSelectionDef,
+	additionalOptions,
+} from "@root/forms/FormFieldAdvancedSelection";
+import { TableDef } from "@root/forms/FormFieldTable";
+import { ImageUploadDef } from "@root/forms/FormFieldImageUpload";
+import { MapCoordinatesDef } from "@root/forms/FormFieldMapCoordinates";
+import { ImageVideoDocumentLinkBrowsingDef } from "@root/forms/FormFieldImageVideoLinkDocumentBrowsing";
+import { FormFieldToggleSwitchDef } from "@root/forms/FormFieldToggleSwitch";
+import { FormFieldRadioDef } from "@root/forms/FormFieldRadio";
+import { DropdownSingleSelectionDef } from "@root/forms/FormFieldDropdownSingleSelection";
+import { FormFieldChipSingleSelectDef } from "@root/forms/FormFieldChipSingleSelect";
+import { FormFieldCheckboxDef } from "@root/forms/FormFieldCheckbox";
+import { TextAreaDef } from "@root/forms/FormFieldTextArea";
+import { ButtonProps } from "@root/components/Button";
+import { NavWrapper } from "@root/components/LeftNav/NavWrapper";
 
-// // export default {
-// // 	title: "Components/Form",
-// // 	decorators: [withKnobs],
-// // };
+export default {
+	title: "Components/Form",
+	component: Form,
+};
 
-// // const deleteTableRow = () => {
-// // 	alert("Delete button clicked");
-// // };
+const deleteTableRow = () => {
+	alert("Delete button clicked");
+};
 
-// const createNewOption = async (newOptionLabel) => {
-// 	const value = `${newOptionLabel}_${additionalOptions.length}`
-// 	const newOption = {
-// 		label: newOptionLabel,
-// 		value,
-// 	}
+const createNewOption = async (newOptionLabel) => {
+	const value = `${newOptionLabel}_${additionalOptions.length}`;
+	const newOption = {
+		label: newOptionLabel,
+		value,
+	};
 
-// 	//Insert to db
-// 	additionalOptions.push(newOption);
+	//Insert to db
+	additionalOptions.push(newOption);
 
-// 	return newOption;
-// }
+	return newOption;
+};
 
-// // export const Playground = (): ReactElement => {
-// // 	const [loadReady, setLoadReady] = useState(false);
-// // 	const { state, dispatch } = useForm();
+const Template = (args) => {
+	const [loadReady, setLoadReady] = useState(false);
+	const { state, dispatch } = useForm();
+	const { addTableRow, editAction, extraActionsTable } = useTable(
+		state.data,
+		"table",
+		dispatch
+	);
 
-// // 	const { addTableRow, editAction, extraActionsTable } = useTable(
-// // 		state.data,
-// // 		"table",
-// // 		dispatch
-// // 	);
-// // 	const { setImage, setVideo, setDocument, setLink, handleRemove } = useImageVideoLinkDocumentBrowsing(dispatch, "imageVideoDocumentLink");
+	const {
+		setImage,
+		setVideo,
+		setDocument,
+		setLink,
+		handleRemove,
+	} = useImageVideoLinkDocumentBrowsing(dispatch, "imageVideoDocumentLink");
 
-// 	const prepopulate = boolean("Prepopulate", false);
-// 	const showSave = boolean("Show SAVE button", true);
-// 	const showCancel = boolean("Show CANCEL button", true);
-// 	const required = boolean("Required", true);
-// 	const disabled = boolean("Disabled", false);
-// 	const showSections = boolean("Show sections", false);
-// 	const prepopulateValues = object("Prepolulate values", {
-// 		"textField": "Text field prepopulated",
-// 		"textArea": "Text area prepopulated",
-// 		"check": [
-// 			"label_1",
-// 			"label_2"
-// 		],
-// 		"chipSelect": "label_1",
-// 		"dropdownSingle": "1972",
-// 		"phoneSelect": "15205751151",
-// 		"radio": "label_3",
-// 		"toggleSwitch": true,
-// 		"color": "#a8001791",
-// 		"date": new Date(),
-// 		"address": [
-// 			{
-// 				"id": 1,
-// 				"address1": "8950 N. Oracle Road",
-// 				"city": "Tuczon",
-// 				"postalCode": "85704",
-// 				"country": "US",
-// 				"state": "AZ",
-// 				"types": [
-// 					"physical",
-// 					"billing",
-// 					"shipping"
-// 				]
-// 			}
-// 		],
-// 		"advancedSelection": [
-// 			{
-// 				label: "Prepopulated 1",
-// 				value: "prep option 1"
-// 			},
-// 			{
-// 				label: "Prepopulated 2",
-// 				value: "prep option 2"
-// 			},
-// 			{
-// 				label: "Prepopulated 3",
-// 				value: "prep option 3"
-// 			},
-// 			{
-// 				label: "Prepopulated 4",
-// 				value: "prep option 4"
-// 			}
-// 		],
-// 		"imageVideoDocumentLink": [
-// 			{
-// 				"label": "Title",
-// 				"value": "Video Thumbnail - YouTube - Visit Santa Fe, New Mexico Video Thumbnail"
-// 			},
-// 			{
-// 				"label": "Type",
-// 				"value": "Image Video Thumbnail"
-// 			},
-// 			{
-// 				"label": "Alt",
-// 				"value": "-"
-// 			},
-// 			{
-// 				"label": "Size",
-// 				"value": "1280x720"
-// 			},
-// 			{
-// 				"label": "Focus",
-// 				"value": "No"
-// 			},
-// 			{
-// 				"label": "Locales",
-// 				"value": "-"
-// 			}
-// 		],
-// 		"table": [
-// 			{
-// 				"id": "1",
-// 				"items": [
-// 					"John",
-// 					"john@email.com",
-// 					"01/01/2021",
-// 					"3231-962-7516"
-// 				]
-// 			}
-// 		],
-// 		"imageUpload": {
-// 			"imgName": "image (2).png",
-// 			"size": 61571,
-// 			"type": "image/png",
-// 			"height": 600,
-// 			"width": 777
-// 		},
-// 		"mapCoordinates": {
-// 			"lat": 32.3395031,
-// 			"lng": -110.9864294
-// 		}
-// 	});
+	const {
+		descriptionSection1,
+		descriptionSection2,
+		descriptionSection3,
+		prepopulate,
+		showSave,
+		showCancel,
+		required,
+		disabled,
+		showSections,
+		prepopulateValues,
+		titleSection1,
+		titleSection2,
+		titleSection3
+	} = args;
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "textField",
-// 					label: "Simple Text",
-// 					type: "text",
-// 					disabled,
-// 					required
-// 				} as FieldDef<TextFieldDef>,
-// 				{
-// 					name: "textArea",
-// 					label: "Text Area",
-// 					type: "textArea",
-// 					disabled,
-// 					required
-// 				} as FieldDef<TextAreaDef>,
-// 				{
-// 					name: "check",
-// 					label: "Checkbox",
-// 					type: "checkbox",
-// 					disabled,
-// 					required,
-// 					inputSettings: {
-// 						options: checkboxOptions
-// 					},
-// 				} as FieldDef<FormFieldCheckboxDef>,
-// 				{
-// 					name: "chipSelect",
-// 					label: "Chip single select",
-// 					type: "chip",
-// 					inputSettings: {
-// 						options: [
-// 							{
-// 								label: "Label 1",
-// 								value: "label_1"
-// 							},
-// 							{
-// 								label: "Label 2",
-// 								value: "label_2"
-// 							},
-// 							{
-// 								label: "Label 3",
-// 								value: "label_3"
-// 							}
-// 						],
-// 					},
-// 					disabled,
-// 					required
-// 				} as FieldDef<FormFieldChipSingleSelectDef>,
-// 				{
-// 					name: "dropdownSingle",
-// 					label: "Dropdown single select",
-// 					type: "dropdown",
-// 					disabled,
-// 					required,
-// 					inputSettings: {
-// 						options: [
-// 							{ label: "The Shawshank Redemption", value: "1994" },
-// 							{ label: "The Godfather", value: "1972" },
-// 							{ label: "The Godfather: Part II", value: "1974" },
-// 							{ label: "The Dark Knight", value: "2008" },
-// 							{ label: "12 Angry Men", value: 1957 },
-// 							{ label: "Schindler's List", value: "1993" },
-// 							{ label: "Pulp Fiction", value: "1994" },
-// 							{ label: "The Lord of the Rings: The Return of the King", value: "2003" },
-// 							{ label: "The Good, the Bad and the Ugly", value: "1966" },
-// 							{ label: "Fight Club", value: "1999" },
-// 							{ label: "The Lord of the Rings: The Fellowship of the Ring", value: "2001" },
-// 							{ label: "Star Wars: Episode V - The Empire Strikes Back", value: "1980" },
-// 							{ label: "Forrest Gump", value: "1994" },
-// 							{ label: "Inception", value: "2010" },
-// 							{ label: "The Lord of the Rings: The Two Towers", value: "2002" },
-// 							{ label: "One Flew Over the Cuckoo's Nest", value: "1975" },
-// 							{ label: "Goodfellas", value: "1990" },
-// 							{ label: "The Matrix", value: "1999" },
-// 							{ label: "Seven Samurai", value: "1954" },
-// 							{ label: "Star Wars: Episode IV - A New Hope", value: "1977" },
-// 							{ label: "City of God", value: "2002" },
-// 							{ label: "Se7en", value: "1995" },
-// 						],
-// 					},
-// 				} as FieldDef<DropdownSingleSelectionDef>,
-// 				{
-// 					name: "phoneSelect",
-// 					label: "Phone selection",
-// 					type: "phone",
-// 					disabled,
-// 					required
-// 				},
-// 				{
-// 					name: "radio",
-// 					label: "Radio selection",
-// 					type: "radio",
-// 					disabled,
-// 					required,
-// 					inputSettings: {
-// 						options: [
-// 							{
-// 								label: "Label 1",
-// 								value: "label_1"
-// 							},
-// 							{
-// 								label: "Label 2",
-// 								value: "label_2"
-// 							},
-// 							{
-// 								label: "Label 3",
-// 								value: "label_3"
-// 							}
-// 						],
-// 					}
-// 				} as FieldDef<FormFieldRadioDef>,
-// 				{
-// 					name: "toggleSwitch",
-// 					label: "Toggle field",
-// 					disabled,
-// 					required,
-// 					type: "toggleSwitch",
-// 					inputSettings: {
-// 						toggleLabel: "To the side"
-// 					}
-// 				} as FieldDef<FormFieldToggleSwitchDef>,
-// 				{
-// 					name: "color",
-// 					label: "Color selector example",
-// 					disabled,
-// 					required,
-// 					type: "color",
-// 				},
-// 				{
-// 					name: "date",
-// 					label: "Single Date Picker",
-// 					type: "date",
-// 					disabled,
-// 					required,
-// 				},
-// 				{
-// 					name: "address",
-// 					label: "Address field",
-// 					type: "address",
-// 					disabled,
-// 					required
-// 				},
-// 				{
-// 					name: "advancedSelection",
-// 					label: "Advanced Selection field",
-// 					type: "advancedSelection",
-// 					disabled,
-// 					required,
-// 					inputSettings: {
-// 						options: additionalOptions,
-// 						createNewOption
-// 					}
-// 				} as FieldDef<AdvancedSelectionDef>,
-// 				{
-// 					name: "imageVideoDocumentLink",
-// 					label: "Image Video and Document field",
-// 					type: "imageVideoDocumentLink",
-// 					disabled,
-// 					required,
-// 					inputSettings: {
-// 						options: menuOptions,
-// 						handleSetImage: setImage,
-// 						handleSetDocument: setDocument,
-// 						handleSetVideo: setVideo,
-// 						handleSetLink: setLink,
-// 						handleRemove,
-// 						src: imageVideoSrc,
-// 					}
-// 				} as FieldDef<ImageVideoDocumentLinkBrowsingDef>,
-// 				{
-// 					name: "textEditor",
-// 					label: "Text Editor field",
-// 					type: "textEditor",
-// 					disabled,
-// 					required
-// 				},
-// 				{
-// 					name: "table",
-// 					label: "Table example",
-// 					type: "table",
-// 					disabled,
-// 					required,
-// 					inputSettings: {
-// 						handleAddElement: addTableRow,
-// 						handleEdit: editAction,
-// 						handleDelete: deleteTableRow,
-// 						extraActions: extraActionsTable,
-// 						headers,
-// 					}
-// 				} as FieldDef<TableDef>,
-// 				{
-// 					name: "imageUpload",
-// 					label: "Image Upload example",
-// 					type: "imageUpload",
-// 					disabled,
-// 					required,
-// 					inputSettings: {
-// 						options: menuOptions
-// 					}
-// 				} as FieldDef<ImageUploadDef>,
-// 				{
-// 					name: "mapCoordinates",
-// 					label: "Map Coordinates Example",
-// 					type: "mapCoordinates",
-// 					disabled,
-// 					required,
-// 					inputSettings: {
-// 						apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac"
-// 					}
-// 				} as FieldDef<MapCoordinatesDef>,
-// 			] as unknown as FieldDef[],
-// 		[additionalOptions, disabled, required]
-// 	);
+	const fields = useMemo(
+		() =>
+			([
+				{
+					name: "textField",
+					label: "Simple Text",
+					type: "text",
+					disabled,
+					required,
+				} as FieldDef<TextFieldDef>,
+				{
+					name: "textArea",
+					label: "Text Area",
+					type: "textArea",
+					disabled,
+					required,
+				} as FieldDef<TextAreaDef>,
+				{
+					name: "check",
+					label: "Checkbox",
+					type: "checkbox",
+					disabled,
+					required,
+					inputSettings: {
+						options: checkboxOptions,
+					},
+				} as FieldDef<FormFieldCheckboxDef>,
+				{
+					name: "chipSelect",
+					label: "Chip single select",
+					type: "chip",
+					inputSettings: {
+						options: [
+							{
+								label: "Label 1",
+								value: "label_1",
+							},
+							{
+								label: "Label 2",
+								value: "label_2",
+							},
+							{
+								label: "Label 3",
+								value: "label_3",
+							},
+						],
+					},
+					disabled,
+					required,
+				} as FieldDef<FormFieldChipSingleSelectDef>,
+				{
+					name: "dropdownSingle",
+					label: "Dropdown single select",
+					type: "dropdown",
+					disabled,
+					required,
+					inputSettings: {
+						options: [
+							{ label: "The Shawshank Redemption", value: "1994" },
+							{ label: "The Godfather", value: "1972" },
+							{ label: "The Godfather: Part II", value: "1974" },
+							{ label: "The Dark Knight", value: "2008" },
+							{ label: "12 Angry Men", value: 1957 },
+							{ label: "Schindler's List", value: "1993" },
+							{ label: "Pulp Fiction", value: "1994" },
+							{
+								label: "The Lord of the Rings: The Return of the King",
+								value: "2003",
+							},
+							{ label: "The Good, the Bad and the Ugly", value: "1966" },
+							{ label: "Fight Club", value: "1999" },
+							{
+								label: "The Lord of the Rings: The Fellowship of the Ring",
+								value: "2001",
+							},
+							{
+								label: "Star Wars: Episode V - The Empire Strikes Back",
+								value: "1980",
+							},
+							{ label: "Forrest Gump", value: "1994" },
+							{ label: "Inception", value: "2010" },
+							{ label: "The Lord of the Rings: The Two Towers", value: "2002" },
+							{ label: "One Flew Over the Cuckoo's Nest", value: "1975" },
+							{ label: "Goodfellas", value: "1990" },
+							{ label: "The Matrix", value: "1999" },
+							{ label: "Seven Samurai", value: "1954" },
+							{ label: "Star Wars: Episode IV - A New Hope", value: "1977" },
+							{ label: "City of God", value: "2002" },
+							{ label: "Se7en", value: "1995" },
+						],
+					},
+				} as FieldDef<DropdownSingleSelectionDef>,
+				{
+					name: "phoneSelect",
+					label: "Phone selection",
+					type: "phone",
+					disabled,
+					required,
+				},
+				{
+					name: "radio",
+					label: "Radio selection",
+					type: "radio",
+					disabled,
+					required,
+					inputSettings: {
+						options: [
+							{
+								label: "Label 1",
+								value: "label_1",
+							},
+							{
+								label: "Label 2",
+								value: "label_2",
+							},
+							{
+								label: "Label 3",
+								value: "label_3",
+							},
+						],
+					},
+				} as FieldDef<FormFieldRadioDef>,
+				{
+					name: "toggleSwitch",
+					label: "Toggle field",
+					disabled,
+					required,
+					type: "toggleSwitch",
+					inputSettings: {
+						toggleLabel: "To the side",
+					},
+				} as FieldDef<FormFieldToggleSwitchDef>,
+				{
+					name: "color",
+					label: "Color selector example",
+					disabled,
+					required,
+					type: "color",
+				},
+				{
+					name: "date",
+					label: "Single Date Picker",
+					type: "date",
+					disabled,
+					required,
+				},
+				{
+					name: "address",
+					label: "Address field",
+					type: "address",
+					disabled,
+					required,
+				},
+				{
+					name: "advancedSelection",
+					label: "Advanced Selection field",
+					type: "advancedSelection",
+					disabled,
+					required,
+					inputSettings: {
+						options: additionalOptions,
+						createNewOption,
+					},
+				} as FieldDef<AdvancedSelectionDef>,
+				{
+					name: "imageVideoDocumentLink",
+					label: "Image Video and Document field",
+					type: "imageVideoDocumentLink",
+					disabled,
+					required,
+					inputSettings: {
+						options: menuOptions,
+						handleSetImage: setImage,
+						handleSetDocument: setDocument,
+						handleSetVideo: setVideo,
+						handleSetLink: setLink,
+						handleRemove,
+						src: imageVideoSrc,
+					},
+				} as FieldDef<ImageVideoDocumentLinkBrowsingDef>,
+				{
+					name: "textEditor",
+					label: "Text Editor field",
+					type: "textEditor",
+					disabled,
+					required,
+				},
+				{
+					name: "table",
+					label: "Table example",
+					type: "table",
+					disabled,
+					required,
+					inputSettings: {
+						handleAddElement: addTableRow,
+						handleEdit: editAction,
+						handleDelete: deleteTableRow,
+						extraActions: extraActionsTable,
+						headers,
+					},
+				} as FieldDef<TableDef>,
+				{
+					name: "imageUpload",
+					label: "Image Upload example",
+					type: "imageUpload",
+					disabled,
+					required,
+					inputSettings: {
+						options: menuOptions,
+					},
+				} as FieldDef<ImageUploadDef>,
+				{
+					name: "mapCoordinates",
+					label: "Map Coordinates Example",
+					type: "mapCoordinates",
+					disabled,
+					required,
+					inputSettings: {
+						apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
+					},
+				} as FieldDef<MapCoordinatesDef>,
+			] as unknown) as FieldDef[],
+		[additionalOptions, disabled, required]
+	);
 
-// 	const sections = [
-// 		{
-// 			title: text("Title section 1", "Section 1"),
-// 			description: text("Description for section 1", "Description for section 1"),
-// 			fields: [
-// 				// row 1
-// 				[["textField"], ["textArea"], ["check"]],
-// 				// row 2
-// 				[["chipSelect"], ["dropdownSingle"]],
-// 				[["table"]],
-// 				// row 3
-// 				[["phoneSelect"], ["radio"]]
-// 			]
-// 		},
-// 		{
-// 			title: text("Title section 2", "Section 2"),
-// 			description: text("Description for section 2", "Description for section 2"),
-// 			fields: [
-// 				// row 1
-// 				[[], [], []],
-// 				// row 2
-// 				[["toggleSwitch"], [], ["mapCoordinates"]],
-// 				[[]],
-// 				// row 3
-// 				[[], ["advancedSelection"]]
-// 			]
-// 		},
-// 		{
-// 			title: text("Title section 3", "Section 3"),
-// 			description: text("Description for section 3", "Description for section 3"),
-// 			fields: [
-// 				// row 1
-// 				[["color"], ["date"],],
-// 				// row 2
-// 				[["textEditor"], []]
-// 			]
-// 		}
-// 	];
+	const sections = [
+		{
+			title: titleSection1,
+			description: descriptionSection1,
+			fields: [
+				// row 1
+				[["textField"], ["textArea"], ["check"]],
+				// row 2
+				[["chipSelect"], ["dropdownSingle"]],
+				[["table"]],
+				// row 3
+				[["phoneSelect"], ["radio"]]
+			]
+		},
+		{
+			title: titleSection2,
+			description: descriptionSection2,
+			fields: [
+				// row 1
+				[[], [], []],
+				// row 2
+				[["toggleSwitch"], [], ["mapCoordinates"]],
+				[[]],
+				// row 3
+				[[], ["advancedSelection"]]
+			]
+		},
+		{
+			title: titleSection3,
+			description: descriptionSection3,
+			fields: [
+				// row 1
+				[["color"], ["date"],],
+				// row 2
+				[["textEditor"], []]
+			]
+		}
+	];
 
-// // 	const onLoad = useCallback(async () => {
-// // 		return {
-// // 			...prepopulateValues
-// // 		};
-// // 	}, [prepopulateValues]);
+	const onLoad = useCallback(async () => {
+		return {
+			...prepopulateValues
+		};
+	}, [prepopulateValues]);
 
-// // 	useEffect(() => {
-// // 		const resetForm = async () => {
-// // 			await dispatch(formActions.resetForm());
-// // 			setLoadReady(true);
-// // 		};
-// // 		prepopulate ? resetForm() : setLoadReady(false);
-// // 	}, [prepopulate])
+	useEffect(() => {
+		const resetForm = async () => {
+			await dispatch(formActions.resetForm());
+			setLoadReady(true);
+		};
+		prepopulate ? resetForm() : setLoadReady(false);
+	}, [prepopulate])
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<div style={{height: "100vh"}}>
-// 				<Form
-// 					title={text("Title", "Form Title")}
-// 					description={text("Description", "This is a description example")}
-// 					state={state}
-// 					fields={fields}
-// 					dispatch={dispatch}
-// 					getFormValues={loadReady && onLoad}
-// 					sections={showSections && sections}
-// 					buttons={renderButtons(dispatch, { showCancel, showSave })}
-// 				/>
-// 			</div>
-// 		</>
-// 	);
-// };
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<div style={{height: "100vh"}}>
+				<Form
+					title="Form Title"
+					description="This is a description example"
+					state={state}
+					fields={fields}
+					dispatch={dispatch}
+					getFormValues={loadReady && onLoad}
+					sections={showSections && sections}
+					buttons={renderButtons(dispatch, { showCancel, showSave })}
+				/>
+			</div>
+		</>
+	);
+};
 
-// // export const FormWithLayout = (): ReactElement => {
-// // 	const { state, dispatch } = useForm();
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	descriptionSection1: "Description section 1",
+	descriptionSection2: "Description section 2",
+	descriptionSection3: "Description section 3",
+	showSave: true,
+	showCancel: true,
+	required: true,
+	disabled: false,
+	showSections: false,
+	titleSection1: "Title section 1",
+	titleSection2: "Title section 2",
+	titleSection3: "Title section 3",
+	prepopulate: false,
+	prepopulateValues: {
+		textField: "Text field prepopulated",
+		textArea: "Text area prepopulated",
+		check: ["label_1", "label_2"],
+		chipSelect: "label_1",
+		dropdownSingle: "1972",
+		phoneSelect: "15205751151",
+		radio: "label_3",
+		toggleSwitch: true,
+		color: "#a8001791",
+		date: new Date(),
+		address: [
+			{
+				id: 1,
+				address1: "8950 N. Oracle Road",
+				city: "Tuczon",
+				postalCode: "85704",
+				country: "US",
+				state: "AZ",
+				types: ["physical", "billing", "shipping"],
+			},
+		],
+		advancedSelection: [
+			{
+				label: "Prepopulated 1",
+				value: "prep option 1",
+			},
+			{
+				label: "Prepopulated 2",
+				value: "prep option 2",
+			},
+			{
+				label: "Prepopulated 3",
+				value: "prep option 3",
+			},
+			{
+				label: "Prepopulated 4",
+				value: "prep option 4",
+			},
+		],
+		imageVideoDocumentLink: [
+			{
+				label: "Title",
+				value:
+					"Video Thumbnail - YouTube - Visit Santa Fe, New Mexico Video Thumbnail",
+			},
+			{
+				label: "Type",
+				value: "Image Video Thumbnail",
+			},
+			{
+				label: "Alt",
+				value: "-",
+			},
+			{
+				label: "Size",
+				value: "1280x720",
+			},
+			{
+				label: "Focus",
+				value: "No",
+			},
+			{
+				label: "Locales",
+				value: "-",
+			},
+		],
+		table: [
+			{
+				id: "1",
+				items: ["John", "john@email.com", "01/01/2021", "3231-962-7516"],
+			},
+		],
+		imageUpload: {
+			imgName: "image (2).png",
+			size: 61571,
+			type: "image/png",
+			height: 600,
+			width: 777,
+		},
+		mapCoordinates: {
+			lat: 32.3395031,
+			lng: -110.9864294,
+		},
+	},
+};
 
-// // 	const fields = useMemo(
-// // 		() =>
-// // 			[
-// // 				{
-// // 					name: "text1",
-// // 					label: "Simple Text",
-// // 					type: "text",
-// // 					instructionText: "Instruction text text1",
-// // 					validators: [validateEmail, validateSlow],
-// // 					layout: { section: 0, row: 1, col: 0 },
-// // 				},
-// // 				{
-// // 					name: "text2",
-// // 					label: "Text with validators and dynamic help",
-// // 					type: "text",
-// // 					help: state.data.text2,
-// // 					instructionText: "Instruction text text2",
-// // 					validators: [validateEmail, validateSlow]
-// // 				},
-// // 				{
-// // 					name: "text3",
-// // 					label: "Text that copies to the next input",
-// // 					type: "text",
-// // 					instructionText: "Instruction text text3",
-// // 				},
-// // 				{
-// // 					name: "text4",
-// // 					label: "Text that receives copy",
-// // 					type: "text",
-// // 					instructionText: "Instruction text text1"
-// // 				},
-// // 				{
-// // 					name: "color",
-// // 					label: "Color selector example",
-// // 					type: "color",
-// // 				},
-// // 				{
-// // 					name: "check",
-// // 					label: "Checkbox",
-// // 					type: "checkbox",
-// // 					inputSettings: {
-// // 						options: checkboxOptions
-// // 					},
-// // 				},
-// // 				{
-// // 					name: "toggleSwitch",
-// // 					label: "Toggle field",
-// // 					type: "toggleSwitch",
-// // 					inputSettings: {
-// // 						toggleLabel: "To the side"
-// // 					}
-// // 				},
-// // 				{
-// // 					name: "imageUpload",
-// // 					label: "Image Upload example",
-// // 					type: "imageUpload",
-// // 					inputSettings: {
-// // 						options: menuOptions
-// // 					}
-// // 				},
-// // 				{
-// // 					name: "textEditor",
-// // 					label: "Text Editor field",
-// // 					type: "textEditor",
-// // 				},
-// // 			] as FieldDef[],
-// // 		[]
-// // 	);
+const FormWithLayoutTemplate = () => {
+	const { state, dispatch } = useForm();
+	const fields = useMemo(
+		() =>
+			[
+				{
+					name: "text1",
+					label: "Simple Text",
+					type: "text",
+					instructionText: "Instruction text text1",
+					validators: [validateEmail, validateSlow],
+					layout: { section: 0, row: 1, col: 0 },
+				},
+				{
+					name: "text2",
+					label: "Text with validators and dynamic help",
+					type: "text",
+					help: state.data.text2,
+					instructionText: "Instruction text text2",
+					validators: [validateEmail, validateSlow]
+				},
+				{
+					name: "text3",
+					label: "Text that copies to the next input",
+					type: "text",
+					instructionText: "Instruction text text3",
+				},
+				{
+					name: "text4",
+					label: "Text that receives copy",
+					type: "text",
+					instructionText: "Instruction text text1"
+				},
+				{
+					name: "color",
+					label: "Color selector example",
+					type: "color",
+				},
+				{
+					name: "check",
+					label: "Checkbox",
+					type: "checkbox",
+					inputSettings: {
+						options: checkboxOptions
+					},
+				},
+				{
+					name: "toggleSwitch",
+					label: "Toggle field",
+					type: "toggleSwitch",
+					inputSettings: {
+						toggleLabel: "To the side"
+					}
+				},
+				{
+					name: "imageUpload",
+					label: "Image Upload example",
+					type: "imageUpload",
+					inputSettings: {
+						options: menuOptions
+					}
+				},
+				{
+					name: "textEditor",
+					label: "Text Editor field",
+					type: "textEditor",
+				},
+			] as FieldDef[],
+		[]
+	);
 
-// // 	const sections = useMemo(() => [
-// // 		{
-// // 			title: "Section 1",
-// // 			description: "Description for section 1",
-// // 			fields: [
-// // 				// row 1
-// // 				[["text1"], ["text2"], ["text3"]],
-// // 				// row 2
-// // 				[["check"], ["text4"], ["color"]],
-// // 				[[]],
-// // 				// row 3
-// // 				[["toggleSwitch"], ["imageUpload"]]
-// // 			]
-// // 		},
-// // 		{
-// // 			title: "Section 2",
-// // 			description: "Description for section 2",
-// // 			fields: [
-// // 				// row 1
-// // 				[["check"], ["toggleSwitch"], ["color"]],
-// // 				// row 2
-// // 				[[], [], []],
-// // 				// row 3
-// // 				[[]],
-// // 				// row 4
-// // 				[[], ["textEditor"]]
-// // 			]
-// // 		},
-// // 		{
-// // 			title: "Section 3",
-// // 			description: "Description for section 3",
-// // 			fields: [
-// // 				// row 1
-// // 				[[], [], []],
-// // 				// row 2
-// // 				[[], [], []],
-// // 				[[]],
-// // 				// row 3
-// // 				[[], []]
-// // 			]
-// // 		},
-// // 	], [fields]);
+	const sections = useMemo(() => [
+		{
+			title: "Section 1",
+			description: "Description for section 1",
+			fields: [
+				// row 1
+				[["text1"], ["text2"], ["text3"]],
+				// row 2
+				[["check"], ["text4"], ["color"]],
+				[[]],
+				// row 3
+				[["toggleSwitch"], ["imageUpload"]]
+			]
+		},
+		{
+			title: "Section 2",
+			description: "Description for section 2",
+			fields: [
+				// row 1
+				[["check"], ["toggleSwitch"], ["color"]],
+				// row 2
+				[[], [], []],
+				// row 3
+				[[]],
+				// row 4
+				[[], ["textEditor"]]
+			]
+		},
+		{
+			title: "Section 3",
+			description: "Description for section 3",
+			fields: [
+				// row 1
+				[[], [], []],
+				// row 2
+				[[], [], []],
+				[[]],
+				// row 3
+				[[], []]
+			]
+		},
+	], [fields]);
 
-// // 	useEffect(() => {
-// // 		dispatch(
-// // 			formActions.setFieldValue({
-// // 				name: "text4",
-// // 				value: state.data.text3
-// // 			})
-// // 		);
-// // 	}, [state.data.text3]);
+	useEffect(() => {
+		dispatch(
+			formActions.setFieldValue({
+				name: "text4",
+				value: state.data.text3
+			})
+		);
+	}, [state.data.text3]);
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<div style={{height: "100vh"}}>
-// 				<Form
-// 					buttons={renderButtons(dispatch)}
-// 					title="Form Title"
-// 					description="This is a description example"
-// 					sections={sections}
-// 					state={state}
-// 					fields={fields}
-// 					dispatch={dispatch}
-// 					onCancel={onCancel}
-// 				/>
-// 			</div>
-// 		</>
-// 	);
-// }
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<div style={{height: "100vh"}}>
+				<Form
+					buttons={renderButtons(dispatch)}
+					title="Form Title"
+					description="This is a description example"
+					sections={sections}
+					state={state}
+					fields={fields}
+					dispatch={dispatch}
+					onCancel={onCancel}
+				/>
+			</div>
+		</>
+	);
+};
 
-// // export const PerformanceWithSubmit = (): ReactElement => {
-// // 	const { state, dispatch } = useForm();
+export const FormWithLayout = FormWithLayoutTemplate.bind({});
 
-// // 	const hundredFields = [];
+export const PerformanceWithSubmit = (): ReactElement => {
+	const { state, dispatch } = useForm();
 
-// // 	for (let i = 0; i < 100; i++) {
-// // 		hundredFields.push({
-// // 			name: `text${i}`,
-// // 			label: `Simple Text ${i}`,
-// // 			type: "text",
-// // 			instructionText: "testing",
-// // 			validators: [required]
-// // 		})
-// // 	}
+	const hundredFields = [];
 
-// 	const fields = useMemo(
-// 		() => hundredFields as FieldDef<TextFieldDef>[],
-// 		[]
-// 	);
+	for (let i = 0; i < 100; i++) {
+		hundredFields.push({
+			name: `text${i}`,
+			label: `Simple Text ${i}`,
+			type: "text",
+			instructionText: "testing",
+			validators: [required]
+		})
+	}
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<div style={{height: "100vh"}}>
-// 				<Form
-// 					buttons={renderButtons(dispatch)}
-// 					state={state}
-// 					fields={fields}
-// 					dispatch={dispatch}
-// 					title='Performance with submit'
-// 				/>
-// 			</div>
-// 		</>
-// 	);
-// };
+	const fields = useMemo(
+		() => hundredFields as FieldDef<TextFieldDef>[],
+		[]
+	);
 
-// 	const fields = useMemo(
-// 		() => hundredFields as FieldDef<TextFieldDef>[],
-// 		[]
-// 	);
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<div style={{height: "100vh"}}>
+				<Form
+					buttons={renderButtons(dispatch)}
+					state={state}
+					fields={fields}
+					dispatch={dispatch}
+					title='Performance with submit'
+				/>
+			</div>
+		</>
+	);
+};
 
-// // 	const fields = useMemo(
-// // 		() =>
-// // 			[
-// // 				{
-// // 					name: "text1",
-// // 					label: "Simple Text",
-// // 					type: "text",
-// // 					instructionText: "testing",
-// // 					validators: [validateEmail, validateSlow]
-// // 				},
-// // 				{
-// // 					name: "text2",
-// // 					label: "Text with validators and dynamic help",
-// // 					type: "text",
-// // 					help: state.data.text2,
-// // 					validators: [validateEmail, validateSlow]
-// // 				},
-// // 				{
-// // 					name: "text3",
-// // 					label: "Text that copies to the next input",
-// // 					type: "text"
-// // 				},
-// // 				{
-// // 					name: "text4",
-// // 					label: "Text that receives copy",
-// // 					type: "text"
-// // 				}
-// // 			] as FieldDef[],
-// // 		[]
-// // 	);
+export const RuntimeBehaviors = (): ReactElement => {
+	const { state, dispatch } = useForm();
 
-// // 	useEffect(() => {
-// // 		dispatch(
-// // 			formActions.setFieldValue({
-// // 				name: "text4",
-// // 				value: state.data.text3
-// // 			})
-// // 		);
-// // 	}, [state.data.text3]);
+	const fields = useMemo(
+		() =>
+			[
+				{
+					name: "text1",
+					label: "Simple Text",
+					type: "text",
+					instructionText: "testing",
+					validators: [validateEmail, validateSlow]
+				},
+				{
+					name: "text2",
+					label: "Text with validators and dynamic help",
+					type: "text",
+					help: state.data.text2,
+					validators: [validateEmail, validateSlow]
+				},
+				{
+					name: "text3",
+					label: "Text that copies to the next input",
+					type: "text"
+				},
+				{
+					name: "text4",
+					label: "Text that receives copy",
+					type: "text"
+				}
+			] as FieldDef[],
+		[]
+	);
 
-// // 	const setText1Value = function () {
-// // 		dispatch(
-// // 			formActions.setFieldValue({
-// // 				name: "text1",
-// // 				value: "test@test.com"
-// // 			})
-// // 		);
-// // 	};
+	useEffect(() => {
+		dispatch(
+			formActions.setFieldValue({
+				name: "text4",
+				value: state.data.text3
+			})
+		);
+	}, [state.data.text3]);
 
-// // 	const setText2Value = function () {
-// // 		dispatch(
-// // 			formActions.setFieldValue({
-// // 				name: "text2",
-// // 				value: "notanemail"
-// // 			})
-// // 		);
-// // 	};
+	const setText1Value = function () {
+		dispatch(
+			formActions.setFieldValue({
+				name: "text1",
+				value: "test@test.com"
+			})
+		);
+	};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<div style={{height: "100vh"}}>
-// 				<Form
-// 					buttons={renderButtons(dispatch)}
-// 					title='Runtime behaviors'
-// 					state={state}
-// 					fields={fields}
-// 					dispatch={dispatch}
-// 					onCancel={onCancel}
-// 				/>
-// 			</div>
-// 			<div>
-// 				<p>
-// 					Here are some buttons that are not part of the form, but can change
-// 					values in the form proving communication between in/out of the form.
-// 					Notice that settext2 runs the validation after setting the value.
-// 				</p>
-// 				<button onClick={setText1Value}>Set Text1 Value</button>
-// 				<button onClick={setText2Value}>Set Text2 Value</button>
-// 			</div>
-// 		</>
-// 	);
-// };
+	const setText2Value = function () {
+		dispatch(
+			formActions.setFieldValue({
+				name: "text2",
+				value: "notanemail"
+			})
+		);
+	};
 
-// // export const SubmitExternalButtons = (): ReactElement => {
-// // 	const { state, dispatch } = useForm();
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<div style={{height: "100vh"}}>
+				<Form
+					buttons={renderButtons(dispatch)}
+					title='Runtime behaviors'
+					state={state}
+					fields={fields}
+					dispatch={dispatch}
+					onCancel={onCancel}
+				/>
+			</div>
+			<div>
+				<p>
+					Here are some buttons that are not part of the form, but can change
+					values in the form proving communication between in/out of the form.
+					Notice that settext2 runs the validation after setting the value.
+				</p>
+				<button onClick={setText1Value}>Set Text1 Value</button>
+				<button onClick={setText2Value}>Set Text2 Value</button>
+			</div>
+		</>
+	);
+};
 
-// // 	const fields = useMemo(
-// // 		() =>
-// // 			[
-// // 				{
-// // 					name: "text1",
-// // 					label: "Full Name",
-// // 					type: "text",
-// // 					instructionText: "testing",
-// // 				},
-// // 				{
-// // 					name: "text2",
-// // 					label: "Email",
-// // 					type: "text",
-// // 					validators: [required, validateEmail]
-// // 				},
-// // 				{
-// // 					name: "text3",
-// // 					label: "Age",
-// // 					type: "text",
-// // 				},
-// // 				{
-// // 					name: "text4",
-// // 					label: "City",
-// // 					type: "text"
-// // 				}
-// // 			] as FieldDef[],
-// // 		[]
-// // 	);
+export const SubmitExternalButtons = (): ReactElement => {
+	const { state, dispatch } = useForm();
 
-// // 	const clickHandler = async () => {
-// // 		const { data } = await dispatch(formActions.submitForm());
+	const fields = useMemo(
+		() =>
+			[
+				{
+					name: "text1",
+					label: "Full Name",
+					type: "text",
+					instructionText: "testing",
+				},
+				{
+					name: "text2",
+					label: "Email",
+					type: "text",
+					validators: [required, validateEmail]
+				},
+				{
+					name: "text3",
+					label: "Age",
+					type: "text",
+				},
+				{
+					name: "text4",
+					label: "City",
+					type: "text"
+				}
+			] as FieldDef[],
+		[]
+	);
 
-// // 		alert("Form submitted with the following data: " + JSON.stringify(data, null, " "));
-// // 	};
+	const clickHandler = async () => {
+		const { data } = await dispatch(formActions.submitForm());
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<p>Here is the form</p>
-// 			<div style={{height: "100vh"}}>
-// 				<Form
-// 					state={state}
-// 					fields={fields}
-// 					dispatch={dispatch}
-// 					onCancel={onCancel}
-// 				/>
-// 			</div>
-// 			<button onClick={clickHandler}>Submit</button>
-// 		</>
-// 	);
-// };
+		alert("Form submitted with the following data: " + JSON.stringify(data, null, " "));
+	};
 
-// // export const DrawerForm = (): ReactElement => {
-// // 	const { state, dispatch } = useForm();
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<p>Here is the form</p>
+			<div style={{height: "100vh"}}>
+				<Form
+					state={state}
+					fields={fields}
+					dispatch={dispatch}
+					onCancel={onCancel}
+				/>
+			</div>
+			<button onClick={clickHandler}>Submit</button>
+		</>
+	);
+};
 
-// // 	const [open, setOpen] = useState(false);
+export const DrawerForm = (): ReactElement => {
+	const { state, dispatch } = useForm();
 
-// // 	const fields = useMemo(
-// // 		() =>
-// // 			[
-// // 				{
-// // 					name: "text1",
-// // 					label: "Email",
-// // 					type: "text",
-// // 					instructionText: "testing",
-// // 					validators: [required, validateEmail],
-// // 				},
-// // 				{
-// // 					name: "text2",
-// // 					label: "Age",
-// // 					type: "text",
-// // 					validators: [required],
-// // 				},
-// // 				{
-// // 					name: "check1",
-// // 					label: "Text that copies to the next input",
-// // 					type: "checkbox",
-// // 					inputSettings: {
-// // 						options: checkboxOptions,
-// // 					},
-// // 					validators: [required]
-// // 				},
-// // 			] as unknown as FieldDef[],
-// // 		[]
-// // 	);
+	const [open, setOpen] = useState(false);
 
-// // 	const onCancel = () => {
-// // 		setOpen(false);
-// // 		alert("Cancelling form, going back to previous site");
-// // 	};
+	const fields = useMemo(
+		() =>
+			[
+				{
+					name: "text1",
+					label: "Email",
+					type: "text",
+					instructionText: "testing",
+					validators: [required, validateEmail],
+				},
+				{
+					name: "text2",
+					label: "Age",
+					type: "text",
+					validators: [required],
+				},
+				{
+					name: "check1",
+					label: "Text that copies to the next input",
+					type: "checkbox",
+					inputSettings: {
+						options: checkboxOptions,
+					},
+					validators: [required]
+				},
+			] as unknown as FieldDef[],
+		[]
+	);
 
-// // 	const onDrawerSubmit = async () => {
-// // 		const { data, valid } = await dispatch(formActions.submitForm());
-// // 		if (!valid) return;
+	const onCancel = () => {
+		setOpen(false);
+		alert("Cancelling form, going back to previous site");
+	};
 
-// // 		setOpen(false);
-// // 		alert("Form submitted with the following data: " + JSON.stringify(data, null, " "));
-// // 	};
+	const onDrawerSubmit = async () => {
+		const { data, valid } = await dispatch(formActions.submitForm());
+		if (!valid) return;
 
-// // 	const buttons: ButtonProps[] = [
-// // 		{
-// // 			label: "Save",
-// // 			onClick: onDrawerSubmit,
-// // 			color: "yellow",
-// // 			variant: "contained",
-// // 		},
-// // 	];
+		setOpen(false);
+		alert("Form submitted with the following data: " + JSON.stringify(data, null, " "));
+	};
 
-// // 	return (
-// // 		<>
-// // 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// // 			<Drawer
-// // 				open={open}
-// // 				onClose={onCancel}
-// // 			>
-// // 				<Form
-// // 					buttons={buttons}
-// // 					title='Drawer form example'
-// // 					type='drawer'
-// // 					state={state}
-// // 					dispatch={dispatch}
-// // 					fields={fields}
-// // 					onCancel={onCancel}
-// // 				/>
-// // 			</Drawer>
-// // 			<button onClick={() => setOpen(true)}>Open drawer</button>
-// // 		</>
-// // 	);
-// // };
+	const buttons: ButtonProps[] = [
+		{
+			label: "Save",
+			onClick: onDrawerSubmit,
+			color: "yellow",
+			variant: "contained",
+		},
+	];
 
-// // export const CustomFields = (): ReactElement => {
-// // 	const { state, dispatch } = useForm();
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Drawer
+				open={open}
+				onClose={onCancel}
+			>
+				<Form
+					buttons={buttons}
+					title='Drawer form example'
+					type='drawer'
+					state={state}
+					dispatch={dispatch}
+					fields={fields}
+					onCancel={onCancel}
+				/>
+			</Drawer>
+			<button onClick={() => setOpen(true)}>Open drawer</button>
+		</>
+	);
+};
 
-// // 	const CustomText = ({ onChange, value }: { onChange: (e: string) => void; value: string }) => {
-// // 		return <input type='text' value={value} onChange={(e) => onChange(e.target.value)} />
-// // 	}
+export const CustomFields = (): ReactElement => {
+	const { state, dispatch } = useForm();
 
-// // 	const CustomTextArea = ({ onChange, value }: { onChange: (e: string) => void; value: string }) => {
-// // 		return <textarea rows={4} value={value} cols={20} onChange={(e) => onChange(e.target.value)} />
-// // 	}
+	const CustomText = ({ onChange, value }: { onChange: (e: string) => void; value: string }) => {
+		return <input type='text' value={value} onChange={(e) => onChange(e.target.value)} />
+	}
 
-// // 	const CustomCheckbox = ({ onChange, value }: { onChange: (e: string) => void; value: string }) => {
-// // 		return (
-// // 			<div>
-// // 				<input
-// // 					type="checkbox"
-// // 					id="vehicle1"
-// // 					name="vehicle1"
-// // 					value="Bike"
-// // 					onChange={(e) => onChange(value ? undefined : e.target.value)}
-// // 					checked={value === "Bike"}
-// // 				/>
-// // 				<label htmlFor="vehicle1"> I have a bike</label><br />
-// // 			</div>
-// // 		)
-// // 	}
+	const CustomTextArea = ({ onChange, value }: { onChange: (e: string) => void; value: string }) => {
+		return <textarea rows={4} value={value} cols={20} onChange={(e) => onChange(e.target.value)} />
+	}
 
-// // 	const fields = useMemo(
-// // 		() =>
-// // 			[
-// // 				{
-// // 					name: "text1",
-// // 					label: "Custom Text",
-// // 					type: CustomText,
-// // 					instructionText: "testing",
-// // 					helperText: "helper text bottom",
-// // 					validators: [required]
-// // 				},
-// // 				{
-// // 					name: "textarea",
-// // 					label: "Custom textArea",
-// // 					type: CustomTextArea,
-// // 					instructionText: "testing",
-// // 					helperText: "helper text bottom",
-// // 					validators: [required]
-// // 				},
-// // 				{
-// // 					name: "checkbox",
-// // 					label: "Custom checkbox",
-// // 					type: CustomCheckbox,
-// // 					instructionText: "testing",
-// // 					helperText: "helper text bottom",
-// // 					validators: [required]
-// // 				},
-// // 			] as FieldDef[],
-// // 		[]
-// // 	);
+	const CustomCheckbox = ({ onChange, value }: { onChange: (e: string) => void; value: string }) => {
+		return (
+			<div>
+				<input
+					type="checkbox"
+					id="vehicle1"
+					name="vehicle1"
+					value="Bike"
+					onChange={(e) => onChange(value ? undefined : e.target.value)}
+					checked={value === "Bike"}
+				/>
+				<label htmlFor="vehicle1"> I have a bike</label><br />
+			</div>
+		)
+	}
 
-// // 	const setText1Value = function () {
-// // 		dispatch(
-// // 			formActions.setFieldValue({
-// // 				name: "text1",
-// // 				value: "My New Value"
-// // 			})
-// // 		);
-// // 	};
+	const fields = useMemo(
+		() =>
+			[
+				{
+					name: "text1",
+					label: "Custom Text",
+					type: CustomText,
+					instructionText: "testing",
+					helperText: "helper text bottom",
+					validators: [required]
+				},
+				{
+					name: "textarea",
+					label: "Custom textArea",
+					type: CustomTextArea,
+					instructionText: "testing",
+					helperText: "helper text bottom",
+					validators: [required]
+				},
+				{
+					name: "checkbox",
+					label: "Custom checkbox",
+					type: CustomCheckbox,
+					instructionText: "testing",
+					helperText: "helper text bottom",
+					validators: [required]
+				},
+			] as FieldDef[],
+		[]
+	);
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<div style={{height: "100vh"}}>
-// 				<Form
-// 					buttons={renderButtons(dispatch)}
-// 					title='Custom components'
-// 					state={state}
-// 					fields={fields}
-// 					dispatch={dispatch}
-// 				/>
-// 			</div>
-// 			<div>
-// 				<button onClick={setText1Value}>Set Text1 Value</button>
-// 			</div>
-// 		</>
-// 	);
-// };
+	const setText1Value = function () {
+		dispatch(
+			formActions.setFieldValue({
+				name: "text1",
+				value: "My New Value"
+			})
+		);
+	};
 
-// // export const Validators = (): ReactElement => {
-// // 	const { state, dispatch } = useForm();
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<div style={{height: "100vh"}}>
+				<Form
+					buttons={renderButtons(dispatch)}
+					title='Custom components'
+					state={state}
+					fields={fields}
+					dispatch={dispatch}
+				/>
+			</div>
+			<div>
+				<button onClick={setText1Value}>Set Text1 Value</button>
+			</div>
+		</>
+	);
+};
 
-// // 	const fields = useMemo(
-// // 		() =>
-// // 			[
-// // 				{
-// // 					name: "required",
-// // 					label: "Required",
-// // 					type: "text",
-// // 					required: true,
-// // 				},
-// // 				{
-// // 					name: "email",
-// // 					label: "Email",
-// // 					type: "text",
-// // 					validators: [validateEmail]
-// // 				},
-// // 				{
-// // 					name: "slow",
-// // 					label: "Slow",
-// // 					type: "text",
-// // 					validators: [validateSlow]
-// // 				},
-// // 				{
-// // 					name: "number",
-// // 					label: "Number",
-// // 					type: "text",
-// // 					validators: [validateNumber]
-// // 				},
-// // 				{
-// // 					name: "url",
-// // 					label: "URL",
-// // 					type: "text",
-// // 					validators: [validateURL]
-// // 				},
-// // 				{
-// // 					name: "startDate",
-// // 					type: "date",
-// // 					label: "Start date",
-// // 					required: false,
-// // 					disabled: false,
-// // 					helperText: "Helper text",
-// // 					instructionText: "Instruction text",
-// // 					validators: [{ fn: "validateDateRange", options: { endDateName: "endDate" } }],
-// // 					pairedFields: ["endDate"],
-// // 					inputSettings: {
-// // 						showTime: false,
-// // 					},
-// // 				},
-// // 				{
-// // 					name: "endDate",
-// // 					type: "date",
-// // 					label: "End date",
-// // 					required: false,
-// // 					disabled: false,
-// // 					helperText: "Helper text",
-// // 					instructionText: "Instruction text",
-// // 					validators: [{ fn: "validateDateRange", options: { startDateName: "startDate" } }],
-// // 					pairedFields: ["startDate"],
-// // 					inputSettings: {
-// // 						showTime: false,
-// // 					},
-// // 				},
-// // 			] as FieldDef[],
-// // 		[]
-// // 	);
+export const Validators = (): ReactElement => {
+	const { state, dispatch } = useForm();
 
-// // 	return (
-// // 		<>
-// // 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// // 			<div style={{height: "100vh"}}>
-// // 				<Form
-// // 					buttons={renderButtons(dispatch)}
-// // 					title='Validators story'
-// // 					state={state}
-// // 					fields={fields}
-// // 					dispatch={dispatch}
-// // 				/>
-// // 			</div>
-// // 		</>
-// // 	);
-// // };
+	const fields = useMemo(
+		() =>
+			[
+				{
+					name: "required",
+					label: "Required",
+					type: "text",
+					required: true,
+				},
+				{
+					name: "email",
+					label: "Email",
+					type: "text",
+					validators: [validateEmail]
+				},
+				{
+					name: "slow",
+					label: "Slow",
+					type: "text",
+					validators: [validateSlow]
+				},
+				{
+					name: "number",
+					label: "Number",
+					type: "text",
+					validators: [validateNumber]
+				},
+				{
+					name: "url",
+					label: "URL",
+					type: "text",
+					validators: [validateURL]
+				},
+				{
+					name: "startDate",
+					type: "date",
+					label: "Start date",
+					required: false,
+					disabled: false,
+					helperText: "Helper text",
+					instructionText: "Instruction text",
+					validators: [{ fn: "validateDateRange", options: { endDateName: "endDate" } }],
+					pairedFields: ["endDate"],
+					inputSettings: {
+						showTime: false,
+					},
+				},
+				{
+					name: "endDate",
+					type: "date",
+					label: "End date",
+					required: false,
+					disabled: false,
+					helperText: "Helper text",
+					instructionText: "Instruction text",
+					validators: [{ fn: "validateDateRange", options: { startDateName: "startDate" } }],
+					pairedFields: ["startDate"],
+					inputSettings: {
+						showTime: false,
+					},
+				},
+			] as FieldDef[],
+		[]
+	);
 
-// // export const DefaultValues = (): ReactElement => {
-// // 	const { state, dispatch } = useForm();
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<div style={{height: "100vh"}}>
+				<Form
+					buttons={renderButtons(dispatch)}
+					title='Validators story'
+					state={state}
+					fields={fields}
+					dispatch={dispatch}
+				/>
+			</div>
+		</>
+	);
+};
 
-// // 	const fields = useMemo(
-// // 		() =>
-// // 			[
-// // 				{
-// // 					name: "required",
-// // 					label: "Required",
-// // 					type: "text",
-// // 					required: true,
-// // 					defaultValue: "Passing default value",
-// // 				},
-// // 			] as FieldDef<TextFieldDef>[],
-// // 		[]
-// // 	);
+export const DefaultValues = (): ReactElement => {
+	const { state, dispatch } = useForm();
 
-// // 	return (
-// // 		<>
-// // 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// // 			<div style={{height: "100vh"}}>
-// // 				<Form
-// // 					buttons={renderButtons(dispatch)}
-// // 					title='Validators story'
-// // 					state={state}
-// // 					fields={fields}
-// // 					dispatch={dispatch}
-// // 					onCancel={onCancel}
-// // 				/>
-// // 			</div>
-// // 		</>
-// // 	);
-// // };
+	const fields = useMemo(
+		() =>
+			[
+				{
+					name: "required",
+					label: "Required",
+					type: "text",
+					required: true,
+					defaultValue: "Passing default value",
+				},
+			] as FieldDef<TextFieldDef>[],
+		[]
+	);
 
-// // export const DMSExample = (): ReactElement => {
-// // 	const items = [{
-// // 		name : "form_with_layout",
-// // 		label : "Form With Layout",
-// // 		mIcon : HomeIcon
-// // 	}];
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<div style={{height: "100vh"}}>
+				<Form
+					buttons={renderButtons(dispatch)}
+					title='Validators story'
+					state={state}
+					fields={fields}
+					dispatch={dispatch}
+					onCancel={onCancel}
+				/>
+			</div>
+		</>
+	);
+};
 
-// // 	return (
-// // 		<NavWrapper items={items}>
-// // 			<FormWithLayout/>
-// // 		</NavWrapper>
-// // 	)
-// // }
+export const DMSExample = (): ReactElement => {
+	const items = [{
+		name : "form_with_layout",
+		label : "Form With Layout",
+		mIcon : HomeIcon
+	}];
+
+	return (
+		<NavWrapper items={items}>
+			<FormWithLayoutTemplate />
+		</NavWrapper>
+	)
+}

--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useEffect, useMemo, useState, useCallback, ReactElement } from "react";
+import { ComponentMeta } from "@storybook/react";
 
 // Utils
 import { checkboxOptions } from "@root/forms/FormFieldCheckbox/FormFieldCheckboxUtils";
@@ -46,7 +47,7 @@ import { NavWrapper } from "@root/components/LeftNav/NavWrapper";
 export default {
 	title: "Components/Form",
 	component: Form,
-};
+} as ComponentMeta<typeof Form>;
 
 const deleteTableRow = () => {
 	alert("Delete button clicked");

--- a/src/components/Form/FormTypes.tsx
+++ b/src/components/Form/FormTypes.tsx
@@ -12,16 +12,58 @@ export interface SectionDef extends Section {
 }
 
 export interface FormProps {
+	/**
+	 * Used when creating a Form inside a drawer.
+	 */
 	type?: "drawer";
+	/**
+	 * Global state of each field included in the Form.
+	 */
 	state: any;
+	/**
+	 * Title of the Form.
+	 */
 	title?: string;
+	/**
+	 * List of fields definition.
+	 */
 	fields: FieldDef[];
+	/**
+	 * Contains a list with the configuration for every section
+	 * of the form, including the layout in which fields will be rendered.
+	 */
 	sections?: SectionDef[];
+	/**
+	 * Function in charge of updating the state of the Form.
+	 */
 	dispatch: any;
+	/**
+	 * Function with any args that will be executed when the user clicks
+	 * on the cancel button of the form.
+	 * @param args
+	 */
 	onCancel?(...args: any): any;
+	/**
+	 * this flag will render a dialog with the message "You have unsaved changes.
+	 * If you leave all your changes will be lost." This only works with the prop type = "drawer".
+	 */
 	dialogOpen?: boolean;
+	/**
+	 * Description text that will be rendered under the title.
+	 */
 	description?: string;
+	/**
+	 * Function that will run once the form renders to prepopulate the fields.
+	 * This should return an object where the key is the name of the field, and
+	 * the value is the value to prepopulate the field.
+	 */
 	getFormValues?(): Promise<MosaicObject>;
+	/**
+	 * Function that will get called when closing the dialog
+	 */
 	handleDialogClose?: (val: boolean) => void;
+	/**
+	 * Array of buttons that will be rendered on the TopComponent.
+	 */
 	buttons?: ButtonProps[];
 }

--- a/src/components/LeftNav/LeftNav.stories.tsx
+++ b/src/components/LeftNav/LeftNav.stories.tsx
@@ -1,799 +1,816 @@
-// import * as React from "react";
-// import { useEffect, ReactElement } from "react";
-// import { select, withKnobs } from "@storybook/addon-knobs";
+import * as React from "react";
+import { useEffect } from "react";
+//
+import { ComponentMeta } from "@storybook/react";
 
-// import HomeIcon from "@mui/icons-material/Home";
-// import AccountTreeIcon from "@mui/icons-material/AccountTree";
-// import ImageIcon from "@mui/icons-material/Image";
-// import ExtensionIcon from "@mui/icons-material/Extension";
-// import BuildIcon from "@mui/icons-material/Build";
-// import DashboardIcon from "@mui/icons-material/Dashboard";
-// import HelpIcon from "@mui/icons-material/Help";
-// import LinkIcon from "@mui/icons-material/Link";
+import HomeIcon from "@mui/icons-material/Home";
+import AccountTreeIcon from "@mui/icons-material/AccountTree";
+import ImageIcon from "@mui/icons-material/Image";
+import ExtensionIcon from "@mui/icons-material/Extension";
+import BuildIcon from "@mui/icons-material/Build";
+import DashboardIcon from "@mui/icons-material/Dashboard";
+import HelpIcon from "@mui/icons-material/Help";
+import LinkIcon from "@mui/icons-material/Link";
 
-// import {
-// 	LeftNavItemRootDef,
-// 	MosaicContext,
-// 	useMosaicSettings,
-// } from "../../";
-// import { NavWrapper } from "./NavWrapper";
+import {
+	LeftNavItemRootDef,
+	MosaicContext,
+	useMosaicSettings,
+} from "../../";
+import { NavWrapper } from "./NavWrapper";
 
-// import "../../utils/storyBookCssReset.css";
+import "../../utils/storyBookCssReset.css";
 
-// export default {
-// 	title : "Components/LeftNav",
-// 	decorators : [withKnobs]
-// }
+export default {
+	title : "Components/LeftNav",
+	component: NavWrapper,
+	argTypes: {
+		items: {
+			options: ["qa", "cms_flat"],
+			control: "select",
+		},
+		locale: {
+			options: ["en", "es", "cimode", "de"],
+			control: "select",
+		},
+	},
+} as ComponentMeta<typeof NavWrapper>
 
-// const siteMapItems = (site) => [
-// 	{
-// 		name : `sitemap.${site}.main`,
-// 		label : "Main Navigation"
-// 	},
-// 	{
-// 		name : `sitemap.${site}.secondary`,
-// 		label : "Secondary Navigation"
-// 	},
-// 	{
-// 		name : `sitemap.${site}.footer`,
-// 		label : "Footer Navigation"
-// 	},
-// 	{
-// 		name : `sitemap.${site}.landing`,
-// 		label : "Landing Pages"
-// 	},
-// 	{
-// 		name : `sitemap.${site}.system`,
-// 		label : "System"
-// 	},
-// 	{
-// 		name : `sitemap.${site}.microsites`,
-// 		label : "Microsites"
-// 	}
-// ];
+const siteMapItems = (site) => [
+	{
+		name : `sitemap.${site}.main`,
+		label : "Main Navigation"
+	},
+	{
+		name : `sitemap.${site}.secondary`,
+		label : "Secondary Navigation"
+	},
+	{
+		name : `sitemap.${site}.footer`,
+		label : "Footer Navigation"
+	},
+	{
+		name : `sitemap.${site}.landing`,
+		label : "Landing Pages"
+	},
+	{
+		name : `sitemap.${site}.system`,
+		label : "System"
+	},
+	{
+		name : `sitemap.${site}.microsites`,
+		label : "Microsites"
+	}
+];
 
-// const blogItems = (blog) => [
-// 	{
-// 		name : `modules.blog.${blog}.authors`,
-// 		label : "Authors"
-// 	},
-// 	{
-// 		name : `modules.blog.${blog}.categories`,
-// 		label : "Categories"
-// 	},
-// 	{
-// 		name : `modules.blog.${blog}.posts`,
-// 		label : "Posts"
-// 	},
-// 	{
-// 		name : `modules.blog.${blog}.tags`,
-// 		label : "Tags"
-// 	}
-// ]
+const blogItems = (blog) => [
+	{
+		name : `modules.blog.${blog}.authors`,
+		label : "Authors"
+	},
+	{
+		name : `modules.blog.${blog}.categories`,
+		label : "Categories"
+	},
+	{
+		name : `modules.blog.${blog}.posts`,
+		label : "Posts"
+	},
+	{
+		name : `modules.blog.${blog}.tags`,
+		label : "Tags"
+	}
+]
 
-// const navSections = {
-// 	dynamic : {
-// 		name : "modules.dynamic",
-// 		label : "Dynamic Content",
-// 		items : [
-// 			{
-// 				name : "modules.dynamic.personas",
-// 				label : "Personas"
-// 			},
-// 			{
-// 				name : "modules.dynamic.profiles",
-// 				label : "Profiles"
-// 			}
-// 		]
-// 	},
-// 	assetRequest : {
-// 		name : "modules.asset_request",
-// 		label : "Asset Request",
-// 		items : [
-// 			{
-// 				name : "modules.asset_request.items",
-// 				label : "Items"
-// 			},
-// 			{
-// 				name : "modules.asset_request.categories",
-// 				label : "Categories"
-// 			},
-// 			{
-// 				name : "modules.asset_request.tags",
-// 				label : "Tags"
-// 			},
-// 			{
-// 				name : "modules.asset_request.licenses",
-// 				label : "Licenses"
-// 			},
-// 			{
-// 				name : "modules.asset_request.requests",
-// 				label : "Requests"
-// 			}
-// 		]
-// 	},
-// 	collections : {
-// 		name : "modules.collections",
-// 		label : "Collection Types",
-// 		items : [
-// 			{
-// 				name : "modules.collections.blog",
-// 				label : "Blog Categories"
-// 			},
-// 			{
-// 				name : "modules.collections.experience",
-// 				label : "Experience"
-// 			},
-// 			{
-// 				name : "modules.collections.header",
-// 				label : "Header Slides"
-// 			},
-// 			{
-// 				name : "modules.collections.header_video",
-// 				label : "Header Video Slides"
-// 			}
-// 		]
-// 	},
-// 	mapPublisher : {
-// 		name : "modules.map_publisher",
-// 		label : "Map Publisher"
-// 	},
-// 	mediaGallery : {
-// 		name : "modules.media_gallery",
-// 		label : "Media Gallery",
-// 		items : [
-// 			{
-// 				name : "modules.media_gallery.galleries",
-// 				label : "Galleries"
-// 			},
-// 			{
-// 				name : "modules.media_gallery.albums",
-// 				label : "Albums"
-// 			},
-// 			{
-// 				name : "modules.media_gallery.album_items",
-// 				label : "Album Items"
-// 			},
-// 			{
-// 				name : "modules.media_gallery.tags",
-// 				label : "Tags"
-// 			}
-// 		]
-// 	},
-// 	assets : {
-// 		name : "assets",
-// 		label : "Assets",
-// 		items : [
-// 			{
-// 				name : "assets.documents",
-// 				label : "Documents"
-// 			},
-// 			{
-// 				name : "assets.external",
-// 				label : "External Links"
-// 			},
-// 			{
-// 				name : "assets.images",
-// 				label : "Images"
-// 			},
-// 			{
-// 				name : "assets.videos",
-// 				label : "Videos"
-// 			}
-// 		]
-// 	},
-// 	sitemap : {
-// 		name : "sitemap",
-// 		label : "Sitemap",
-// 		mIcon : AccountTreeIcon,
-// 		items : [
-// 			{
-// 				name : "sitemap.primary",
-// 				label : "Primary",
-// 				items : siteMapItems("primary")
-// 			},
-// 			{
-// 				name : "sitemap.dutch",
-// 				label : "Dutch",
-// 				items : siteMapItems("dutch")
-// 			},
-// 			{
-// 				name : "sitemap.french",
-// 				label : "French",
-// 				items : siteMapItems("french")
-// 			},
-// 			{
-// 				name : "sitemap.spanish",
-// 				label : "Spanish",
-// 				items : siteMapItems("spanish")
-// 			}
-// 		]
-// 	},
-// 	settings : {
-// 		name : "settings",
-// 		label : "Settings",
-// 		mIcon : BuildIcon,
-// 		items : [
-// 			{
-// 				name : "settings.assets",
-// 				label : "Assets",
-// 				items : [
-// 					{
-// 						name : "settings.assets.document_categories",
-// 						label : "Document Categories"
-// 					},
-// 					{
-// 						name : "settings.assets.image_categories",
-// 						label : "Image Categories"
-// 					},
-// 					{
-// 						name : "settings.assets.video_categories",
-// 						label : "Video Categories"
-// 					}
-// 				]
-// 			},
-// 			{
-// 				name : "settings.cms_tags",
-// 				label : "CMS Tags"
-// 			},
-// 			{
-// 				name : "settings.field_builder",
-// 				label : "Field Builder",
-// 				items : [
-// 					{
-// 						name : "settings.field_builder.assets_documents",
-// 						label : "Asset Library - Documents"
-// 					},
-// 					{
-// 						name : "settings.field_builder.assets_external",
-// 						label : "Asset Library - External Links"
-// 					},
-// 					{
-// 						name : "settings.field_builder.assets_images",
-// 						label : "Asset Library - Images"
-// 					},
-// 					{
-// 						name : "settings.field_builder.assets_videos",
-// 						label : "Asset Library - Videos"
-// 					},
-// 					{
-// 						name : "settings.field_builder.core_textbox",
-// 						label : "Core - Textbox"
-// 					}
-// 				]
-// 			},
-// 			{
-// 				name : "settings.nav",
-// 				label : "Nav",
-// 				items : [
-// 					{
-// 						name : "settings.nav.locale_tags",
-// 						label : "Locale Tags"
-// 					},
-// 					{
-// 						name : "settings.nav.nav_tags",
-// 						label : "Nav Tags"
-// 					}
-// 				]
-// 			},
-// 			{
-// 				name : "settings.tasks",
-// 				label : "Tasks",
-// 				items : [
-// 					{
-// 						name : "settings.tasks.categories",
-// 						label : "Categories"
-// 					}
-// 				]
-// 			},
-// 			{
-// 				name : "settings.users",
-// 				label : "Users",
-// 				items : [
-// 					{
-// 						name : "settings.users.manage",
-// 						label : "Manage Users"
-// 					},
-// 					{
-// 						name : "settings.users.roles",
-// 						label : "Manage Roles"
-// 					},
-// 					{
-// 						name : "settings.users.history",
-// 						label : "User History"
-// 					}
-// 				]
-// 			},
-// 			{
-// 				name : "settings.visitors",
-// 				label : "Visitors",
-// 				items : [
-// 					{
-// 						name : "settings.visitors.test_subscription",
-// 						label : "Test Subscriptions"
-// 					}
-// 				]
-// 			}
-// 		]
-// 	},
-// 	autoResponder : {
-// 		name : "modules.auto_responder",
-// 		label : "Auto Responder",
-// 		items : [
-// 			{
-// 				name : "modules.auto_responder.content",
-// 				label : "Content"
-// 			},
-// 			{
-// 				name : "modules.auto_responder.links",
-// 				label : "Links"
-// 			}
-// 		]
-// 	},
-// 	translation : {
-// 		name : "modules.translation",
-// 		label : "Translation",
-// 		items : [
-// 			{
-// 				name : "modules.translation.static",
-// 				label : "Static Namespaces"
-// 			}
-// 		]
-// 	},
-// 	blog : {
-// 		name : "modules.blog",
-// 		label : "Public Relations",
-// 		items : [
-// 			{
-// 				name : "modules.blog.articles",
-// 				label : "Articles",
-// 				items : blogItems("articles")
-// 			},
-// 			{
-// 				name : "modules.blog.blog",
-// 				label : "Blog",
-// 				items : blogItems("blog")
-// 			},
-// 			{
-// 				name : "modules.blog.meetings",
-// 				label : "Meetings Blog",
-// 				items : blogItems("meetings")
-// 			}
-// 		]
-// 	}
-// }
+const navSections = {
+	dynamic : {
+		name : "modules.dynamic",
+		label : "Dynamic Content",
+		items : [
+			{
+				name : "modules.dynamic.personas",
+				label : "Personas"
+			},
+			{
+				name : "modules.dynamic.profiles",
+				label : "Profiles"
+			}
+		]
+	},
+	assetRequest : {
+		name : "modules.asset_request",
+		label : "Asset Request",
+		items : [
+			{
+				name : "modules.asset_request.items",
+				label : "Items"
+			},
+			{
+				name : "modules.asset_request.categories",
+				label : "Categories"
+			},
+			{
+				name : "modules.asset_request.tags",
+				label : "Tags"
+			},
+			{
+				name : "modules.asset_request.licenses",
+				label : "Licenses"
+			},
+			{
+				name : "modules.asset_request.requests",
+				label : "Requests"
+			}
+		]
+	},
+	collections : {
+		name : "modules.collections",
+		label : "Collection Types",
+		items : [
+			{
+				name : "modules.collections.blog",
+				label : "Blog Categories"
+			},
+			{
+				name : "modules.collections.experience",
+				label : "Experience"
+			},
+			{
+				name : "modules.collections.header",
+				label : "Header Slides"
+			},
+			{
+				name : "modules.collections.header_video",
+				label : "Header Video Slides"
+			}
+		]
+	},
+	mapPublisher : {
+		name : "modules.map_publisher",
+		label : "Map Publisher"
+	},
+	mediaGallery : {
+		name : "modules.media_gallery",
+		label : "Media Gallery",
+		items : [
+			{
+				name : "modules.media_gallery.galleries",
+				label : "Galleries"
+			},
+			{
+				name : "modules.media_gallery.albums",
+				label : "Albums"
+			},
+			{
+				name : "modules.media_gallery.album_items",
+				label : "Album Items"
+			},
+			{
+				name : "modules.media_gallery.tags",
+				label : "Tags"
+			}
+		]
+	},
+	assets : {
+		name : "assets",
+		label : "Assets",
+		items : [
+			{
+				name : "assets.documents",
+				label : "Documents"
+			},
+			{
+				name : "assets.external",
+				label : "External Links"
+			},
+			{
+				name : "assets.images",
+				label : "Images"
+			},
+			{
+				name : "assets.videos",
+				label : "Videos"
+			}
+		]
+	},
+	sitemap : {
+		name : "sitemap",
+		label : "Sitemap",
+		mIcon : AccountTreeIcon,
+		items : [
+			{
+				name : "sitemap.primary",
+				label : "Primary",
+				items : siteMapItems("primary")
+			},
+			{
+				name : "sitemap.dutch",
+				label : "Dutch",
+				items : siteMapItems("dutch")
+			},
+			{
+				name : "sitemap.french",
+				label : "French",
+				items : siteMapItems("french")
+			},
+			{
+				name : "sitemap.spanish",
+				label : "Spanish",
+				items : siteMapItems("spanish")
+			}
+		]
+	},
+	settings : {
+		name : "settings",
+		label : "Settings",
+		mIcon : BuildIcon,
+		items : [
+			{
+				name : "settings.assets",
+				label : "Assets",
+				items : [
+					{
+						name : "settings.assets.document_categories",
+						label : "Document Categories"
+					},
+					{
+						name : "settings.assets.image_categories",
+						label : "Image Categories"
+					},
+					{
+						name : "settings.assets.video_categories",
+						label : "Video Categories"
+					}
+				]
+			},
+			{
+				name : "settings.cms_tags",
+				label : "CMS Tags"
+			},
+			{
+				name : "settings.field_builder",
+				label : "Field Builder",
+				items : [
+					{
+						name : "settings.field_builder.assets_documents",
+						label : "Asset Library - Documents"
+					},
+					{
+						name : "settings.field_builder.assets_external",
+						label : "Asset Library - External Links"
+					},
+					{
+						name : "settings.field_builder.assets_images",
+						label : "Asset Library - Images"
+					},
+					{
+						name : "settings.field_builder.assets_videos",
+						label : "Asset Library - Videos"
+					},
+					{
+						name : "settings.field_builder.core_textbox",
+						label : "Core - Textbox"
+					}
+				]
+			},
+			{
+				name : "settings.nav",
+				label : "Nav",
+				items : [
+					{
+						name : "settings.nav.locale_tags",
+						label : "Locale Tags"
+					},
+					{
+						name : "settings.nav.nav_tags",
+						label : "Nav Tags"
+					}
+				]
+			},
+			{
+				name : "settings.tasks",
+				label : "Tasks",
+				items : [
+					{
+						name : "settings.tasks.categories",
+						label : "Categories"
+					}
+				]
+			},
+			{
+				name : "settings.users",
+				label : "Users",
+				items : [
+					{
+						name : "settings.users.manage",
+						label : "Manage Users"
+					},
+					{
+						name : "settings.users.roles",
+						label : "Manage Roles"
+					},
+					{
+						name : "settings.users.history",
+						label : "User History"
+					}
+				]
+			},
+			{
+				name : "settings.visitors",
+				label : "Visitors",
+				items : [
+					{
+						name : "settings.visitors.test_subscription",
+						label : "Test Subscriptions"
+					}
+				]
+			}
+		]
+	},
+	autoResponder : {
+		name : "modules.auto_responder",
+		label : "Auto Responder",
+		items : [
+			{
+				name : "modules.auto_responder.content",
+				label : "Content"
+			},
+			{
+				name : "modules.auto_responder.links",
+				label : "Links"
+			}
+		]
+	},
+	translation : {
+		name : "modules.translation",
+		label : "Translation",
+		items : [
+			{
+				name : "modules.translation.static",
+				label : "Static Namespaces"
+			}
+		]
+	},
+	blog : {
+		name : "modules.blog",
+		label : "Public Relations",
+		items : [
+			{
+				name : "modules.blog.articles",
+				label : "Articles",
+				items : blogItems("articles")
+			},
+			{
+				name : "modules.blog.blog",
+				label : "Blog",
+				items : blogItems("blog")
+			},
+			{
+				name : "modules.blog.meetings",
+				label : "Meetings Blog",
+				items : blogItems("meetings")
+			}
+		]
+	}
+}
 
-// const dataSets: { [key: string]: LeftNavItemRootDef[] } = {
-// 	qa : [
-// 		{
-// 			name : "short_icon",
-// 			label : "Short Icon",
-// 			mIcon : HomeIcon
-// 		},
-// 		{
-// 			name : "short_icon_children",
-// 			label : "Short Icon Children",
-// 			mIcon : ExtensionIcon,
-// 			items : [
-// 				{
-// 					name : "short_icon_children.short",
-// 					label : "Short"
-// 				},
-// 				{
-// 					name : "short_icon_children.short_icon",
-// 					label : "Short Icon",
-// 					mIcon : HomeIcon
-// 				},
-// 				{
-// 					name : "short_icon_children.short_children",
-// 					label : "Short Children",
-// 					items : [
-// 						{
-// 							name :"short_icon_children.short_children.item",
-// 							label : "Item"
-// 						},
-// 						{
-// 							name : "short_icon_children.short_children.children",
-// 							label : "With Children",
-// 							items : [
-// 								{
-// 									name :"short_icon_children.short_children.children.item",
-// 									label : "Item"
-// 								},
-// 								{
-// 									name : "short_icon_children.short_children.children.children",
-// 									label : "With Children",
-// 									items : [
-// 										{
-// 											name :"short_icon_children.short_children.children.children.item",
-// 											label : "Item"
-// 										},
-// 										{
-// 											name : "short_icon_children.short_children.children.children.children",
-// 											label : "With Children",
-// 											items : [
-// 												{
-// 													name :"short_icon_children.short_children.children.children.children.item",
-// 													label : "Item"
-// 												},
-// 												{
-// 													name : "short_icon_children.short_children.children.children.children.children",
-// 													label : "With Children",
-// 													items : [
-// 														{
-// 															name :"short_icon_children.short_children.children.children.children.children.item",
-// 															label : "Item"
-// 														},
-// 														{
-// 															name : "short_icon_children.short_children.children.children.children.children.children",
-// 															label : "With Children",
-// 															items : [
-// 																{
-// 																	name :"short_icon_children.short_children.children.children.children.children.children.item",
-// 																	label : "Item"
-// 																},
-// 																{
-// 																	name : "short_icon_children.short_children.children.children.children.children.children.children",
-// 																	label : "With Children",
-// 																	items : [
-// 																		{
-// 																			name :"short_icon_children.short_children.children.children.children.children.children.children.item",
-// 																			label : "Item"
-// 																		},
-// 																		{
-// 																			name : "short_icon_children.short_children.children.children.children.children.children.children.children",
-// 																			label : "With Children",
-// 																			items : [
-// 																				{
-// 																					name :"short_icon_children.short_children.children.children.children.children.children.children.children.item",
-// 																					label : "Item"
-// 																				},
-// 																				{
-// 																					name : "short_icon_children.short_children.children.children.children.children.children.children.children.children",
-// 																					label : "With Children",
-// 																					items : [
-// 																						{
-// 																							name :"short_icon_children.short_children.children.children.children.children.children.children.children.children.item",
-// 																							label : "Item"
-// 																						},
-// 																						{
-// 																							name : "short_icon_children.short_children.children.children.children.children.children.children.children.children.children",
-// 																							label : "With Children",
-// 																							items : [
-// 																								{
-// 																									name :"short_icon_children.short_children.children.children.children.children.children.children.children.children.children.item",
-// 																									label : "Item"
-// 																								}
-// 																							]
-// 																						}
-// 																					]
-// 																				}
-// 																			]
-// 																		}
-// 																	]
-// 																}
-// 															]
-// 														}
-// 													]
-// 												}
-// 											]
-// 										}
-// 									]
-// 								}
-// 							]
-// 						}
-// 					]
-// 				},
-// 				{
-// 					name : "short_icon_children.short_icon_children",
-// 					label : "Short Icon Children",
-// 					mIcon : HomeIcon,
-// 					items : [
-// 						{
-// 							name : "short_icon_children.short_icon_children.item",
-// 							label : "Item"
-// 						}
-// 					]
-// 				},
-// 				{
-// 					name : "short_icon_children.long",
-// 					label : "Long - lorem ipsum dolor sit amet"
-// 				},
-// 				{
-// 					name : "short_icon_children.long_icon",
-// 					label : "Long Icon - lorem ipsum dolor sit amet",
-// 					mIcon : HomeIcon
-// 				},
-// 				{
-// 					name : "short_icon_children.long_children",
-// 					label : "Long Children - lorem ipsum dolor sit amet",
-// 					items : [
-// 						{
-// 							name : "short_icon_children.long_children.item",
-// 							label : "Item"
-// 						}
-// 					]
-// 				},
-// 				{
-// 					name : "short_icon_children.long_icon_children",
-// 					label : "Long Icon Children - lorem ipsum dolor sit amet",
-// 					mIcon : HomeIcon,
-// 					items : [
-// 						{
-// 							name : "short_icon_children.long_icon_children.item",
-// 							label : "Item"
-// 						}
-// 					]
-// 				},
-// 				// automate 20 entries to create a vertical scroller in the flyout
-// 				...(
-// 					new Array(35).fill(0).map((val, i) => {
-// 						return {
-// 							name : `short_icon_children.filler_item_${i}`,
-// 							label : `Filler ${i}`
-// 						}
-// 					})
-// 				),
-// 				{
-// 					name : "short_icon_children.after_filler",
-// 					label : "After Filler with Children",
-// 					items : [
-// 						{
-// 							name : "short_icon_children.after_filler.item",
-// 							label : "Item"
-// 						}
-// 					]
-// 				}
-// 			]
-// 		},
-// 		{
-// 			name : "long_icon",
-// 			label : "Long Icon - lorem ipsum dolor sit amet",
-// 			mIcon : DashboardIcon
-// 		},
-// 		{
-// 			name : "long_icon_children",
-// 			label : "Long Icon Children - lorem ipsum dolor sit amet",
-// 			mIcon : AccountTreeIcon,
-// 			items : [
-// 				{
-// 					name : "long_icon_children.item",
-// 					label : "Item"
-// 				}
-// 			]
-// 		},
-// 		{
-// 			name : "group_short_icon",
-// 			label : "Group Short",
-// 			type : "group",
-// 			mIcon : ImageIcon,
-// 			items : [
-// 				{
-// 					name : "group_short_icon.short",
-// 					label : "Short"
-// 				},
-// 				{
-// 					name : "group_short_icon.short_icon",
-// 					label : "Short Icon",
-// 					mIcon : HomeIcon
-// 				},
-// 				{
-// 					name : "group_short_icon.short_children",
-// 					label : "Short Children",
-// 					items : [
-// 						{
-// 							name : "group_short_icon.short_children.short_children.item",
-// 							label : "Item"
-// 						},
-// 						{
-// 							name : "group_short_icon.short_children.short_children.children",
-// 							label : "With Children",
-// 							items : [
-// 								{
-// 									name :"group_short_icon.short_children.short_children.children.item",
-// 									label : "Item"
-// 								},
-// 								{
-// 									name : "group_short_icon.short_children.short_children.children.children",
-// 									label : "With Children",
-// 									items : [
-// 										{
-// 											name : "group_short_icon.short_children.short_children.children.children.item",
-// 											label : "Item"
-// 										}
-// 									]
-// 								}
-// 							]
-// 						}
-// 					]
-// 				},
-// 				{
-// 					name : "group_short_icon.short_icon_children",
-// 					label : "Short Icon Children",
-// 					mIcon : HomeIcon,
-// 					items : [
-// 						{
-// 							name : "group_short_icon.short_icon_children.item",
-// 							label : "Item"
-// 						}
-// 					]
-// 				},
-// 				{
-// 					name : "group_short_icon.long",
-// 					label : "Long - lorem ipsum dolor sit amet"
-// 				},
-// 				{
-// 					name : "group_short_icon.long_icon",
-// 					label : "Long Icon - lorem ipsum dolor sit amet",
-// 					mIcon : HomeIcon
-// 				},
-// 				{
-// 					name : "group_short_icon.long_children",
-// 					label : "Long Children - lorem ipsum dolor sit amet",
-// 					items : [
-// 						{
-// 							name : "group_short_icon.long_children.item",
-// 							label : "Item"
-// 						}
-// 					]
-// 				},
-// 				{
-// 					name : "group_short_icon.long_icon_children",
-// 					label : "Long Icon Children - lorem ipsum dolor sit amet",
-// 					mIcon : HomeIcon,
-// 					items : [
-// 						{
-// 							name : "group_short_icon.long_icon_children.item",
-// 							label : "Item"
-// 						}
-// 					]
-// 				},
-// 			]
-// 		},
-// 		{
-// 			name : "group_long_icon",
-// 			label : "Group Long Icon - lorem ipsum dolor sit amet",
-// 			type : "group",
-// 			mIcon : BuildIcon,
-// 			items : [
-// 				{
-// 					name : "group_long_icon.item",
-// 					label : "Item"
-// 				}
-// 			]
-// 		},
-// 		{
-// 			name : "item_with_attrs",
-// 			label : "Items With Attrs",
-// 			mIcon : HomeIcon,
-// 			attrs : {
-// 				"data-attr" : "foo"
-// 			}
-// 		},
-// 		{
-// 			name : "click_variations",
-// 			label : "Click Variations",
-// 			mIcon : LinkIcon,
-// 			items : [
-// 				{
-// 					name : "click_variations.default",
-// 					label : "Default"
-// 				},
-// 				{
-// 					name : "click_variations.default_with_href",
-// 					label : "Default with href",
-// 					attrs : {
-// 						href : "https://www.google.com/"
-// 					}
-// 				},
-// 				{
-// 					name : "click_variations.href_only",
-// 					label : "Href Only",
-// 					onNav : false,
-// 					attrs : {
-// 						href : "https://www.google.com/"
-// 					}
-// 				},
-// 				{
-// 					name : "click_variations.href_new_window",
-// 					label : "Href, new window",
-// 					onNav : false,
-// 					attrs : {
-// 						href : "https://www.google.com/",
-// 						target : "_blank"
-// 					}
-// 				},
-// 				{
-// 					name : "click_variations.custom_handler",
-// 					label : "Custom Handler",
-// 					onNav : function() {
-// 						alert("Custom handler!");
-// 					}
-// 				}
-// 			]
-// 		},
-// 		{
-// 			name : "pinned_bottom",
-// 			label : "Pinned Bottom",
-// 			pinned : "bottom",
-// 			mIcon : HelpIcon,
-// 			items : [
-// 				{
-// 					name : "pinned_bottom.short",
-// 					label : "Short"
-// 				},
-// 				{
-// 					name : "pinned_bottom.short_icon",
-// 					label : "Short Icon",
-// 					mIcon : HomeIcon
-// 				},
-// 				{
-// 					name : "pinned_bottom.short_icon_children",
-// 					label : "Short Icon Children",
-// 					mIcon : HomeIcon,
-// 					items : [
-// 						{
-// 							name : "pinned_bottom.short_icon_children.item",
-// 							label : "Item"
-// 						}
-// 					]
-// 				},
-// 			]
-// 		}
-// 	],
-// 	cms_flat : [
-// 		{
-// 			name : "home",
-// 			label : "Home",
-// 			mIcon : HomeIcon
-// 		},
-// 		{
-// 			...navSections.sitemap
-// 		},
-// 		{
-// 			...navSections.assets,
-// 			mIcon : ImageIcon
-// 		},
-// 		{
-// 			name : "modules",
-// 			label : "Modules",
-// 			type : "group",
-// 			mIcon : ExtensionIcon,
-// 			items : [
-// 				navSections.assetRequest,
-// 				navSections.autoResponder,
-// 				navSections.collections,
-// 				navSections.dynamic,
-// 				navSections.mapPublisher,
-// 				navSections.mediaGallery,
-// 				navSections.blog,
-// 				navSections.translation
-// 			]
-// 		},
-// 		{
-// 			...navSections.settings,
-// 			type : "group"
-// 		}
-// 	]
-// }
+const dataSets: { [key: string]: LeftNavItemRootDef[] } = {
+	qa : [
+		{
+			name : "short_icon",
+			label : "Short Icon",
+			mIcon : HomeIcon
+		},
+		{
+			name : "short_icon_children",
+			label : "Short Icon Children",
+			mIcon : ExtensionIcon,
+			items : [
+				{
+					name : "short_icon_children.short",
+					label : "Short"
+				},
+				{
+					name : "short_icon_children.short_icon",
+					label : "Short Icon",
+					mIcon : HomeIcon
+				},
+				{
+					name : "short_icon_children.short_children",
+					label : "Short Children",
+					items : [
+						{
+							name :"short_icon_children.short_children.item",
+							label : "Item"
+						},
+						{
+							name : "short_icon_children.short_children.children",
+							label : "With Children",
+							items : [
+								{
+									name :"short_icon_children.short_children.children.item",
+									label : "Item"
+								},
+								{
+									name : "short_icon_children.short_children.children.children",
+									label : "With Children",
+									items : [
+										{
+											name :"short_icon_children.short_children.children.children.item",
+											label : "Item"
+										},
+										{
+											name : "short_icon_children.short_children.children.children.children",
+											label : "With Children",
+											items : [
+												{
+													name :"short_icon_children.short_children.children.children.children.item",
+													label : "Item"
+												},
+												{
+													name : "short_icon_children.short_children.children.children.children.children",
+													label : "With Children",
+													items : [
+														{
+															name :"short_icon_children.short_children.children.children.children.children.item",
+															label : "Item"
+														},
+														{
+															name : "short_icon_children.short_children.children.children.children.children.children",
+															label : "With Children",
+															items : [
+																{
+																	name :"short_icon_children.short_children.children.children.children.children.children.item",
+																	label : "Item"
+																},
+																{
+																	name : "short_icon_children.short_children.children.children.children.children.children.children",
+																	label : "With Children",
+																	items : [
+																		{
+																			name :"short_icon_children.short_children.children.children.children.children.children.children.item",
+																			label : "Item"
+																		},
+																		{
+																			name : "short_icon_children.short_children.children.children.children.children.children.children.children",
+																			label : "With Children",
+																			items : [
+																				{
+																					name :"short_icon_children.short_children.children.children.children.children.children.children.children.item",
+																					label : "Item"
+																				},
+																				{
+																					name : "short_icon_children.short_children.children.children.children.children.children.children.children.children",
+																					label : "With Children",
+																					items : [
+																						{
+																							name :"short_icon_children.short_children.children.children.children.children.children.children.children.children.item",
+																							label : "Item"
+																						},
+																						{
+																							name : "short_icon_children.short_children.children.children.children.children.children.children.children.children.children",
+																							label : "With Children",
+																							items : [
+																								{
+																									name :"short_icon_children.short_children.children.children.children.children.children.children.children.children.children.item",
+																									label : "Item"
+																								}
+																							]
+																						}
+																					]
+																				}
+																			]
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					name : "short_icon_children.short_icon_children",
+					label : "Short Icon Children",
+					mIcon : HomeIcon,
+					items : [
+						{
+							name : "short_icon_children.short_icon_children.item",
+							label : "Item"
+						}
+					]
+				},
+				{
+					name : "short_icon_children.long",
+					label : "Long - lorem ipsum dolor sit amet"
+				},
+				{
+					name : "short_icon_children.long_icon",
+					label : "Long Icon - lorem ipsum dolor sit amet",
+					mIcon : HomeIcon
+				},
+				{
+					name : "short_icon_children.long_children",
+					label : "Long Children - lorem ipsum dolor sit amet",
+					items : [
+						{
+							name : "short_icon_children.long_children.item",
+							label : "Item"
+						}
+					]
+				},
+				{
+					name : "short_icon_children.long_icon_children",
+					label : "Long Icon Children - lorem ipsum dolor sit amet",
+					mIcon : HomeIcon,
+					items : [
+						{
+							name : "short_icon_children.long_icon_children.item",
+							label : "Item"
+						}
+					]
+				},
+				// automate 20 entries to create a vertical scroller in the flyout
+				...(
+					new Array(35).fill(0).map((val, i) => {
+						return {
+							name : `short_icon_children.filler_item_${i}`,
+							label : `Filler ${i}`
+						}
+					})
+				),
+				{
+					name : "short_icon_children.after_filler",
+					label : "After Filler with Children",
+					items : [
+						{
+							name : "short_icon_children.after_filler.item",
+							label : "Item"
+						}
+					]
+				}
+			]
+		},
+		{
+			name : "long_icon",
+			label : "Long Icon - lorem ipsum dolor sit amet",
+			mIcon : DashboardIcon
+		},
+		{
+			name : "long_icon_children",
+			label : "Long Icon Children - lorem ipsum dolor sit amet",
+			mIcon : AccountTreeIcon,
+			items : [
+				{
+					name : "long_icon_children.item",
+					label : "Item"
+				}
+			]
+		},
+		{
+			name : "group_short_icon",
+			label : "Group Short",
+			type : "group",
+			mIcon : ImageIcon,
+			items : [
+				{
+					name : "group_short_icon.short",
+					label : "Short"
+				},
+				{
+					name : "group_short_icon.short_icon",
+					label : "Short Icon",
+					mIcon : HomeIcon
+				},
+				{
+					name : "group_short_icon.short_children",
+					label : "Short Children",
+					items : [
+						{
+							name : "group_short_icon.short_children.short_children.item",
+							label : "Item"
+						},
+						{
+							name : "group_short_icon.short_children.short_children.children",
+							label : "With Children",
+							items : [
+								{
+									name :"group_short_icon.short_children.short_children.children.item",
+									label : "Item"
+								},
+								{
+									name : "group_short_icon.short_children.short_children.children.children",
+									label : "With Children",
+									items : [
+										{
+											name : "group_short_icon.short_children.short_children.children.children.item",
+											label : "Item"
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					name : "group_short_icon.short_icon_children",
+					label : "Short Icon Children",
+					mIcon : HomeIcon,
+					items : [
+						{
+							name : "group_short_icon.short_icon_children.item",
+							label : "Item"
+						}
+					]
+				},
+				{
+					name : "group_short_icon.long",
+					label : "Long - lorem ipsum dolor sit amet"
+				},
+				{
+					name : "group_short_icon.long_icon",
+					label : "Long Icon - lorem ipsum dolor sit amet",
+					mIcon : HomeIcon
+				},
+				{
+					name : "group_short_icon.long_children",
+					label : "Long Children - lorem ipsum dolor sit amet",
+					items : [
+						{
+							name : "group_short_icon.long_children.item",
+							label : "Item"
+						}
+					]
+				},
+				{
+					name : "group_short_icon.long_icon_children",
+					label : "Long Icon Children - lorem ipsum dolor sit amet",
+					mIcon : HomeIcon,
+					items : [
+						{
+							name : "group_short_icon.long_icon_children.item",
+							label : "Item"
+						}
+					]
+				},
+			]
+		},
+		{
+			name : "group_long_icon",
+			label : "Group Long Icon - lorem ipsum dolor sit amet",
+			type : "group",
+			mIcon : BuildIcon,
+			items : [
+				{
+					name : "group_long_icon.item",
+					label : "Item"
+				}
+			]
+		},
+		{
+			name : "item_with_attrs",
+			label : "Items With Attrs",
+			mIcon : HomeIcon,
+			attrs : {
+				"data-attr" : "foo"
+			}
+		},
+		{
+			name : "click_variations",
+			label : "Click Variations",
+			mIcon : LinkIcon,
+			items : [
+				{
+					name : "click_variations.default",
+					label : "Default"
+				},
+				{
+					name : "click_variations.default_with_href",
+					label : "Default with href",
+					attrs : {
+						href : "https://www.google.com/"
+					}
+				},
+				{
+					name : "click_variations.href_only",
+					label : "Href Only",
+					onNav : false,
+					attrs : {
+						href : "https://www.google.com/"
+					}
+				},
+				{
+					name : "click_variations.href_new_window",
+					label : "Href, new window",
+					onNav : false,
+					attrs : {
+						href : "https://www.google.com/",
+						target : "_blank"
+					}
+				},
+				{
+					name : "click_variations.custom_handler",
+					label : "Custom Handler",
+					onNav : function() {
+						alert("Custom handler!");
+					}
+				}
+			]
+		},
+		{
+			name : "pinned_bottom",
+			label : "Pinned Bottom",
+			pinned : "bottom",
+			mIcon : HelpIcon,
+			items : [
+				{
+					name : "pinned_bottom.short",
+					label : "Short"
+				},
+				{
+					name : "pinned_bottom.short_icon",
+					label : "Short Icon",
+					mIcon : HomeIcon
+				},
+				{
+					name : "pinned_bottom.short_icon_children",
+					label : "Short Icon Children",
+					mIcon : HomeIcon,
+					items : [
+						{
+							name : "pinned_bottom.short_icon_children.item",
+							label : "Item"
+						}
+					]
+				},
+			]
+		}
+	],
+	cms_flat : [
+		{
+			name : "home",
+			label : "Home",
+			mIcon : HomeIcon
+		},
+		{
+			...navSections.sitemap
+		},
+		{
+			...navSections.assets,
+			mIcon : ImageIcon
+		},
+		{
+			name : "modules",
+			label : "Modules",
+			type : "group",
+			mIcon : ExtensionIcon,
+			items : [
+				navSections.assetRequest,
+				navSections.autoResponder,
+				navSections.collections,
+				navSections.dynamic,
+				navSections.mapPublisher,
+				navSections.mediaGallery,
+				navSections.blog,
+				navSections.translation
+			]
+		},
+		{
+			...navSections.settings,
+			type : "group"
+		}
+	]
+}
 
-// export const Example = (): ReactElement => {
-// 	const dataSet = select("Data", ["qa", "cms_flat"], "cms_flat");
-// 	const locale: string = select("Locale", { en : "en", es : "es", cimode : "cimode", de : "de" }, "en");
-// 	const items = dataSets[dataSet];
+const Template = (args) => {
+	const { items, locale } = args;
 
-// 	const mosaicSettings = useMosaicSettings();
+	const selectedItems = dataSets[items];
 
-// 	// If the user changes the locale knob we need to propagate to our i18n object
-// 	useEffect(() => {
-// 		if (mosaicSettings.i18n.language !== locale) {
-// 			mosaicSettings.i18n.changeLanguage(locale);
-// 		}
-// 	}, [locale]);
+	const mosaicSettings = useMosaicSettings();
 
-// 	return (
-// 		<MosaicContext.Provider value={mosaicSettings}>
-// 			<NavWrapper items={items}/>
-// 		</MosaicContext.Provider>
-// 	)
-// }
+	// If the user changes the locale knob we need to propagate to our i18n object
+	useEffect(() => {
+		if (mosaicSettings.i18n.language !== locale) {
+			mosaicSettings.i18n.changeLanguage(locale);
+		}
+	}, [locale]);
+
+	return (
+		<MosaicContext.Provider value={mosaicSettings}>
+			<NavWrapper items={selectedItems}/>
+		</MosaicContext.Provider>
+	)
+};
+
+export const Playground = Template.bind({});
+Playground.args = {
+	locale: "en",
+	items: "cms_flat"
+}

--- a/src/components/LeftNav/NavWrapper.tsx
+++ b/src/components/LeftNav/NavWrapper.tsx
@@ -58,7 +58,6 @@ const AppDiv = styled.div`
 
 	& > .main {
 		flex: 1 1 0;
-		overflow: hidden;
 		display: flex;
 	}
 

--- a/src/forms/FormFieldAddress/Address.stories.mdx
+++ b/src/forms/FormFieldAddress/Address.stories.mdx
@@ -8,7 +8,3 @@ Countries, states and cities information retrieved from: https://github.com/dr5h
 
 ### Props
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldAddress/AddressTypes.tsx
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldAddress/Address.stories.tsx
+++ b/src/forms/FormFieldAddress/Address.stories.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
 import { useMemo } from "react";
 import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
-import { FieldDef } from "../../components/Field";
+import FormFieldAddress, { FieldDef } from "../../components/Field";
 import Form, { useForm } from "@root/components/Form";
+import { ComponentMeta } from "@storybook/react";
 
 export default {
 	title: "FormFields/FormFieldAddress",
-	component: Form,
-};
+	component: FormFieldAddress,
+} as ComponentMeta<typeof FormFieldAddress>;
 
 const Template = (args) => {
 	const { state, dispatch } = useForm();

--- a/src/forms/FormFieldAddress/Address.stories.tsx
+++ b/src/forms/FormFieldAddress/Address.stories.tsx
@@ -1,59 +1,78 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { boolean, number, text, withKnobs } from "@storybook/addon-knobs";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
-// import { FieldDef } from "../../components/Field";
-// import Form, { useForm } from "@root/components/Form";
+import * as React from "react";
+import { useMemo } from "react";
+import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
+import { FieldDef } from "../../components/Field";
+import Form, { useForm } from "@root/components/Form";
 
-// export default {
-// 	title: "FormFields/FormFieldAddress",
-// 	decorators: [withKnobs],
-// };
+export default {
+	title: "FormFields/FormFieldAddress",
+	component: Form,
+};
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		disabled,
+		label,
+		required,
+		amountPerType,
+		amountShipping,
+		amountPhysical,
+		amountBilling
+	} = args;
 
-// const label = text("Label", "Label");
-// const disabled = boolean("Disabled", false);
-// const required = boolean("Required", false);
-// const amountPerType = number("Amount per type", 1);
-// const amountShipping = number("Amount shipping", 1);
-// const amountPhysical = number("Amount physical", 1);
-// const amountBilling = number("Amount billing", 1);
+	const fields = useMemo(
+		() =>
+			[
+				{
+					disabled,
+					label,
+					required,
+					name: "address",
+					type: "address",
+					inputSettings: {
+						amountPerType,
+						amountShipping,
+						amountPhysical,
+						amountBilling,
+					},
+				},
+			] as FieldDef[],
+		[
+			disabled,
+			label,
+			required,
+			amountPerType,
+			amountShipping,
+			amountPhysical,
+			amountBilling,
+		]
+	);
 
-// const fields = useMemo(
-// 	() => (
-// 		[
-// 			{
-// 				disabled,
-// 				label,
-// 				required,
-// 				name: "address",
-// 				type: "address",
-// 				inputSettings: {
-// 					amountPerType,
-// 					amountShipping,
-// 					amountPhysical,
-// 					amountBilling
-// 				},
-// 			},
-// 		] as FieldDef[]
-// 	),
-// 	[disabled, label, required, amountPerType, amountShipping, amountPhysical, amountBilling]
-// );
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	label: "Label",
+	required: false,
+	disabled: false,
+	amountPerType: 1,
+	amountShipping: 1,
+	amountPhysical: 1,
+	amountBilling: 1
+};

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelection.stories.mdx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelection.stories.mdx
@@ -5,16 +5,11 @@ import * as stories from './AdvancedSelection.stories';
 
 # Advanced Selection
 
-- Allow users to select one or more options from a modal menu. 
-- Used for very long lists. 
+- Allow users to select one or more options from a modal menu.
+- Used for very long lists.
 - Have the ability to type and search.
 
 ## Props
 
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldAdvancedSelection/AdvancedSelectionTypes.tsx
 
-## Advanced Selection Example
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
@@ -1,222 +1,249 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { boolean, text, withKnobs } from "@storybook/addon-knobs";
-// import { AdvancedSelectionDef } from ".";
-// import { FieldDef } from "@root/components/Field";
-// import Form, { useForm } from "@root/components/Form";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
-// import { additionalOptions } from "@root/forms/FormFieldAdvancedSelection";
+import * as React from "react";
+import { useMemo } from "react";
+import { AdvancedSelectionDef } from ".";
+import { FieldDef } from "@root/components/Field";
+import Form, { useForm } from "@root/components/Form";
+import {
+	excludedFormFieldsControls,
+	onCancel,
+	renderButtons,
+} from "@root/utils/storyUtils";
+import { additionalOptions } from "@root/forms/FormFieldAdvancedSelection";
 
 // Components
-// import { MosaicLabelValue } from "@root/types";
+import { MosaicLabelValue } from "@root/types";
 
-// export default {
-// 	title: "FormFields/FormFieldAdvancedSelection",
-// 	decorators: [withKnobs],
-// };
+export default {
+	title: "FormFields/FormFieldAdvancedSelection",
+	component: Form,
+};
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
-// 	const options = additionalOptions ? additionalOptions : [];
-// 	const label = text("Label", "Label");
-// 	const required = boolean("Required", false);
-// 	const disabled = boolean("Disabled", false);
-// 	const instructionText = text("Instruction text", "Instruction text");
-// 	const helperText = text("Helper text", "Helper text");
-// 	const shouldUseGetOptions = boolean("Obtain options from db", false);
-// 	const getOptionsLimit = text("Get options limit", "5");
-// 	const createNewOptionsKnob = boolean("Create new option", true);
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		additionalOptions,
+		disabled,
+		label,
+		required,
+		instructionText,
+		helperText,
+		shouldUseGetOptions,
+		getOptionsLimit,
+		createNewOptions,
+	} = args;
 
-// 	const getOptions: ({
-// 		filter,
-// 		limit,
-// 		offset,
-// 	}: {
-// 		filter?: string;
-// 		limit?: number;
-// 		offset?: number;
-// 	}) => Promise<MosaicLabelValue[]> = async ({ limit, filter, offset }) => {
-// 		let internalOptionsArr = [...additionalOptions];
+	const options = additionalOptions ? additionalOptions : [];
 
-// 		if (filter) {
-// 			const trimmedFilter = filter.trim().toLowerCase();
-// 			internalOptionsArr = additionalOptions.filter((option) =>
-// 				option.label.toLowerCase().includes(trimmedFilter)
-// 			);
-// 		}
+	const getOptions: ({
+		filter,
+		limit,
+		offset,
+	}: {
+		filter?: string;
+		limit?: number;
+		offset?: number;
+	}) => Promise<MosaicLabelValue[]> = async ({ limit, filter, offset }) => {
+		let internalOptionsArr = [...additionalOptions];
 
-// 		let optionsToReturn = [];
-// 		if (limit) {
-// 			for (let i = offset; i < offset + limit; i++) {
-// 				if (i < internalOptionsArr.length)
-// 					optionsToReturn.push(internalOptionsArr[i]);
-// 			}
-// 		} else {
-// 			optionsToReturn = internalOptionsArr;
-// 		}
+		if (filter) {
+			const trimmedFilter = filter.trim().toLowerCase();
+			internalOptionsArr = additionalOptions.filter((option) =>
+				option.label.toLowerCase().includes(trimmedFilter)
+			);
+		}
 
-// 		return optionsToReturn;
-// 	};
+		let optionsToReturn = [];
+		if (limit) {
+			for (let i = offset; i < offset + limit; i++) {
+				if (i < internalOptionsArr.length)
+					optionsToReturn.push(internalOptionsArr[i]);
+			}
+		} else {
+			optionsToReturn = internalOptionsArr;
+		}
 
-// const createNewOption = async (newOptionLabel) => {
-// 	const value = `${newOptionLabel}_${additionalOptions.length}`;
-// 	const newOption = {
-// 		label: newOptionLabel,
-// 		value,
-// 	};
+		return optionsToReturn;
+	};
 
-// 		//Insert to db
-// 		additionalOptions.push(newOption);
+	const createNewOption = async (newOptionLabel) => {
+		const value = `${newOptionLabel}_${additionalOptions.length}`;
+		const newOption = {
+			label: newOptionLabel,
+			value,
+		};
 
-// 	return newOption;
-// };
+		// Insert to db
+		additionalOptions.push(newOption);
 
-// const fields = useMemo(
-// 	() =>
-// 		[
-// 			{
-// 				name: "advancedSelection",
-// 				label,
-// 				required,
-// 				disabled,
-// 				helperText,
-// 				instructionText,
-// 				type: "advancedSelection",
-// 				inputSettings: {
-// 					options: !shouldUseGetOptions ? options : undefined,
-// 					getOptions: shouldUseGetOptions ? getOptions : undefined,
-// 					getOptionsLimit:
-// 						shouldUseGetOptions && getOptionsLimit
-// 							? getOptionsLimit
-// 							: undefined,
-// 					createNewOption: createNewOptionsKnob ? createNewOption : undefined
-// 				},
-// 			},
-// 		] as FieldDef<AdvancedSelectionDef>[],
-// 	[
-// 		label,
-// 		required,
-// 		disabled,
-// 		helperText,
-// 		instructionText,
-// 		getOptionsLimit,
-// 		options,
-// 		shouldUseGetOptions,
-// 		createNewOptionsKnob
-// 	]
-// );
+		return newOption;
+	};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+	const fields = useMemo(
+		() =>
+			[
+				{
+					name: "advancedSelection",
+					label,
+					required,
+					disabled,
+					helperText,
+					instructionText,
+					type: "advancedSelection",
+					inputSettings: {
+						options: !shouldUseGetOptions ? options : undefined,
+						getOptions: shouldUseGetOptions ? getOptions : undefined,
+						getOptionsLimit:
+							shouldUseGetOptions && getOptionsLimit
+								? getOptionsLimit
+								: undefined,
+						createNewOption: createNewOptions ? createNewOption : undefined,
+					},
+				},
+			] as FieldDef<AdvancedSelectionDef>[],
+		[
+			label,
+			required,
+			disabled,
+			helperText,
+			instructionText,
+			getOptionsLimit,
+			options,
+			shouldUseGetOptions,
+			createNewOptions,
+		]
+	);
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
-// 	const options = additionalOptions ? additionalOptions : [];
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// const getOptions: ({
-// 	filter,
-// 	limit,
-// 	offset,
-// }: {
-// 	filter?: string;
-// 	limit?: number;
-// 	offset?: number;
-// }) => Promise<MosaicLabelValue[]> = async ({ limit, filter, offset }) => {
-// 	let internalOptionsArr = [...additionalOptions];
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	additionalOptions,
+	label: "Label",
+	required: false,
+	disabled: false,
+	instructionText: "Instruction text",
+	helperText: "Helper text",
+	shouldUseGetOptions: false,
+	getOptionsLimit: "5",
+	createNewOptions: true,
+};
 
-// 	if (filter) {
-// 		const trimmedFilter = filter.trim().toLowerCase();
-// 		internalOptionsArr = additionalOptions.filter((option) =>
-// 			option.label.toLowerCase().includes(trimmedFilter)
-// 		);
-// 	}
+const KitchenSinkTemplate = (args) => {
+	const { state, dispatch } = useForm();
+	const options = args.additionalOptions ? args.additionalOptions : [];
 
-// 		let optionsToReturn = [];
-// 		if (limit) {
-// 			for (let i = offset; i < offset + limit; i++) {
-// 				if (i < internalOptionsArr.length)
-// 					optionsToReturn.push(internalOptionsArr[i]);
-// 			}
-// 		} else {
-// 			optionsToReturn = internalOptionsArr;
-// 		}
+	const getOptions: ({
+		filter,
+		limit,
+		offset,
+	}: {
+		filter?: string;
+		limit?: number;
+		offset?: number;
+	}) => Promise<MosaicLabelValue[]> = async ({ limit, filter, offset }) => {
+		let internalOptionsArr = [...additionalOptions];
 
-// 		return optionsToReturn;
-// 	};
+		if (filter) {
+			const trimmedFilter = filter.trim().toLowerCase();
+			internalOptionsArr = additionalOptions.filter((option) =>
+				option.label.toLowerCase().includes(trimmedFilter)
+			);
+		}
 
-// const createNewOption = async (newOptionLabel) => {
-// 	const value = `${newOptionLabel}_${additionalOptions.length}`;
-// 	const newOption = {
-// 		label: newOptionLabel,
-// 		value,
-// 	};
+		let optionsToReturn = [];
+		if (limit) {
+			for (let i = offset; i < offset + limit; i++) {
+				if (i < internalOptionsArr.length)
+					optionsToReturn.push(internalOptionsArr[i]);
+			}
+		} else {
+			optionsToReturn = internalOptionsArr;
+		}
 
-// 		//Insert to db
-// 		additionalOptions.push(newOption);
+		return optionsToReturn;
+	};
 
-// 	return newOption;
-// };
+	const createNewOption = async (newOptionLabel) => {
+		const value = `${newOptionLabel}_${additionalOptions.length}`;
+		const newOption = {
+			label: newOptionLabel,
+			value,
+		};
 
-// const fields = useMemo(
-// 	() =>
-// 		[
-// 			{
-// 				name: "checkboxOptions",
-// 				label: "Advanced selection with options prop",
-// 				type: "advancedSelection",
-// 				inputSettings: {
-// 					options,
-// 				},
-// 			},
-// 			{
-// 				name: "getOptions",
-// 				label: "Advanced selection with getOptions prop",
-// 				type: "advancedSelection",
-// 				inputSettings: {
-// 					getOptions,
-// 					getOptionsLimit: 5,
-// 				},
-// 			},
+		// Insert to db
+		additionalOptions.push(newOption);
 
-// 			{
-// 				name: "createNewOption",
-// 				label: "Advanced selection with createNewOption prop",
-// 				type: "advancedSelection",
-// 				inputSettings: {
-// 					options,
-// 					getOptionsLimit: 10,
-// 					createNewOption,
-// 				},
-// 			},
-// 		] as FieldDef<AdvancedSelectionDef>[],
-// 	[options]
-// );
+		return newOption;
+	};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title="Form Title"
-// 				description="Description"
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+	const fields = useMemo(
+		() =>
+			[
+				{
+					name: "checkboxOptions",
+					label: "Advanced selection with options prop",
+					type: "advancedSelection",
+					inputSettings: {
+						options,
+					},
+				},
+				{
+					name: "getOptions",
+					label: "Advanced selection with getOptions prop",
+					type: "advancedSelection",
+					inputSettings: {
+						getOptions,
+						getOptionsLimit: 5,
+					},
+				},
+
+				{
+					name: "createNewOption",
+					label: "Advanced selection with createNewOption prop",
+					type: "advancedSelection",
+					inputSettings: {
+						options,
+						getOptionsLimit: 10,
+						createNewOption,
+					},
+				},
+			] as FieldDef<AdvancedSelectionDef>[],
+		[options]
+	);
+
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="Description"
+				state={state}
+				fields={fields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
+
+export const KitchenSink = KitchenSinkTemplate.bind({});
+KitchenSink.parameters = { controls: { exclude: [...excludedFormFieldsControls, "additionalOptions"] } };
+KitchenSink.args = {
+	additionalOptions
+};

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useMemo } from "react";
 import { AdvancedSelectionDef } from ".";
-import { FieldDef } from "@root/components/Field";
+import FormFieldAdvancedSelection, { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
 import {
 	excludedFormFieldsControls,
@@ -9,6 +9,7 @@ import {
 	renderButtons,
 } from "@root/utils/storyUtils";
 import { additionalOptions } from "@root/forms/FormFieldAdvancedSelection";
+import { ComponentMeta } from "@storybook/react";
 
 // Components
 import { MosaicLabelValue } from "@root/types";
@@ -16,7 +17,7 @@ import { MosaicLabelValue } from "@root/types";
 export default {
 	title: "FormFields/FormFieldAdvancedSelection",
 	component: Form,
-};
+} as ComponentMeta<typeof FormFieldAdvancedSelection>;
 
 const Template = (args) => {
 	const { state, dispatch } = useForm();

--- a/src/forms/FormFieldCheckbox/FormFieldCheckbox.stories.mdx
+++ b/src/forms/FormFieldCheckbox/FormFieldCheckbox.stories.mdx
@@ -9,8 +9,3 @@ import * as stories from './FormFieldCheckbox.stories';
 
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldCheckbox/FormFieldCheckboxTypes.tsx
 
-## FormFieldCheckbox
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldCheckbox/FormFieldCheckbox.stories.tsx
+++ b/src/forms/FormFieldCheckbox/FormFieldCheckbox.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { useMemo } from "react";
-import { FormFieldCheckboxDef } from ".";
+import FormFieldCheckbox, { FormFieldCheckboxDef } from ".";
 import { FieldDef } from "@root/components/Field";
+import { ComponentMeta } from "@storybook/react";
 
 // Components
 import Form, { useForm } from "@root/components/Form";
@@ -12,8 +13,8 @@ import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils
 
 export default {
 	title: "FormFields/FormFieldCheckbox",
-	component: Form,
-};
+	component: FormFieldCheckbox,
+} as ComponentMeta<typeof FormFieldCheckbox>;
 
 const Template = (args) => {
 	const { state, dispatch } = useForm();
@@ -23,7 +24,8 @@ const Template = (args) => {
 		fields,
 		disabled,
 		helperText,
-		instructionText
+		instructionText,
+		options
 	} = args;
 
 	const playgroundFields = useMemo(
@@ -36,13 +38,13 @@ const Template = (args) => {
 					required,
 					disabled,
 					inputSettings: {
-						options: checkboxOptions,
+						options,
 					},
 					helperText,
 					instructionText,
 				},
 			] as FieldDef<FormFieldCheckboxDef>[],
-		[required, disabled, label, instructionText, helperText]
+		[required, disabled, label, instructionText, helperText, options]
 	);
 
 	return (
@@ -69,6 +71,7 @@ Playground.args = {
 	disabled: false,
 	instructionText: "Instruction text",
 	helperText: "Helper text",
+	options: checkboxOptions
 };
 
 

--- a/src/forms/FormFieldCheckbox/FormFieldCheckbox.stories.tsx
+++ b/src/forms/FormFieldCheckbox/FormFieldCheckbox.stories.tsx
@@ -1,118 +1,116 @@
-// import * as React from "react";
-// import { useMemo, ReactElement } from "react";
-// import { boolean, withKnobs, text } from "@storybook/addon-knobs";
-// import { Meta } from "@storybook/addon-docs/blocks";
-// import { FormFieldCheckboxDef } from ".";
-// import { FieldDef } from "@root/components/Field";
+import * as React from "react";
+import { useMemo } from "react";
+import { FormFieldCheckboxDef } from ".";
+import { FieldDef } from "@root/components/Field";
 
-// // Components
-// import Form, { useForm } from "@root/components/Form";
+// Components
+import Form, { useForm } from "@root/components/Form";
 
-// // Utils
-// import { checkboxOptions } from "./FormFieldCheckboxUtils";
-// // import { onCancel, renderButtons } from "@root/utils/storyUtils";
+// Utils
+import { checkboxOptions } from "./FormFieldCheckboxUtils";
+import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
 
-// export default {
-// 	title: "FormFields/FormFieldCheckbox",
-// 	decorators: [withKnobs],
-// } as Meta;
+export default {
+	title: "FormFields/FormFieldCheckbox",
+	component: Form,
+};
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		label,
+		required,
+		fields,
+		disabled,
+		helperText,
+		instructionText
+	} = args;
 
-// 	const disabled = boolean("Disabled", false);
-// 	const required = boolean("Required", false);
-// 	const label = text("Label", "Label");
-// 	const instructionText = text("Instruction Text", "Instruction Text");
-// 	const helperText = text("Helper Text", "Helper Text");
+	const playgroundFields = useMemo(
+		() =>
+			[
+				{
+					name: "checkbox",
+					label,
+					type: "checkbox",
+					required,
+					disabled,
+					inputSettings: {
+						options: checkboxOptions,
+					},
+					helperText,
+					instructionText,
+				},
+			] as FieldDef<FormFieldCheckboxDef>[],
+		[required, disabled, label, instructionText, helperText]
+	);
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "checkbox",
-// 					label,
-// 					type: "checkbox",
-// 					required,
-// 					disabled,
-// 					inputSettings: {
-// 						options: checkboxOptions,
-// 					},
-// 					helperText,
-// 					instructionText,
-// 				},
-// 			] as FieldDef<FormFieldCheckboxDef>[],
-// 		[required, disabled, label, instructionText, helperText]
-// 	);
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields ? fields : playgroundFields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	label: "Label",
+	required: false,
+	disabled: false,
+	instructionText: "Instruction text",
+	helperText: "Helper text",
+};
 
-// const kitchenSinkFields = [
-// 	{
-// 		name: "checkbox",
-// 		label: "Regular example",
-// 		type: "checkbox",
-// 		required: false,
-// 		disabled: false,
-// 		inputSettings: {
-// 			options: checkboxOptions,
-// 		},
-// 		helperText: "Helper Text",
-// 		instructionText: "InstructionText",
-// 	},
-// 	{
-// 		name: "disabledCheckbox",
-// 		label: "Disabled example",
-// 		type: "checkbox",
-// 		required: false,
-// 		disabled: true,
-// 		inputSettings: {
-// 			options: checkboxOptions,
-// 		},
-// 		helperText: "Helper Text",
-// 		instructionText: "InstructionText",
-// 	},
-// 	/* Should inputSettings be an optional prop?
-// 	{
-// 		name: 'withoutOptions',
-// 		label: 'Without options',
-// 		type: 'checkbox',
-// 		required: false,
-// 		disabled: false,
-// 		helperText: 'Helper Text',
-// 		instructionText: 'InstructionText',
-// 	}, */
-// ] as FieldDef<FormFieldCheckboxDef>[];
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const kitchenSinkFields = [
+	{
+		name: "checkbox",
+		label: "Regular example",
+		type: "checkbox",
+		required: false,
+		disabled: false,
+		inputSettings: {
+			options: checkboxOptions,
+		},
+		helperText: "Helper Text",
+		instructionText: "InstructionText",
+	},
+	{
+		name: "disabledCheckbox",
+		label: "Disabled example",
+		type: "checkbox",
+		required: false,
+		disabled: true,
+		inputSettings: {
+			options: checkboxOptions,
+		},
+		helperText: "Helper Text",
+		instructionText: "InstructionText",
+	},
+	/* Should inputSettings be an optional prop?
+	{
+		name: 'withoutOptions',
+		label: 'Without options',
+		type: 'checkbox',
+		required: false,
+		disabled: false,
+		helperText: 'Helper Text',
+		instructionText: 'InstructionText',
+	}, */
+] as FieldDef<FormFieldCheckboxDef>[];
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title='Form Title'
-// 				description='This is a description example'
-// 				state={state}
-// 				fields={kitchenSinkFields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: excludedFormFieldsControls } };
+KitchenSink.args = {
+	fields: kitchenSinkFields,
+};

--- a/src/forms/FormFieldChipSingleSelect/FormFieldChipSingleSelect.stories.mdx
+++ b/src/forms/FormFieldChipSingleSelect/FormFieldChipSingleSelect.stories.mdx
@@ -13,8 +13,3 @@ Description
 
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldChipSingleSelect/FormFieldChipSingleSelectTypes.tsx
 
-## FormFieldChipSingleSelect
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldChipSingleSelect/FormFieldChipSingleSelect.stories.tsx
+++ b/src/forms/FormFieldChipSingleSelect/FormFieldChipSingleSelect.stories.tsx
@@ -38,6 +38,7 @@ const Template = (args) => {
 		instructionText,
 		required,
 		disabled,
+		optionsArgs
 	} = args;
 
 	const playgroundFields = useMemo(
@@ -52,11 +53,11 @@ const Template = (args) => {
 					name: "Form Field Chip Single Select",
 					type: "chip",
 					inputSettings: {
-						options,
+						options: optionsArgs
 					},
 				},
 			] as FieldDef<FormFieldChipSingleSelectDef>[],
-		[label, helperText, instructionText, required, disabled]
+		[label, helperText, instructionText, required, disabled, optionsArgs]
 	);
 
 	return (
@@ -83,6 +84,7 @@ Playground.args = {
 	disabled: false,
 	instructionText: "Instruction text",
 	helperText: "Helper text",
+	optionsArgs: options
 };
 
 const kitchenSinkFields = [

--- a/src/forms/FormFieldChipSingleSelect/FormFieldChipSingleSelect.stories.tsx
+++ b/src/forms/FormFieldChipSingleSelect/FormFieldChipSingleSelect.stories.tsx
@@ -1,149 +1,131 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { boolean, text, withKnobs } from "@storybook/addon-knobs";
-// import { Meta } from "@storybook/addon-docs/blocks";
-// import { FormFieldChipSingleSelectDef } from ".";
-// import { FieldDef } from "@root/components/Field";
-// import Form, { useForm } from "@root/components/Form";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
+import * as React from "react";
+import { useMemo } from "react";
+import { FormFieldChipSingleSelectDef } from ".";
+import { FieldDef } from "@root/components/Field";
+import Form, { useForm } from "@root/components/Form";
+import {
+	excludedFormFieldsControls,
+	onCancel,
+	renderButtons,
+} from "@root/utils/storyUtils";
 
-// export default {
-// 	title: "FormFields/FormFieldChipSingleSelect",
-// 	decorators: [withKnobs],
-// } as Meta;
+export default {
+	title: "FormFields/FormFieldChipSingleSelect",
+	component: Form,
+}
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const options = [
+	{
+		label: "Option 1",
+		value: "Option_1",
+	},
+	{
+		label: "Option 2",
+		value: "Option_2",
+	},
+	{
+		label: "Option 3",
+		value: "Option_3",
+	},
+];
 
-// 	const options = useMemo( ()=> [
-// 		{
-// 			label: "Option 1",
-// 			value: "Option_1",
-// 		},
-// 		{
-// 			label: "Option 2",
-// 			value: "Option_2",
-// 		},
-// 		{
-// 			label: "Option 3",
-// 			value: "Option_3",
-// 		},
-// 	], []);
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		label,
+		fields,
+		helperText,
+		instructionText,
+		required,
+		disabled,
+	} = args;
 
-// 	const label = text("Label", "Label");
-// 	const helperText = text("Helper Text", "Helper Text");
-// 	const instructionText = text("Instruction text", "Instruction text");
-// 	const required = boolean("Required", false);
-// 	const disabled = boolean("Disabled", false);
+	const playgroundFields = useMemo(
+		() =>
+			[
+				{
+					label,
+					helperText,
+					instructionText,
+					required,
+					disabled,
+					name: "Form Field Chip Single Select",
+					type: "chip",
+					inputSettings: {
+						options,
+					},
+				},
+			] as FieldDef<FormFieldChipSingleSelectDef>[],
+		[label, helperText, instructionText, required, disabled]
+	);
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					label,
-// 					helperText,
-// 					instructionText,
-// 					required,
-// 					disabled,
-// 					name: "Form Field Chip Single Select",
-// 					type: "chip",
-// 					inputSettings: {
-// 						options
-// 					},
-// 				}
-// 			] as FieldDef<FormFieldChipSingleSelectDef>[],
-// 		[label, helperText, instructionText, required, disabled]
-// 	);
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields ? fields : playgroundFields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	label: "Label",
+	required: false,
+	disabled: false,
+	instructionText: "Instruction text",
+	helperText: "Helper text",
+};
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const kitchenSinkFields = [
+	{
+		name: "chipRegular",
+		label: "Regular example",
+		type: "chip",
+		required: false,
+		disabled: false,
+		inputSettings: {
+			options,
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "chipDisable",
+		label: "Disable example",
+		type: "chip",
+		required: false,
+		disabled: true,
+		inputSettings: {
+			options,
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "chipRequired",
+		label: "Required example",
+		type: "chip",
+		required: true,
+		disabled: false,
+		inputSettings: {
+			options,
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+] as FieldDef<FormFieldChipSingleSelectDef>[];
 
-// 	const options = useMemo(() => [
-// 		{
-// 			label: "Option 1",
-// 			value: "Option_1",
-// 		},
-// 		{
-// 			label: "Option 2",
-// 			value: "Option_2",
-// 		},
-// 		{
-// 			label: "Option 3",
-// 			value: "Option_3",
-// 		},
-// 	], []);
-
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "chipRegular",
-// 					label: "Regular example",
-// 					type: "chip",
-// 					required: false,
-// 					disabled: false,
-// 					inputSettings: {
-// 						options,
-// 					},
-// 					helperText: "Helper text",
-// 					instructionText: "Instruction text"
-// 				},
-// 				{
-// 					name: "chipDisable",
-// 					label: "Disable example",
-// 					type: "chip",
-// 					required: false,
-// 					disabled: true,
-// 					inputSettings: {
-// 						options,
-// 					},
-// 					helperText: "Helper text",
-// 					instructionText: "Instruction text"
-// 				},
-// 				{
-// 					name: "chipRequired",
-// 					label: "Required example",
-// 					type: "chip",
-// 					required: true,
-// 					disabled: false,
-// 					inputSettings: {
-// 						options,
-// 					},
-// 					helperText: "Helper text",
-// 					instructionText: "Instruction text"
-// 				}
-// 			] as FieldDef<FormFieldChipSingleSelectDef>[],
-// 		[]
-// 	);
-
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title='Form Regular Example'
-// 				description='This is a description example'
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: excludedFormFieldsControls } };
+KitchenSink.args = {
+	fields: kitchenSinkFields,
+};

--- a/src/forms/FormFieldColorPicker/ColorPicker.stories.mdx
+++ b/src/forms/FormFieldColorPicker/ColorPicker.stories.mdx
@@ -6,8 +6,3 @@ import * as stories from './ColorPicker.stories';
 ## Color Picker
 The color picker component allows users to select from pre-defined colors (swatches) or custom colors using a HSB selection interface.
 The implementation of this component is based on the following package: https://casesandberg.github.io/react-color/
-
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldColorPicker/ColorPicker.stories.tsx
+++ b/src/forms/FormFieldColorPicker/ColorPicker.stories.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
 import { useMemo } from "react";
-import { FieldDef } from "@root/components/Field";
+import FormFieldColorPicker, { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
 import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
+import { ComponentMeta } from "@storybook/react";
 
 export default {
 	title: "FormFields/FormFieldColorPicker",
 	component: Form,
-};
+} as ComponentMeta<typeof FormFieldColorPicker>;
 
 const Template = (args) => {
 	const { state, dispatch } = useForm();

--- a/src/forms/FormFieldColorPicker/ColorPicker.stories.tsx
+++ b/src/forms/FormFieldColorPicker/ColorPicker.stories.tsx
@@ -1,92 +1,88 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { boolean, text, withKnobs } from "@storybook/addon-knobs";
-// import { FieldDef } from "@root/components/Field";
-// import Form, { useForm } from "@root/components/Form";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
+import * as React from "react";
+import { useMemo } from "react";
+import { FieldDef } from "@root/components/Field";
+import Form, { useForm } from "@root/components/Form";
+import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
 
-// export default {
-// 	title: "FormFields/FormFieldColorPicker",
-// 	decorators: [withKnobs],
-// };
+export default {
+	title: "FormFields/FormFieldColorPicker",
+	component: Form,
+};
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		label,
+		disabled,
+		required,
+		fields,
+		helperText,
+		instructionText
+	} = args;
 
-// 	const label = text("Label", "Label");
-// 	const disabled = boolean("Disabled", false);
-// 	const required = boolean("Required", false);
+	const playgroundFields = useMemo(
+		() =>
+			[
+				{
+					name: "color",
+					label,
+					type: "color",
+					required,
+					disabled,
+					helperText,
+					instructionText,
+				},
+			] as FieldDef[],
+		[label, required, disabled, instructionText, helperText]
+	);
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "color",
-// 					label,
-// 					type: "color",
-// 					required,
-// 					disabled,
-// 				},
-// 			] as FieldDef[],
-// 		[label, required, disabled]
-// 	);
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<div style={{ height: "100vh" }}>
+				<Form
+					buttons={renderButtons(dispatch)}
+					title="Form Title"
+					description="This is a description example"
+					state={state}
+					fields={fields ? fields : playgroundFields}
+					dispatch={dispatch}
+					onCancel={onCancel}
+				/>
+			</div>
+		</>
+	);
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// <div style={{height: "100vh"}}>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// </div>
-// 		</>
-// 	);
-// };
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	label: "Label",
+	required: false,
+	disabled: false,
+	instructionText: "Instruction text",
+	helperText: "Helper text",
+};
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const kitchenSinkFields = [
+	{
+		name: "color",
+		label: "Regular Example",
+		type: "color",
+		required: false,
+		disabled: false,
+	},
+	{
+		name: "colorDisabled",
+		label: "Disabled Example",
+		type: "color",
+		required: false,
+		disabled: true,
+	},
+] as FieldDef[];
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "color",
-// 					label: "Regular Example",
-// 					type: "color",
-// 					required: false,
-// 					disabled: false,
-// 				},
-// 				{
-// 					name: "colorDisabled",
-// 					label: "Disabled Example",
-// 					type: "color",
-// 					required: false,
-// 					disabled: true,
-// 				},
-// 			] as FieldDef[],
-// 		[]
-// 	);
-
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// <div style={{height: "100vh"}}>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title='Form Title'
-// 				description='This is a description example'
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// </div>
-// 		</>
-// 	);
-// };
+export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: excludedFormFieldsControls } };
+KitchenSink.args = {
+	fields: kitchenSinkFields,
+};

--- a/src/forms/FormFieldDate/DateField/DateField.stories.tsx
+++ b/src/forms/FormFieldDate/DateField/DateField.stories.tsx
@@ -1,18 +1,19 @@
 import * as React from "react";
 import { useMemo } from "react";
 import { FieldDef } from "@root/components/Field";
-import { DateFieldDef } from "./DateFieldTypes";
+import FormFieldDateField, { DateFieldDef } from ".";
 import Form, { useForm } from "@root/components/Form";
 import {
 	excludedFormFieldsControls,
 	onCancel,
 	renderButtons,
 } from "@root/utils/storyUtils";
+import { ComponentMeta } from "@storybook/react";
 
 export default {
 	title: "FormFields/FormFieldDateField",
-	component: Form,
-};
+	component: FormFieldDateField,
+}  as ComponentMeta<typeof FormFieldDateField>;
 
 const Template = (args) => {
 	const { state, dispatch } = useForm();

--- a/src/forms/FormFieldDate/DateField/DateField.stories.tsx
+++ b/src/forms/FormFieldDate/DateField/DateField.stories.tsx
@@ -1,142 +1,145 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { boolean, text, withKnobs } from "@storybook/addon-knobs";
-// import { FieldDef } from "@root/components/Field";
-// import { DateFieldDef } from "./DateFieldTypes";
-// import Form, { useForm } from "@root/components/Form";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
+import * as React from "react";
+import { useMemo } from "react";
+import { FieldDef } from "@root/components/Field";
+import { DateFieldDef } from "./DateFieldTypes";
+import Form, { useForm } from "@root/components/Form";
+import {
+	excludedFormFieldsControls,
+	onCancel,
+	renderButtons,
+} from "@root/utils/storyUtils";
 
-// export default {
-// 	title: "FormFields/FormFieldDateField",
-// 	decorators: [withKnobs],
-// };
+export default {
+	title: "FormFields/FormFieldDateField",
+	component: Form,
+};
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		label,
+		fields,
+		helperText,
+		instructionText,
+		disabled,
+		required,
+		showTime,
+	} = args;
 
-// 	const label = text("Label", "Date Field Picker");
-// 	const helperText = text("Helper text", "Helper text");
-// 	const instructionText = text("Instruction text", "Instruction text");
-// 	const disabled = boolean("Disabled", false);
-// 	const required = boolean("Required", false);
-// 	const showTime = boolean("Show time", false);
+	const playgroundFields = useMemo(
+		() =>
+			[
+				{
+					name: "date",
+					type: "date",
+					label,
+					required,
+					disabled,
+					helperText,
+					instructionText,
+					inputSettings: {
+						showTime,
+					},
+				},
+			] as FieldDef[],
+		[label, required, disabled, helperText, instructionText, showTime]
+	);
 
-// 	const fields = useMemo(
-// 		() => [
-// 			{
-// 				name: "date",
-// 				type: "date",
-// 				label,
-// 				required,
-// 				disabled,
-// 				helperText,
-// 				instructionText,
-// 				inputSettings: {
-// 					showTime
-// 				}
-// 			}
-// 		] as FieldDef[],
-// 		[label, required, disabled, helperText, instructionText, showTime]
-// 	);
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields ? fields : playgroundFields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	label: "Label",
+	required: false,
+	disabled: false,
+	instructionText: "Instruction text",
+	helperText: "Helper text",
+	showTime: false
+};
 
-// export const KitchenSink = (): ReactElement => {
-// 	const {	state, dispatch	} = useForm();
-// 	const helperText = "Helper text";
-// 	const instructionText = "Instruction text";
+const helperText = "Helper text";
+const instructionText = "Instruction text";
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "singleDate",
-// 					type: "date",
-// 					label: "Single Date Calendar",
-// 					required: false,
-// 					disabled: false,
-// 					helperText,
-// 					instructionText,
-// 					inputSettings: {
-// 						showTime: false
-// 					}
-// 				},
-// 				{
-// 					name: "disableSingleDate",
-// 					type: "date",
-// 					label: "Disable Single Date Calendar",
-// 					required: false,
-// 					disabled: true,
-// 					helperText,
-// 					instructionText,
-// 					inputSettings: {
-// 						showTime: false
-// 					}
-// 				},
-// 				{
-// 					name: "dateTime",
-// 					type: "date",
-// 					label: "Date Time Input",
-// 					required: false,
-// 					disabled: false,
-// 					helperText,
-// 					instructionText,
-// 					inputSettings: {
-// 						showTime: true
-// 					}
-// 				}, {
-// 					name: "disableDateTime",
-// 					type: "date",
-// 					label: "Disable Date Time Calendar",
-// 					required: false,
-// 					disabled: true,
-// 					helperText,
-// 					instructionText,
-// 					inputSettings: {
-// 						showTime: true
-// 					}
-// 				}, {
-// 					name: "requiredDateTime",
-// 					type: "date",
-// 					label: "Required Single Date Calendar",
-// 					required: true,
-// 					disabled: false,
-// 					helperText,
-// 					instructionText,
-// 					inputSettings: {
-// 						showTime: true
-// 					}
-// 				} as FieldDef<DateFieldDef>
-// 			],
-// 		[]
-// 	);
+const kitchenSinkFields = [
+	{
+		name: "singleDate",
+		type: "date",
+		label: "Single Date Calendar",
+		required: false,
+		disabled: false,
+		helperText,
+		instructionText,
+		inputSettings: {
+			showTime: false,
+		},
+	},
+	{
+		name: "disableSingleDate",
+		type: "date",
+		label: "Disable Single Date Calendar",
+		required: false,
+		disabled: true,
+		helperText,
+		instructionText,
+		inputSettings: {
+			showTime: false,
+		},
+	},
+	{
+		name: "dateTime",
+		type: "date",
+		label: "Date Time Input",
+		required: false,
+		disabled: false,
+		helperText,
+		instructionText,
+		inputSettings: {
+			showTime: true,
+		},
+	},
+	{
+		name: "disableDateTime",
+		type: "date",
+		label: "Disable Date Time Calendar",
+		required: false,
+		disabled: true,
+		helperText,
+		instructionText,
+		inputSettings: {
+			showTime: true,
+		},
+	},
+	{
+		name: "requiredDateTime",
+		type: "date",
+		label: "Required Single Date Calendar",
+		required: true,
+		disabled: false,
+		helperText,
+		instructionText,
+		inputSettings: {
+			showTime: true,
+		},
+	} as FieldDef<DateFieldDef>,
+];
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={"Date Field Calendar"}
-// 				description={"This is a description example"}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: excludedFormFieldsControls } };
+KitchenSink.args = {
+	fields: kitchenSinkFields,
+};

--- a/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.stories.mdx
+++ b/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.stories.mdx
@@ -10,9 +10,3 @@ import * as stories from "./FormFieldDropdownSingleSelection.stories";
 ## Props
 
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelectionTypes.tsx
-
-## Example
-
-<Preview withSource="none">
-	<stories.Playground/>
-</Preview>

--- a/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.stories.tsx
+++ b/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { useMemo } from "react";
 import { FieldDef } from "@root/components/Field";
-import { DropdownSingleSelectionDef } from ".";
+import FormFieldDropdownSingleSelection, { DropdownSingleSelectionDef } from ".";
 import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
+import { ComponentMeta } from "@storybook/react";
 
 // Components
 import Form, { useForm } from "@root/components/Form";
@@ -16,7 +17,7 @@ export default {
 			control: "select",
 		},
 	},
-};
+} as ComponentMeta<typeof FormFieldDropdownSingleSelection>;
 
 // Top 100 films as rated by IMDb users. http://www.imdb.com/chart/top
 const options = [
@@ -54,7 +55,8 @@ const Template = (args) => {
 		helperText,
 		instructionText,
 		label,
-		disabled
+		disabled,
+		optionsArgs
 	} = args;
 
 	const playgroundFields = useMemo(
@@ -68,7 +70,7 @@ const Template = (args) => {
 					disabled,
 					size,
 					inputSettings: {
-						options,
+						options: optionsArgs,
 						placeholder,
 					},
 					helperText,
@@ -84,6 +86,7 @@ const Template = (args) => {
 			helperText,
 			instructionText,
 			label,
+			optionsArgs
 		]
 	);
 
@@ -112,7 +115,8 @@ Playground.args = {
 	instructionText: "Instruction text",
 	helperText: "Helper text",
 	size: "sm",
-	placeholder: "placeholder"
+	placeholder: "placeholder",
+	optionsArgs: options
 };
 
 const kitchenSinkFields = [

--- a/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.stories.tsx
+++ b/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.stories.tsx
@@ -1,192 +1,194 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { boolean, select, withKnobs, text } from "@storybook/addon-knobs";
-// import { FieldDef } from "@root/components/Field";
-// import { DropdownSingleSelectionDef } from ".";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
+import * as React from "react";
+import { useMemo } from "react";
+import { FieldDef } from "@root/components/Field";
+import { DropdownSingleSelectionDef } from ".";
+import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
 
 // Components
-//import Form, { useForm } from "@root/components/Form";
+import Form, { useForm } from "@root/components/Form";
 
-// export default {
-// 	title: "FormFields/FormFieldDropdownSingleSelection",
-// 	decorators: [withKnobs],
-// };
+export default {
+	title: "FormFields/FormFieldDropdownSingleSelection",
+	component: Form,
+	argTypes: {
+		size: {
+			options: ["xs", "sm", "md", "lg"],
+			control: "select",
+		},
+	},
+};
 
-// // Top 100 films as rated by IMDb users. http://www.imdb.com/chart/top
-// const options = [
-// 	{ label: "The Shawshank Redemption", value: "1994" },
-// 	{ label: "The Godfather", value: "1972" },
-// 	{ label: "The Godfather: Part II", value: "1974" },
-// 	{ label: "The Dark Knight", value: "2008" },
-// 	{ label: "12 Angry Men", value: "1957" },
-// 	{ label: "Schindler's List", value: "1993" },
-// 	{ label: "Pulp Fiction", value: "1994" },
-// 	{ label: "The Lord of the Rings: The Return of the King", value: "2003" },
-// 	{ label: "The Good, the Bad and the Ugly", value: "1966" },
-// 	{ label: "Fight Club", value: "1999" },
-// 	{ label: "The Lord of the Rings: The Fellowship of the Ring", value: "2001" },
-// 	{ label: "Star Wars: Episode V - The Empire Strikes Back", value: "1980" },
-// 	{ label: "Forrest Gump", value: "1994" },
-// 	{ label: "Inception", value: "2010" },
-// 	{ label: "The Lord of the Rings: The Two Towers", value: "2002" },
-// 	{ label: "One Flew Over the Cuckoo's Nest", value: "1975" },
-// 	{ label: "Goodfellas", value: "1990" },
-// 	{ label: "The Matrix", value: "1999" },
-// 	{ label: "Seven Samurai", value: "1954" },
-// 	{ label: "Star Wars: Episode IV - A New Hope", value: "1977" },
-// 	{ label: "City of God", value: "2002" },
-// 	{ label: "Se7en", value: "1995" },
-// ];
+// Top 100 films as rated by IMDb users. http://www.imdb.com/chart/top
+const options = [
+	{ label: "The Shawshank Redemption", value: "1994" },
+	{ label: "The Godfather", value: "1972" },
+	{ label: "The Godfather: Part II", value: "1974" },
+	{ label: "The Dark Knight", value: "2008" },
+	{ label: "12 Angry Men", value: "1957" },
+	{ label: "Schindler's List", value: "1993" },
+	{ label: "Pulp Fiction", value: "1994" },
+	{ label: "The Lord of the Rings: The Return of the King", value: "2003" },
+	{ label: "The Good, the Bad and the Ugly", value: "1966" },
+	{ label: "Fight Club", value: "1999" },
+	{ label: "The Lord of the Rings: The Fellowship of the Ring", value: "2001" },
+	{ label: "Star Wars: Episode V - The Empire Strikes Back", value: "1980" },
+	{ label: "Forrest Gump", value: "1994" },
+	{ label: "Inception", value: "2010" },
+	{ label: "The Lord of the Rings: The Two Towers", value: "2002" },
+	{ label: "One Flew Over the Cuckoo's Nest", value: "1975" },
+	{ label: "Goodfellas", value: "1990" },
+	{ label: "The Matrix", value: "1999" },
+	{ label: "Seven Samurai", value: "1954" },
+	{ label: "Star Wars: Episode IV - A New Hope", value: "1977" },
+	{ label: "City of God", value: "2002" },
+	{ label: "Se7en", value: "1995" },
+];
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		size,
+		placeholder,
+		required,
+		fields,
+		helperText,
+		instructionText,
+		label,
+		disabled
+	} = args;
 
-// 	const size = select(
-// 		"Size",
-// 		["xs", "sm", "md", "lg"],
-// 		"sm"
-// 	);
-// 	const placeholder = text("Placeholder", "placeholder");
-// 	const disabled = boolean("Disabled", false);
-// 	const required = boolean("Required", false);
-// 	const helperText = text("Helper text", "Helper text");
-// 	const instructionText = text("Instruction text", "Instruction text");
-// 	const label = text("Label", "Label");
+	const playgroundFields = useMemo(
+		() =>
+			[
+				{
+					name: "dropdown",
+					label,
+					type: "dropdown",
+					required,
+					disabled,
+					size,
+					inputSettings: {
+						options,
+						placeholder,
+					},
+					helperText,
+					instructionText,
+				},
+			] as FieldDef<DropdownSingleSelectionDef>[],
+		[
+			required,
+			disabled,
+			size,
+			placeholder,
+			options,
+			helperText,
+			instructionText,
+			label,
+		]
+	);
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "dropdown",
-// 					label,
-// 					type: "dropdown",
-// 					required,
-// 					disabled,
-// 					size,
-// 					inputSettings: {
-// 						options,
-// 						placeholder,
-// 					},
-// 					helperText,
-// 					instructionText,
-// 				},
-// 			] as FieldDef<DropdownSingleSelectionDef>[],
-// 		[
-// 			required,
-// 			disabled,
-// 			size,
-// 			placeholder,
-// 			options,
-// 			helperText,
-// 			instructionText,
-// 			label,
-// 		]
-// 	);
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields ? fields : playgroundFields }
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	label: "Label",
+	required: false,
+	disabled: false,
+	instructionText: "Instruction text",
+	helperText: "Helper text",
+	size: "sm",
+	placeholder: "placeholder"
+};
 
-// const kitchenSinkFields = [
-// 	{
-// 		name: "dropdown",
-// 		label: "Regular example",
-// 		type: "dropdown",
-// 		size: "md",
-// 		inputSettings: {
-// 			options,
-// 			placeholder: "placeholder"
-// 		},
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// 	{
-// 		name: "disabledExample",
-// 		label: "Disabled",
-// 		type: "dropdown",
-// 		disabled: true,
-// 		size: "md",
-// 		inputSettings: {
-// 			options,
-// 			placeholder: "placeholder"
-// 		},
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// 	{
-// 		name: "xsSize",
-// 		label: "Size xs",
-// 		type: "dropdown",
-// 		size: "xs",
-// 		inputSettings: {
-// 			options,
-// 		},
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// 	{
-// 		name: "smSize",
-// 		label: "Size sm",
-// 		type: "dropdown",
-// 		size: "sm",
-// 		inputSettings: {
-// 			options,
-// 		},
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// 	{
-// 		name: "mdSize",
-// 		label: "Size md",
-// 		type: "dropdown",
-// 		size: "md",
-// 		inputSettings: {
-// 			options,
-// 		},
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// 	{
-// 		name: "lgSize",
-// 		label: "Size lg",
-// 		type: "dropdown",
-// 		size: "lg",
-// 		inputSettings: {
-// 			options,
-// 		},
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// ] as FieldDef<DropdownSingleSelectionDef>[];
+const kitchenSinkFields = [
+	{
+		name: "dropdown",
+		label: "Regular example",
+		type: "dropdown",
+		size: "md",
+		inputSettings: {
+			options,
+			placeholder: "placeholder"
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "disabledExample",
+		label: "Disabled",
+		type: "dropdown",
+		disabled: true,
+		size: "md",
+		inputSettings: {
+			options,
+			placeholder: "placeholder"
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "xsSize",
+		label: "Size xs",
+		type: "dropdown",
+		size: "xs",
+		inputSettings: {
+			options,
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "smSize",
+		label: "Size sm",
+		type: "dropdown",
+		size: "sm",
+		inputSettings: {
+			options,
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "mdSize",
+		label: "Size md",
+		type: "dropdown",
+		size: "md",
+		inputSettings: {
+			options,
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "lgSize",
+		label: "Size lg",
+		type: "dropdown",
+		size: "lg",
+		inputSettings: {
+			options,
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+] as FieldDef<DropdownSingleSelectionDef>[];
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
-
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title='Form title'
-// 				description='Form description'
-// 				state={state}
-// 				fields={kitchenSinkFields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: excludedFormFieldsControls } };
+KitchenSink.args = {
+	fields: kitchenSinkFields,
+};

--- a/src/forms/FormFieldImageUpload/FormFieldImageUpload.stories.mdx
+++ b/src/forms/FormFieldImageUpload/FormFieldImageUpload.stories.mdx
@@ -12,8 +12,3 @@ import * as stories from './FormFieldImageUpload.stories';
 
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldImageUpload/FormFieldImageUploadTypes.ts
 
-## ImageUpload Example
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldImageUpload/FormFieldImageUpload.stories.tsx
+++ b/src/forms/FormFieldImageUpload/FormFieldImageUpload.stories.tsx
@@ -1,123 +1,132 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { boolean, text, withKnobs } from "@storybook/addon-knobs";
-// import { ImageUploadDef } from ".";
-// import { FieldDef } from "@root/components/Field";
+import * as React from "react";
+import { useMemo } from "react";
+import { ImageUploadDef } from ".";
+import { FieldDef } from "@root/components/Field";
 
 // Components
-// import Form, { useForm } from "@root/components/Form";
+import Form, { useForm } from "@root/components/Form";
 
 // Utils
-// import { menuOptions } from "@root/forms/MenuFormFieldCard/MenuFormFieldUtils";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
+import { menuOptions } from "@root/forms/MenuFormFieldCard/MenuFormFieldUtils";
+import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
 
-// export default {
-// 	title: "FormFields/FormFieldImageUpload",
-// 	decorators: [withKnobs],
-// };
+export default {
+	title: "FormFields/FormFieldImageUpload",
+	component: Form,
+};
 
-// const handleSetFocus = () => {
-// 	alert("Set focus is called");
-// };
+const handleSetFocus = () => {
+	alert("Set focus is called");
+};
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		disabled,
+		required,
+		label,
+		fields,
+		helperText,
+		instructionText,
+		showMenu,
+		withSetFocusCallback,
+	} = args;
 
-// 	const disabled = boolean("Disabled", false);
-// 	const required = boolean("Required", false);
-// 	const label = text("Label", "Image Upload Label");
-// 	const helperText = text("Helper text", "Helper text");
-// 	const instructionText = text("Instruction text", "Instruction text");
-// 	const showMenu = boolean("Show menu", true);
-// 	const withSetFocusCallback = boolean("With set focus callback", true);
+	const playgroundFields = useMemo(
+		() =>
+			[
+				{
+					name: "imageUpload",
+					label,
+					type: "imageUpload",
+					required,
+					disabled,
+					helperText,
+					instructionText,
+					inputSettings: {
+						options: showMenu && menuOptions,
+						handleSetFocus: withSetFocusCallback && handleSetFocus,
+					},
+				},
+			] as FieldDef<ImageUploadDef>[],
+		[
+			required,
+			disabled,
+			showMenu,
+			instructionText,
+			helperText,
+			label,
+			withSetFocusCallback
+		]
+	);
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "imageUpload",
-// 					label,
-// 					type: "imageUpload",
-// 					required,
-// 					disabled,
-// 					helperText,
-// 					instructionText,
-// 					inputSettings: {
-// 						options: showMenu && menuOptions,
-// 						handleSetFocus: withSetFocusCallback && handleSetFocus,
-// 					},
-// 				},
-// 			] as FieldDef<ImageUploadDef>[],
-// 		[required, disabled, showMenu, instructionText, helperText, label]
-// 	);
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields ? fields : playgroundFields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	disabled: false,
+	helperText: "Helper text",
+	label: "Label",
+	instructionText: "Instruction text",
+	required: false,
+	withSetFocusCallback: false,
+	showMenu: true,
+};
 
-// const kitchenSinkFields = [
-// 	{
-// 		name: "imageUploadWithMenu",
-// 		label: "Image Upload with menu options and without setFocus handler",
-// 		type: "imageUpload",
-// 		required: false,
-// 		disabled: false,
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 		inputSettings: {
-// 			options: menuOptions,
-// 		},
-// 	},
-// 	{
-// 		name: "imageUploadwithSetFocus",
-// 		label: "Image Upload with set focus callback",
-// 		type: "imageUpload",
-// 		required: false,
-// 		disabled: false,
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 		inputSettings: {
-// 			handleSetFocus: handleSetFocus,
-// 		},
-// 	},
-// 	{
-// 		name: "imageUploadDisabled",
-// 		label: "Image Upload disabled",
-// 		type: "imageUpload",
-// 		required: false,
-// 		disabled: true,
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// ] as FieldDef<ImageUploadDef>[];
+const kitchenSinkFields = [
+	{
+		name: "imageUploadWithMenu",
+		label: "Image Upload with menu options and without setFocus handler",
+		type: "imageUpload",
+		required: false,
+		disabled: false,
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+		inputSettings: {
+			options: menuOptions,
+		},
+	},
+	{
+		name: "imageUploadwithSetFocus",
+		label: "Image Upload with set focus callback",
+		type: "imageUpload",
+		required: false,
+		disabled: false,
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+		inputSettings: {
+			handleSetFocus: handleSetFocus,
+		},
+	},
+	{
+		name: "imageUploadDisabled",
+		label: "Image Upload disabled",
+		type: "imageUpload",
+		required: false,
+		disabled: true,
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+] as FieldDef<ImageUploadDef>[];
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: excludedFormFieldsControls } };
+KitchenSink.args = {
+	fields: kitchenSinkFields,
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={"Form Title"}
-// 				description={"This is a description example"}
-// 				state={state}
-// 				fields={kitchenSinkFields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };

--- a/src/forms/FormFieldImageUpload/FormFieldImageUpload.stories.tsx
+++ b/src/forms/FormFieldImageUpload/FormFieldImageUpload.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { useMemo } from "react";
 import { ImageUploadDef } from ".";
-import { FieldDef } from "@root/components/Field";
+import FormFieldImageUpload, { FieldDef } from "@root/components/Field";
+import { ComponentMeta } from "@storybook/react";
 
 // Components
 import Form, { useForm } from "@root/components/Form";
@@ -12,8 +13,8 @@ import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils
 
 export default {
 	title: "FormFields/FormFieldImageUpload",
-	component: Form,
-};
+	component: FormFieldImageUpload,
+} as ComponentMeta<typeof FormFieldImageUpload>;
 
 const handleSetFocus = () => {
 	alert("Set focus is called");

--- a/src/forms/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsing.stories.mdx
+++ b/src/forms/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsing.stories.mdx
@@ -12,8 +12,3 @@ The setup supports images, videos, documents or links.
 
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsingTypes.tsx
 
-## ImageVideoLinkDocumentBrowsing Example
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsing.stories.tsx
+++ b/src/forms/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsing.stories.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
 import { useMemo } from "react";
-import { FieldDef } from "@root/components/Field";
+import FormFieldImageVideoLinkDocumentBrowsing, { FieldDef } from "@root/components/Field";
 import { ImageVideoDocumentLinkBrowsingDef } from ".";
 import {
 	excludedFormFieldsControls,
 	onCancel,
 	renderButtons,
 } from "@root/utils/storyUtils";
+import { ComponentMeta } from "@storybook/react";
 
 // Components
 import Form, { useForm } from "@root/components/Form";
@@ -20,8 +21,8 @@ import {
 
 export default {
 	title: "FormFields/FormFieldImageVideoLinkDocumentBrowsing",
-	component: Form,
-};
+	component: FormFieldImageVideoLinkDocumentBrowsing,
+} as ComponentMeta<typeof FormFieldImageVideoLinkDocumentBrowsing>;
 
 const Template = (args) => {
 	const { state, dispatch } = useForm();

--- a/src/forms/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsing.stories.tsx
+++ b/src/forms/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsing.stories.tsx
@@ -1,203 +1,282 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { text, withKnobs, boolean } from "@storybook/addon-knobs";
-// import { FieldDef } from "@root/components/Field";
-// import { ImageVideoDocumentLinkBrowsingDef, } from ".";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
+import * as React from "react";
+import { useMemo } from "react";
+import { FieldDef } from "@root/components/Field";
+import { ImageVideoDocumentLinkBrowsingDef } from ".";
+import {
+	excludedFormFieldsControls,
+	onCancel,
+	renderButtons,
+} from "@root/utils/storyUtils";
 
-// // Components
-// import Form, { useForm } from "@root/components/Form";
+// Components
+import Form, { useForm } from "@root/components/Form";
 
-// // Utils
-// // import { menuOptions } from "@root/forms/MenuFormFieldCard/MenuFormFieldUtils";
-// import { useImageVideoLinkDocumentBrowsing, imageVideoSrc } from "./ImageVideoLinkDocumentBrowsingUtils";
+// Utils
+import { menuOptions } from "@root/forms/MenuFormFieldCard/MenuFormFieldUtils";
+import {
+	useImageVideoLinkDocumentBrowsing,
+	imageVideoSrc,
+} from "./ImageVideoLinkDocumentBrowsingUtils";
 
-// export default {
-// 	title: "FormFields/FormFieldImageVideoLinkDocumentBrowsing",
-// 	decorators: [withKnobs],
-// };
+export default {
+	title: "FormFields/FormFieldImageVideoLinkDocumentBrowsing",
+	component: Form,
+};
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
-// 	const { setImage, setVideo, setDocument, setLink, handleRemove } = useImageVideoLinkDocumentBrowsing(dispatch, "imageVideoLinkDocumentBrowsing");
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		setImage,
+		setVideo,
+		setDocument,
+		setLink,
+		handleRemove,
+	} = useImageVideoLinkDocumentBrowsing(
+		dispatch,
+		"imageVideoLinkDocumentBrowsing"
+	);
+	const {
+		label,
+		disabled,
+		helperText,
+		instructionText,
+		required,
+		withVideoOption,
+		withDocumentOption,
+		withImageOption,
+		withLinkOption,
+		withImage,
+		src,
+	} = args;
 
-// 	const label = text("Label", "Label");
-// 	const disabled = boolean("Disabled", false);
-// 	const required = boolean("Required", false);
-// 	const withVideoOption = boolean("Show video browsing option", false);
-// 	const withDocumentOption = boolean("Show document browsing option", false);
-// 	const withImageOption = boolean("Show image browsing option", true);
-// 	const withLinkOption = boolean("Show link browsing option", false);
-// 	const withImage = boolean("Show image", true);
+	const fields = useMemo(
+		() =>
+			[
+				{
+					name: "imageVideoLinkDocumentBrowsing",
+					label,
+					helperText,
+					instructionText,
+					type: "imageVideoDocumentLink",
+					required,
+					disabled,
+					inputSettings: {
+						options: menuOptions,
+						handleSetImage: withImageOption ? setImage : undefined,
+						handleSetDocument: withDocumentOption ? setDocument : undefined,
+						handleSetVideo: withVideoOption ? setVideo : undefined,
+						handleSetLink: withLinkOption ? setLink : undefined,
+						handleRemove,
+						src: withImage && src,
+					},
+				},
+			] as FieldDef<ImageVideoDocumentLinkBrowsingDef>[],
+		[
+			label,
+			required,
+			disabled,
+			menuOptions,
+			setImage,
+			withLinkOption,
+			setLink,
+			withDocumentOption,
+			setDocument,
+			withVideoOption,
+			setVideo,
+		]
+	);
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "imageVideoLinkDocumentBrowsing",
-// 					label,
-// 					type: "imageVideoDocumentLink",
-// 					required,
-// 					disabled,
-// 					inputSettings: {
-// 						options: menuOptions,
-// 						handleSetImage: withImageOption ? setImage : undefined,
-// 						handleSetDocument: withDocumentOption ? setDocument : undefined,
-// 						handleSetVideo: withVideoOption ? setVideo : undefined,
-// 						handleSetLink: withLinkOption ? setLink : undefined,
-// 						handleRemove,
-// 						src: withImage && imageVideoSrc
-// 					},
-// 				}
-// 			] as FieldDef<ImageVideoDocumentLinkBrowsingDef>[],
-// 		[label, required, disabled, menuOptions, setImage, withLinkOption, setLink, withDocumentOption, setDocument, withVideoOption, setVideo]
-// 	);
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	label: "Label",
+	required: false,
+	disabled: false,
+	instructionText: "Instruction text",
+	helperText: "Helper text",
+	withVideoOption: false,
+	withDocumentOption: false,
+	withLinkOption: false,
+	withImageOption: true,
+	withImage: true,
+	src: imageVideoSrc,
+};
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
-// 	const { setImage, setVideo, setDocument, setLink, handleRemove } = useImageVideoLinkDocumentBrowsing(dispatch, "browseAllOptions");
-// 	const { setImage: browseImage, handleRemove: removeImage } = useImageVideoLinkDocumentBrowsing(dispatch, "browseImage");
-// 	const { setVideo: browseVideo, handleRemove: removeVideo } = useImageVideoLinkDocumentBrowsing(dispatch, "browseVideo");
-// 	const { setDocument: browseDocument, handleRemove: removeDocument } = useImageVideoLinkDocumentBrowsing(dispatch, "browseDocument");
-// 	const { setLink: browseLink, handleRemove: removeLink } = useImageVideoLinkDocumentBrowsing(dispatch, "browseLink");
-// 	const { setVideo: setVideoWithoutSrc, setImage: setImageWithoutSrc, handleRemove: removeImageOrVideo } = useImageVideoLinkDocumentBrowsing(dispatch, "browseImageOrVideo");
-// 	const { setImage: setImageDisabled } = useImageVideoLinkDocumentBrowsing(dispatch, "disabledExample");
 
-// const fields = useMemo(
-// 	() =>
-// 		[
-// 			{
-// 				name: "browseAllOptions",
-// 				label: "Example with all types of browsing options (document, link, video and image) enabled",
-// 				type: "imageVideoDocumentLink",
-// 				required: false,
-// 				disabled: false,
-// 				inputSettings: {
-// 					options: menuOptions,
-// 					handleSetImage: setImage,
-// 					handleSetDocument: setDocument,
-// 					handleSetVideo: setVideo,
-// 					handleSetLink: setLink,
-// 					handleRemove,
-// 					src: imageVideoSrc
-// 				},
-// 			},
-// 			{
-// 				name: "browseImageOrVideo",
-// 				label: "Browsing and image or video without a src image specified",
-// 				type: "imageVideoDocumentLink",
-// 				required: false,
-// 				disabled: false,
-// 				inputSettings: {
-// 					options: menuOptions,
-// 					handleSetImage: setImageWithoutSrc,
-// 					handleSetVideo: setVideoWithoutSrc,
-// 					handleRemove: removeImageOrVideo
-// 				},
-// 			},
-// 			{
-// 				name: "browseImage",
-// 				label: "Browsing an image",
-// 				type: "imageVideoDocumentLink",
-// 				required: false,
-// 				disabled: false,
-// 				inputSettings: {
-// 					options: menuOptions,
-// 					handleSetImage: browseImage,
-// 					handleRemove: removeImage,
-// 					src: imageVideoSrc
-// 				},
-// 			},
-// 			{
-// 				name: "browseVideo",
-// 				label: "Browsing a video",
-// 				type: "imageVideoDocumentLink",
-// 				required: false,
-// 				disabled: false,
-// 				inputSettings: {
-// 					options: menuOptions,
-// 					handleSetVideo: browseVideo,
-// 					handleRemove: removeVideo,
-// 					src: imageVideoSrc,
-// 				},
-// 			},
-// 			{
-// 				name: "browseDocument",
-// 				label: "Browsing a document",
-// 				type: "imageVideoDocumentLink",
-// 				required: false,
-// 				disabled: false,
-// 				inputSettings: {
-// 					options: menuOptions,
-// 					handleSetDocument: browseDocument,
-// 					handleRemove: removeDocument
-// 				},
-// 			},
-// 			{
-// 				name: "browseLink",
-// 				label: "Browsing a link",
-// 				type: "imageVideoDocumentLink",
-// 				required: false,
-// 				disabled: false,
-// 				inputSettings: {
-// 					options: menuOptions,
-// 					handleSetLink: browseLink,
-// 					handleRemove: removeLink
-// 				},
-// 			},
-// 			{
-// 				name: "withoutAnyBrowsingOption",
-// 				label: "Without any browsing option",
-// 				type: "imageVideoDocumentLink",
-// 				required: false,
-// 				disabled: false,
-// 				inputSettings: {
-// 					options: menuOptions,
-// 				},
-// 			},
-// 			{
-// 				name: "disabledExample",
-// 				label: "Disabled example",
-// 				type: "imageVideoDocumentLink",
-// 				required: false,
-// 				disabled: true,
-// 				inputSettings: {
-// 					options: menuOptions,
-// 					handleSetImage: setImageDisabled
-// 				},
-// 			},
-// 		] as FieldDef<ImageVideoDocumentLinkBrowsingDef>[],
-// 	[menuOptions, setImage, setVideo, setDocument, handleRemove]
-// );
+const KitchenSinkTemplate = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		setImage,
+		setVideo,
+		setDocument,
+		setLink,
+		handleRemove,
+	} = useImageVideoLinkDocumentBrowsing(dispatch, "browseAllOptions");
+	const {
+		setImage: browseImage,
+		handleRemove: removeImage,
+	} = useImageVideoLinkDocumentBrowsing(dispatch, "browseImage");
+	const {
+		setVideo: browseVideo,
+		handleRemove: removeVideo,
+	} = useImageVideoLinkDocumentBrowsing(dispatch, "browseVideo");
+	const {
+		setDocument: browseDocument,
+		handleRemove: removeDocument,
+	} = useImageVideoLinkDocumentBrowsing(dispatch, "browseDocument");
+	const {
+		setLink: browseLink,
+		handleRemove: removeLink,
+	} = useImageVideoLinkDocumentBrowsing(dispatch, "browseLink");
+	const {
+		setVideo: setVideoWithoutSrc,
+		setImage: setImageWithoutSrc,
+		handleRemove: removeImageOrVideo,
+	} = useImageVideoLinkDocumentBrowsing(dispatch, "browseImageOrVideo");
+	const { setImage: setImageDisabled } = useImageVideoLinkDocumentBrowsing(
+		dispatch,
+		"disabledExample"
+	);
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+	const fields = useMemo(
+		() =>
+			[
+				{
+					name: "browseAllOptions",
+					label:
+						"Example with all types of browsing options (document, link, video and image) enabled",
+					type: "imageVideoDocumentLink",
+					required: false,
+					disabled: false,
+					inputSettings: {
+						options: menuOptions,
+						handleSetImage: setImage,
+						handleSetDocument: setDocument,
+						handleSetVideo: setVideo,
+						handleSetLink: setLink,
+						handleRemove,
+						src: imageVideoSrc,
+					},
+				},
+				{
+					name: "browseImageOrVideo",
+					label: "Browsing and image or video without a src image specified",
+					type: "imageVideoDocumentLink",
+					required: false,
+					disabled: false,
+					inputSettings: {
+						options: menuOptions,
+						handleSetImage: setImageWithoutSrc,
+						handleSetVideo: setVideoWithoutSrc,
+						handleRemove: removeImageOrVideo,
+					},
+				},
+				{
+					name: "browseImage",
+					label: "Browsing an image",
+					type: "imageVideoDocumentLink",
+					required: false,
+					disabled: false,
+					inputSettings: {
+						options: menuOptions,
+						handleSetImage: browseImage,
+						handleRemove: removeImage,
+						src: imageVideoSrc,
+					},
+				},
+				{
+					name: "browseVideo",
+					label: "Browsing a video",
+					type: "imageVideoDocumentLink",
+					required: false,
+					disabled: false,
+					inputSettings: {
+						options: menuOptions,
+						handleSetVideo: browseVideo,
+						handleRemove: removeVideo,
+						src: imageVideoSrc,
+					},
+				},
+				{
+					name: "browseDocument",
+					label: "Browsing a document",
+					type: "imageVideoDocumentLink",
+					required: false,
+					disabled: false,
+					inputSettings: {
+						options: menuOptions,
+						handleSetDocument: browseDocument,
+						handleRemove: removeDocument,
+					},
+				},
+				{
+					name: "browseLink",
+					label: "Browsing a link",
+					type: "imageVideoDocumentLink",
+					required: false,
+					disabled: false,
+					inputSettings: {
+						options: menuOptions,
+						handleSetLink: browseLink,
+						handleRemove: removeLink,
+					},
+				},
+				{
+					name: "withoutAnyBrowsingOption",
+					label: "Without any browsing option",
+					type: "imageVideoDocumentLink",
+					required: false,
+					disabled: false,
+					inputSettings: {
+						options: menuOptions,
+					},
+				},
+				{
+					name: "disabledExample",
+					label: "Disabled example",
+					type: "imageVideoDocumentLink",
+					required: false,
+					disabled: true,
+					inputSettings: {
+						options: menuOptions,
+						handleSetImage: setImageDisabled,
+					},
+				},
+			] as FieldDef<ImageVideoDocumentLinkBrowsingDef>[],
+		[menuOptions, setImage, setVideo, setDocument, handleRemove]
+	);
+
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
+
+export const KitchenSink = KitchenSinkTemplate.bind({});
+KitchenSink.parameters = { controls: { exclude: excludedFormFieldsControls } };

--- a/src/forms/FormFieldMapCoordinates/MapCoordinates.stories.mdx
+++ b/src/forms/FormFieldMapCoordinates/MapCoordinates.stories.mdx
@@ -8,8 +8,3 @@ import * as stories from './MapCoordinates.stories';
 ## Props
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldMapCoordinates/MapCoordinatesTypes.ts
 
-## MapCoordinates Example
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldMapCoordinates/MapCoordinates.stories.tsx
+++ b/src/forms/FormFieldMapCoordinates/MapCoordinates.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { useMemo } from "react";
 import { FieldDef } from "@root/components/Field";
-import { MapCoordinatesDef } from ".";
+import FormFieldMapCoordinates, { MapCoordinatesDef } from ".";
 import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
+import { ComponentMeta } from "@storybook/react";
 
 // Components
 import Form, { useForm } from "@root/components/Form";
@@ -12,11 +13,11 @@ import { address, defaultMapPosition } from "./MapCoordinatesUtils";
 
 export default {
 	title: "FormFields/FormFieldMapCoordinates",
-	component: Form,
+	component: FormFieldMapCoordinates,
 	argTypes: {
 		zoom: { control: { type: "number", min: 0, max: 18 } }
 	}
-};
+} as ComponentMeta<typeof FormFieldMapCoordinates>;
 
 const Template = (args) => {
 	const { state, dispatch } = useForm();

--- a/src/forms/FormFieldMapCoordinates/MapCoordinates.stories.tsx
+++ b/src/forms/FormFieldMapCoordinates/MapCoordinates.stories.tsx
@@ -1,143 +1,148 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { boolean, withKnobs, object, text, number } from "@storybook/addon-knobs";
-// import { FieldDef } from "@root/components/Field";
-// import { MapCoordinatesDef } from ".";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
+import * as React from "react";
+import { useMemo } from "react";
+import { FieldDef } from "@root/components/Field";
+import { MapCoordinatesDef } from ".";
+import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
 
-// // Components
-// import Form, { useForm } from "@root/components/Form";
+// Components
+import Form, { useForm } from "@root/components/Form";
 
-// // Utils
-// // import { address, defaultMapPosition } from "./MapCoordinatesUtils";
+// Utils
+import { address, defaultMapPosition } from "./MapCoordinatesUtils";
 
-// export default {
-// 	title: "FormFields/FormFieldMapCoordinates",
-// 	decorators: [withKnobs],
-// };
+export default {
+	title: "FormFields/FormFieldMapCoordinates",
+	component: Form,
+	argTypes: {
+		zoom: { control: { type: "number", min: 0, max: 18 } }
+	}
+};
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		address,
+		disabled,
+		label,
+		initialMapPosition,
+		required,
+		withAddress,
+		zoom,
+		fields
+	} = args;
 
-// 	const addressKnob = object("Address", address);
-// 	const disabled = boolean("Disabled", false);
-// 	const label = text("Label", "Map Coordinates Example");
-// 	const mapPositionKnob = object("Initial map position", defaultMapPosition);
-// 	const required = boolean("Required", false);
-// 	const withAddress = boolean("With address", false);
-//	const zoom = number("Zoom", 7, { min: 0, max: 18 });
+	const playgroundFields = useMemo(
+		() =>
+			[
+				{
+					name: "map",
+					label,
+					type: "mapCoordinates",
+					required,
+					disabled,
+					inputSettings: {
+						apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
+						address: withAddress ? address : {},
+						mapPosition: initialMapPosition,
+						zoom: zoom,
+					},
+				},
+			] as FieldDef<MapCoordinatesDef>[],
+		[address, disabled, label, initialMapPosition, required, withAddress, zoom]
+	);
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "map",
-// 					label,
-// 					type: "mapCoordinates",
-// 					required,
-// 					disabled,
-// 					inputSettings: {
-// 						apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
-// 						address: withAddress ? addressKnob : {},
-// 						mapPosition: mapPositionKnob,
-// 						zoom: zoom
-// 					},
-// 				},
-// 			] as FieldDef<MapCoordinatesDef>[],
-// 		[addressKnob, disabled, label, mapPositionKnob, required, withAddress, zoom]
-// 	);
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields ? fields : playgroundFields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	label: "Label",
+	required: false,
+	disabled: false,
+	instructionText: "Instruction text",
+	helperText: "Helper text",
+	address,
+	initialMapPosition: defaultMapPosition,
+	withAddress: false,
+	zoom: 7
+};
 
-// const kitchenSinkFields = [
-// 	{
-// 		name: "mapWithoutAddress",
-// 		label: "Map without an address. Autocoordinates disabled",
-// 		type: "mapCoordinates",
-// 		required: false,
-// 		disabled: false,
-// 		inputSettings: {
-// 			apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
-// 		},
-// 	},
-// 	{
-// 		name: "mapZoom",
-// 		label: "Map with zoom set to 8",
-// 		type: "mapCoordinates",
-// 		required: false,
-// 		disabled: false,
-// 		inputSettings: {
-// 			apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
-// 			zoom: 8,
-// 			mapPosition: { lat: 40.7127753, lng: -74.0059728 }
-// 		},
-// 	},
-// 	{
-// 		name: "mapWithAddress",
-// 		label: "Map with an address. Autocoordinates enabled",
-// 		type: "mapCoordinates",
-// 		required: false,
-// 		disabled: false,
-// 		inputSettings: {
-// 			apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
-// 			address: address,
-// 			mapPosition: { lat: 40.7127753, lng: -74.0059728 }
-// 		},
-// 	},
-// 	{
-// 		name: "mapWithInitalPosition",
-// 		label: "Map with an inital map position set",
-// 		type: "mapCoordinates",
-// 		required: false,
-// 		disabled: false,
-// 		inputSettings: {
-// 			apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
-// 			address: address,
-// 			mapPosition: { lat: 19.3884403, lng: -99.1747252 }
-// 		},
-// 	},
-// 	{
-// 		name: "mapDisabled",
-// 		label: "Map disabled",
-// 		type: "mapCoordinates",
-// 		required: false,
-// 		disabled: true,
-// 		inputSettings: {
-// 			apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
-// 			address: address
-// 		},
-// 	}
-// ] as FieldDef<MapCoordinatesDef>[];
+const kitchenSinkFields = [
+	{
+		name: "mapWithoutAddress",
+		label: "Map without an address. Autocoordinates disabled",
+		type: "mapCoordinates",
+		required: false,
+		disabled: false,
+		inputSettings: {
+			apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
+		},
+	},
+	{
+		name: "mapZoom",
+		label: "Map with zoom set to 8",
+		type: "mapCoordinates",
+		required: false,
+		disabled: false,
+		inputSettings: {
+			apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
+			zoom: 8,
+			mapPosition: { lat: 40.7127753, lng: -74.0059728 }
+		},
+	},
+	{
+		name: "mapWithAddress",
+		label: "Map with an address. Autocoordinates enabled",
+		type: "mapCoordinates",
+		required: false,
+		disabled: false,
+		inputSettings: {
+			apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
+			address: address,
+			mapPosition: { lat: 40.7127753, lng: -74.0059728 }
+		},
+	},
+	{
+		name: "mapWithInitalPosition",
+		label: "Map with an inital map position set",
+		type: "mapCoordinates",
+		required: false,
+		disabled: false,
+		inputSettings: {
+			apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
+			address: address,
+			mapPosition: { lat: 19.3884403, lng: -99.1747252 }
+		},
+	},
+	{
+		name: "mapDisabled",
+		label: "Map disabled",
+		type: "mapCoordinates",
+		required: false,
+		disabled: true,
+		inputSettings: {
+			apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
+			address: address
+		},
+	}
+] as FieldDef<MapCoordinatesDef>[];
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
-
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title='Form Title'
-// 				description='This is a description example'
-// 				state={state}
-// 				fields={kitchenSinkFields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: [...excludedFormFieldsControls ,"zoom"] } };
+KitchenSink.args = {
+	fields: kitchenSinkFields,
+};

--- a/src/forms/FormFieldMapCoordinates/MapCoordinates.test.tsx
+++ b/src/forms/FormFieldMapCoordinates/MapCoordinates.test.tsx
@@ -137,9 +137,9 @@ jest.mock("@react-google-maps/api", () => ({
 		isLoaded: true,
 		loadError: null,
 	}),
-	// eslint-disable-next-line react/display-name
+	// eslint-disable-next-line
 	GoogleMap: () => <div>Mocked Google Map Component</div>,
-	// eslint-disable-next-line react/display-name
+	// eslint-disable-next-line
 	Marker: () => <div />,
 }));
 

--- a/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.stories.mdx
+++ b/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.stories.mdx
@@ -7,15 +7,9 @@ import * as stories from './FormFieldPhoneSelectionDropdown.stories';
 
 The `FormFieldPhoneSelectionDropdown` component is built over [React-Phone-Input-2](https://www.npmjs.com/package/react-phone-input-2) but with SimpleView brand colors.
 
-The phone selection dropdown is useful when you want to allow users to enter the information of phone numbers, is conformed with the selection of the country in the 
+The phone selection dropdown is useful when you want to allow users to enter the information of phone numbers, is conformed with the selection of the country in the
 dropdown that contains the country flag, and automatically the prefix and number or characters placeholder are showed.
 
 ## Props
 
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
-
-## FormFieldPhoneSelectionDropdown
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.stories.tsx
+++ b/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.stories.tsx
@@ -1,135 +1,144 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { boolean, withKnobs, text } from "@storybook/addon-knobs";
-// import { PhoneSelectionDef } from "./FormFieldPhoneSelectionDropdownTypes";
-// import { FieldDef } from "@root/components/Field";
-// import Form, { useForm } from "@root/components/Form";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
+import * as React from "react";
+import { useMemo } from "react";
+import { PhoneSelectionDef } from "./FormFieldPhoneSelectionDropdownTypes";
+import { FieldDef } from "@root/components/Field";
+import Form, { useForm } from "@root/components/Form";
+import {
+	excludedFormFieldsControls,
+	onCancel,
+	renderButtons,
+} from "@root/utils/storyUtils";
 
+export default {
+	title: "FormFields/FormFieldPhoneSelectionDropdown",
+	component: Form,
+};
 
-// export default {
-// 	title: "FormFields/FormFieldPhoneSelectionDropdown",
-// 	decorators: [withKnobs],
-// };
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		label,
+		required,
+		disabled,
+		autoFormat,
+		country,
+		placeholder,
+		helperText,
+		instructionText,
+		fields,
+	} = args;
 
-// export const Playground = () : ReactElement => {
-// 	const { state, dispatch } = useForm();
+	const playgroudFields = useMemo(
+		() =>
+			[
+				{
+					name: "phone",
+					label,
+					type: "phone",
+					required,
+					disabled,
+					inputSettings: {
+						autoFormat,
+						country,
+						placeholder,
+					},
+					helperText,
+					instructionText,
+				},
+			] as FieldDef<PhoneSelectionDef>[],
+		[
+			disabled,
+			required,
+			autoFormat,
+			country,
+			placeholder,
+			label,
+			helperText,
+			instructionText,
+		]
+	);
 
-// 	const disabled = boolean("Disabled", false);
-// 	const required = boolean("Required", false);
-// 	const autoFormat = boolean("Autoformat", true);
-// 	const country = text("Country code (e.g., us, mx, etc.)", "");
-// 	const placeholder = text("Placeholder", "Placeholder");
-// 	const label = text("Label", "Label");
-// 	const helperText = text("Helper text", "Helper text");
-// 	const instructionText = text("Instruction text", "Instruction text")
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields ? fields : playgroudFields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "phone",
-// 					label,
-// 					type: "phone",
-// 					required,
-// 					disabled,
-// 					inputSettings: {
-// 						autoFormat,
-// 						country,
-// 						placeholder,
-// 					},
-// 					helperText,
-// 					instructionText
-// 				},
-// 			] as FieldDef<PhoneSelectionDef>[],
-// 		[disabled, required, autoFormat, country, placeholder, label, helperText, instructionText]
-// 	);
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	label: "Label",
+	required: false,
+	disabled: false,
+	instructionText: "Instruction text",
+	helperText: "Helper text",
+	autoFormat: true,
+	country: "",
+	placeholder: "placeholder",
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// }
+const kitchenSinkFields = [
+	{
+		name: "phone",
+		label: "Regular example",
+		type: "phone",
+		required: false,
+		disabled: false,
+		helperText: "Helper text",
+		instructionText: 'Default contry code is "us"',
+	},
+	{
+		name: "countryCode",
+		label: "With a country code provided",
+		type: "phone",
+		required: false,
+		disabled: false,
+		inputSettings: {
+			country: "ar",
+		},
+		helperText: "Helper text",
+		instructionText: 'The country code of "ar" was provided',
+	},
+	{
+		name: "autoformatEnabled",
+		label: "Autoformat enabled",
+		type: "phone",
+		required: false,
+		disabled: false,
+		inputSettings: {
+			autoFormat: true,
+			country: "us",
+		},
+		helperText: "Helper text",
+		instructionText: "Type a phone number to see the format",
+	},
+	{
+		name: "withPlaceholder",
+		label: "With a custom placeholder",
+		type: "phone",
+		required: false,
+		disabled: false,
+		inputSettings: {
+			country: "us",
+			placeholder: "Enter phone number",
+		},
+		helperText: "Helper text",
+		instructionText: "Remove the phone number prefix to see the placeholder",
+	},
+] as FieldDef<PhoneSelectionDef>[];
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
-
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "phone",
-// 					label: "Regular example",
-// 					type: "phone",
-// 					required: false,
-// 					disabled: false,
-// 					helperText: "Helper text",
-// 					instructionText: 'Default contry code is "us"',
-// 				},
-// 				{
-// 					name: "countryCode",
-// 					label: "With a country code provided",
-// 					type: "phone",
-// 					required: false,
-// 					disabled: false,
-// 					inputSettings: {
-// 						country: "ar",
-// 					},
-// 					helperText: "Helper text",
-// 					instructionText: 'The country code of "ar" was provided',
-// 				},
-// 				{
-// 					name: "autoformatEnabled",
-// 					label: "Autoformat enabled",
-// 					type: "phone",
-// 					required: false,
-// 					disabled: false,
-// 					inputSettings: {
-// 						autoFormat: true,
-// 						country: "us",
-// 					},
-// 					helperText: "Helper text",
-// 					instructionText: "Type a phone number to see the format",
-// 				},
-// 				{
-// 					name: "withPlaceholder",
-// 					label: "With a custom placeholder",
-// 					type: "phone",
-// 					required: false,
-// 					disabled: false,
-// 					inputSettings: {
-// 						country: "us",
-// 						placeholder: "Enter phone number"
-// 					},
-// 					helperText: "Helper text",
-// 					instructionText: "Remove the phone number prefix to see the placeholder",
-// 				},
-// 			] as FieldDef<PhoneSelectionDef>[],
-// 		[]
-// 	);
-
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title='Form Title'
-// 				description='Form description'
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: excludedFormFieldsControls } };
+KitchenSink.args = {
+	fields: kitchenSinkFields,
+};

--- a/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.stories.tsx
+++ b/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.stories.tsx
@@ -1,18 +1,19 @@
 import * as React from "react";
 import { useMemo } from "react";
 import { PhoneSelectionDef } from "./FormFieldPhoneSelectionDropdownTypes";
-import { FieldDef } from "@root/components/Field";
+import FormFieldPhoneSelectionDropdown, { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
 import {
 	excludedFormFieldsControls,
 	onCancel,
 	renderButtons,
 } from "@root/utils/storyUtils";
+import { ComponentMeta } from "@storybook/react";
 
 export default {
 	title: "FormFields/FormFieldPhoneSelectionDropdown",
-	component: Form,
-};
+	component: FormFieldPhoneSelectionDropdown,
+} as ComponentMeta<typeof FormFieldPhoneSelectionDropdown>;
 
 const Template = (args) => {
 	const { state, dispatch } = useForm();

--- a/src/forms/FormFieldRadio/FormFieldRadio.stories.mdx
+++ b/src/forms/FormFieldRadio/FormFieldRadio.stories.mdx
@@ -14,9 +14,3 @@ The `FormFieldRadio` component is built over a wrapper for [MUI Radio](https://m
 ## Props
 
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldRadio/FormFieldRadio.tsx
-
-## FormFieldRadio
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldRadio/FormFieldRadio.stories.tsx
+++ b/src/forms/FormFieldRadio/FormFieldRadio.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useMemo } from "react";
-import { FormFieldRadioDef } from ".";
+import FormFieldRadio, { FormFieldRadioDef } from ".";
 import { FieldDef } from "@root/components/Field";
 import {
 	excludedFormFieldsControls,
@@ -8,11 +8,12 @@ import {
 	renderButtons,
 } from "@root/utils/storyUtils";
 import Form, { useForm } from "@root/components/Form";
+import { ComponentMeta } from "@storybook/react";
 
 export default {
 	title: "FormFields/FormFieldRadio",
-	component: Form,
-};
+	component: FormFieldRadio,
+} as ComponentMeta<typeof FormFieldRadio>;
 
 const options = [
 	{

--- a/src/forms/FormFieldRadio/FormFieldRadio.stories.tsx
+++ b/src/forms/FormFieldRadio/FormFieldRadio.stories.tsx
@@ -1,122 +1,119 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { boolean, withKnobs, text } from "@storybook/addon-knobs";
-// import { Meta } from "@storybook/addon-docs/blocks";
-// // import { FormFieldRadioDef } from ".";
-// import { FieldDef } from "@root/components/Field";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
+import * as React from "react";
+import { useMemo } from "react";
+import { FormFieldRadioDef } from ".";
+import { FieldDef } from "@root/components/Field";
+import {
+	excludedFormFieldsControls,
+	onCancel,
+	renderButtons,
+} from "@root/utils/storyUtils";
+import Form, { useForm } from "@root/components/Form";
 
-// // Components
-// import Form, { useForm } from "@root/components/Form";
+export default {
+	title: "FormFields/FormFieldRadio",
+	component: Form,
+};
 
-// export default {
-// 	title: "FormFields/FormFieldRadio",
-// 	decorators: [withKnobs],
-// } as Meta;
+const options = [
+	{
+		label: "Label 1",
+		value: "label_1",
+	},
+	{
+		label: "Label 2",
+		value: "label_2",
+	},
+	{
+		label: "Label 3",
+		value: "label_3",
+	},
+];
 
-// const options = [
-// 	{
-// 		label: "Label 1",
-// 		value: "label_1",
-// 	},
-// 	{
-// 		label: "Label 2",
-// 		value: "label_2",
-// 	},
-// 	{
-// 		label: "Label 3",
-// 		value: "label_3",
-// 	},
-// ];
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		label,
+		required,
+		disabled,
+		instructionText,
+		helperText,
+		fields,
+	} = args;
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
-// 	const label = text("Label", "Label");
-// 	const required = boolean("Required", false);
-// 	const disabled = boolean("Disabled", false);
-// 	const instructionText = text("Instruction text", "");
-// 	const helperText = text("Helper text", "");
+	const playGroundFields = useMemo(
+		() =>
+			[
+				{
+					name: "radio",
+					label,
+					type: "radio",
+					required,
+					disabled,
+					inputSettings: {
+						options,
+					},
+					helperText,
+					instructionText,
+				},
+			] as FieldDef<FormFieldRadioDef>[],
+		[label, required, disabled, instructionText, helperText]
+	);
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "radio",
-// 					label,
-// 					type: "radio",
-// 					required,
-// 					disabled,
-// 					inputSettings: {
-// 						options,
-// 					},
-// 					helperText,
-// 					instructionText,
-// 				}
-// 			] as FieldDef<FormFieldRadioDef>[],
-// 		[label, required, disabled, instructionText, helperText]
-// 	);
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields ? fields : playGroundFields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Form Title", "Form Title")}
-// 				description={text("Form Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	label: "Label",
+	required: false,
+	disabled: false,
+	instructionText: "Instruction text",
+	helperText: "Helper text",
+};
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "radio",
-// 					label: "Regular example",
-// 					type: "radio",
-// 					required: false,
-// 					disabled: false,
-// 					inputSettings: {
-// 						options,
-// 					},
-// 					helperText: "Helper text",
-// 					instructionText: "Instruction text",
-// 				},
-// 				{
-// 					name: "radio-disabled",
-// 					label: "Disabled example",
-// 					type: "radio",
-// 					required: false,
-// 					disabled: true,
-// 					inputSettings: {
-// 						options,
-// 					},
-// 					helperText: "Helper text",
-// 					instructionText: "Instruction text",
-// 				},
-// 			] as FieldDef<FormFieldRadioDef>[],
-// 		[]
-// 	);
+const kitchenSinkFields = [
+	{
+		name: "radio",
+		label: "Regular example",
+		type: "radio",
+		required: false,
+		disabled: false,
+		inputSettings: {
+			options,
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "radio-disabled",
+		label: "Disabled example",
+		type: "radio",
+		required: false,
+		disabled: true,
+		inputSettings: {
+			options,
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+];
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title='Form Title'
-// 				description='This is a description example'
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: excludedFormFieldsControls } };
+KitchenSink.args = {
+	fields: kitchenSinkFields,
+};

--- a/src/forms/FormFieldTable/FormFieldTable.tsx
+++ b/src/forms/FormFieldTable/FormFieldTable.tsx
@@ -75,9 +75,8 @@ const FormFieldTable = (props: MosaicFieldProps<TableDef, TableRow[]>): ReactEle
 		let rowDataCopy = [...rows];
 		rowDataCopy.splice(rowIndex, 1);
 
-		if (rowDataCopy.length === 0) rowDataCopy = undefined;
+		if (rowDataCopy.length === 0) rowDataCopy = [];
 
-		setRows(rowDataCopy);
 		onChange(rowDataCopy);
 	};
 
@@ -92,11 +91,13 @@ const FormFieldTable = (props: MosaicFieldProps<TableDef, TableRow[]>): ReactEle
 			row?.items?.length ? row?.items?.length : 0
 		);
 
-		const maxRowItems = Math.max(...itemsLengths);
-		const headersToAdd = maxRowItems - fieldDef?.inputSettings?.headers.length;
-		if (headersToAdd > 0) {
-			for (let i = 0; i < headersToAdd; i++) {
-				emptyHeaders.push(<Th key={`empty-header-${i}`}></Th>);
+		if (itemsLengths?.length > 0) {
+			const maxRowItems = Math.max(...itemsLengths);
+			const headersToAdd = maxRowItems - fieldDef?.inputSettings?.headers.length;
+			if (headersToAdd > 0) {
+				for (let i = 0; i < headersToAdd; i++) {
+					emptyHeaders.push(<Th key={`empty-header-${i}`}></Th>);
+				}
 			}
 		}
 
@@ -105,7 +106,7 @@ const FormFieldTable = (props: MosaicFieldProps<TableDef, TableRow[]>): ReactEle
 
 	/**
 	 * Executes the add element callback function
-	 * when the add button is clicked. 
+	 * when the add button is clicked.
 	 * @param e onClick event
 	 */
 	const addElement = (e) => {
@@ -121,7 +122,6 @@ const FormFieldTable = (props: MosaicFieldProps<TableDef, TableRow[]>): ReactEle
 						color="gray"
 						variant="outlined"
 						label="ADD ELEMENT"
-						muiAttrs={{ disableRipple: true }}
 						disabled={fieldDef?.disabled}
 						onClick={(e) => addElement(e)}
 					></Button>

--- a/src/forms/FormFieldTable/Table.stories.mdx
+++ b/src/forms/FormFieldTable/Table.stories.mdx
@@ -11,8 +11,3 @@ import * as stories from './Table.stories';
 ## Props
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldTable/TableTypes.ts
 
-## Table Example
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldTable/Table.stories.tsx
+++ b/src/forms/FormFieldTable/Table.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { useMemo } from "react";
-import { TableDef } from "./TableTypes";
+import FormFieldTable, { TableDef } from ".";
 import { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
+import { ComponentMeta } from "@storybook/react";
 
 // Utils
 import {
@@ -14,8 +15,8 @@ import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils
 
 export default {
 	title: "FormFields/FormFieldTable",
-	component: Form,
-};
+	component: FormFieldTable,
+} as ComponentMeta<typeof FormFieldTable>;
 
 const Template = (args) => {
 	const { state, dispatch } = useForm();

--- a/src/forms/FormFieldTable/Table.stories.tsx
+++ b/src/forms/FormFieldTable/Table.stories.tsx
@@ -1,172 +1,189 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { array, boolean, text, withKnobs } from "@storybook/addon-knobs";
-// import { TableDef } from "./TableTypes";
+import * as React from "react";
+import { useMemo } from "react";
+import { TableDef } from "./TableTypes";
+import { FieldDef } from "@root/components/Field";
+import Form, { useForm } from "@root/components/Form";
 
-// // Components
-// import { FieldDef } from "@root/components/Field";
-// import Form, { useForm } from "@root/components/Form";
+// Utils
+import {
+	headers,
+	deleteTableRow,
+	useTable,
+} from "@root/forms/FormFieldTable/tableUtils";
+import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
 
-// // Utils
-// // import {
-// 	headers,
-// 	deleteTableRow,
-// 	useTable,
-// } from "@root/forms/FormFieldTable/tableUtils";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
+export default {
+	title: "FormFields/FormFieldTable",
+	component: Form,
+};
 
-// export default {
-// 	title: "FormFields/FormFieldTable",
-// 	decorators: [withKnobs],
-// };
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const { addTableRow, editAction, extraActionsTable } = useTable(
+		state.data,
+		"table",
+		dispatch
+	);
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+	const {
+		disabled,
+		helperText,
+		instructionText,
+		withMoreActions,
+		headersArgs,
+		label,
+		required,
+	} = args;
 
-// 	const { addTableRow, editAction, extraActionsTable } = useTable(
-// 		state.data,
-// 		"table",
-// 		dispatch
-// 	);
+	const fields = useMemo(
+		() =>
+			[
+				{
+					disabled,
+					helperText,
+					instructionText,
+					inputSettings: {
+						handleAddElement: addTableRow,
+						handleEdit: editAction,
+						handleDelete: deleteTableRow,
+						extraActions: withMoreActions && extraActionsTable,
+						headers: headersArgs,
+					},
+					label,
+					name: "table",
+					required,
+					type: "table",
+				},
+			] as FieldDef<TableDef>[],
+		[
+			addTableRow,
+			disabled,
+			headersArgs,
+			helperText,
+			instructionText,
+			label,
+			required,
+			withMoreActions,
+		]
+	);
 
-// 	const disabled = boolean("Disabled", false);
-// 	const headersKnob = array("Headers", headers);
-// 	const helperText = text("Helper text", "Helper text");
-// 	const label = text("Label", "Label");
-// 	const instructionText = text("Instruction text", "Instruction text");
-// 	const required = boolean("Required", false);
-// 	const withMoreActions = boolean("With more actions", false);
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				description="This is a description example"
+				dispatch={dispatch}
+				fields={fields}
+				onCancel={onCancel}
+				state={state}
+				title="Form Title"
+			/>
+		</>
+	);
+};
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					disabled,
-// 					helperText,
-// 					instructionText,
-// 					inputSettings: {
-// 						handleAddElement: addTableRow,
-// 						handleEdit: editAction,
-// 						handleDelete: deleteTableRow,
-// 						extraActions: withMoreActions && extraActionsTable,
-// 						headers: headersKnob,
-// 					},
-// 					label,
-// 					name: "table",
-// 					required,
-// 					type: "table",
-// 				},
-// 			] as FieldDef<TableDef>[],
-// 		[
-// 			addTableRow,
-// 			disabled,
-// 			headersKnob,
-// 			helperText,
-// 			instructionText,
-// 			label,
-// 			required,
-// 			withMoreActions,
-// 		]
-// 	);
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	disabled: false,
+	headersArgs: headers,
+	helperText: "Helper text",
+	label: "Label",
+	instructionText: "Instruction text",
+	required: false,
+	withMoreActions: false,
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				description={text("Description", "This is a description example")}
-// 				dispatch={dispatch}
-// 				fields={fields}
-// 				onCancel={onCancel}
-// 				state={state}
-// 				title={text("Title", "Form Title")}
-// 			/>
-// 		</>
-// 	);
-// };
+const KitchenSinkTemplate = (args) => {
+	const { state, dispatch } = useForm();
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+	const { addTableRow, editAction, extraActionsTable } = useTable(
+		state.data,
+		"table",
+		dispatch
+	);
 
-// 	const { addTableRow, editAction, extraActionsTable } = useTable(
-// 		state.data,
-// 		"table",
-// 		dispatch
-// 	);
-// 	const { addTableRow: withoutHeaders } = useTable(
-// 		state.data,
-// 		"tableWithoutHeaders",
-// 		dispatch
-// 	);
+	const { addTableRow: withoutHeaders } = useTable(
+		state.data,
+		"tableWithoutHeaders",
+		dispatch
+	);
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					disabled: false,
-// 					helperText:
-// 						"The translate and the menu icons are shown to prove that the table can receive multiple actions",
-// 					instructionText: "Instruction text",
-// 					inputSettings: {
-// 						handleAddElement: addTableRow,
-// 						handleEdit: editAction,
-// 						handleDelete: deleteTableRow,
-// 						extraActions: extraActionsTable,
-// 						headers,
-// 					},
-// 					label: "Table example with extra actions",
-// 					name: "table",
-// 					required: false,
-// 					type: "table",
-// 				},
-// 				{
-// 					disabled: false,
-// 					helperText: "Default actions are the deletion and edition",
-// 					instructionText: "Instruction text",
-// 					inputSettings: {
-// 						handleAddElement: withoutHeaders,
-// 						handleEdit: editAction,
-// 						handleDelete: deleteTableRow,
-// 						extraActions: [],
-// 						headers: [],
-// 					},
-// 					label: "Table without headers and with the default actions",
-// 					name: "tableWithoutHeaders",
-// 					required: false,
-// 					type: "table",
-// 				},
-// 				{
-// 					disabled: true,
-// 					helperText: "Helper text",
-// 					instructionText: "Instruction text",
-// 					inputSettings: {
-// 						handleAddElement: withoutHeaders,
-// 						handleEdit: editAction,
-// 						handleDelete: deleteTableRow,
-// 						extraActions: [],
-// 						headers,
-// 					},
-// 					label: "Table disabled",
-// 					name: "disabled",
-// 					required: false,
-// 					type: "table",
-// 				},
-// 			] as FieldDef<TableDef>[],
-// 		[addTableRow, withoutHeaders]
-// 	);
+	const fields = useMemo(
+		() =>
+			[
+				{
+					disabled: false,
+					helperText:
+						"The translate and the menu icons are shown to prove that the table can receive multiple actions",
+					instructionText: "Instruction text",
+					inputSettings: {
+						handleAddElement: addTableRow,
+						handleEdit: editAction,
+						handleDelete: deleteTableRow,
+						extraActions: extraActionsTable,
+						headers: args.headers
+					},
+					label: "Table example with extra actions",
+					name: "table",
+					required: false,
+					type: "table",
+				},
+				{
+					disabled: false,
+					helperText: "Default actions are the deletion and edition",
+					instructionText: "Instruction text",
+					inputSettings: {
+						handleAddElement: withoutHeaders,
+						handleEdit: editAction,
+						handleDelete: deleteTableRow,
+						extraActions: [],
+						headers: [],
+					},
+					label: "Table without headers and with the default actions",
+					name: "tableWithoutHeaders",
+					required: false,
+					type: "table",
+				},
+				{
+					disabled: true,
+					helperText: "Helper text",
+					instructionText: "Instruction text",
+					inputSettings: {
+						handleAddElement: withoutHeaders,
+						handleEdit: editAction,
+						handleDelete: deleteTableRow,
+						extraActions: [],
+						headers: args.headers
+					},
+					label: "Table disabled",
+					name: "disabled",
+					required: false,
+					type: "table",
+				},
+			] as FieldDef<TableDef>[],
+		[addTableRow, withoutHeaders, args.headers]
+	);
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				description='Form description'
-// 				dispatch={dispatch}
-// 				fields={fields}
-// 				onCancel={onCancel}
-// 				state={state}
-// 				title='Form Title'
-// 			/>
-// 		</>
-// 	);
-// };
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				description='Form description'
+				dispatch={dispatch}
+				fields={fields}
+				onCancel={onCancel}
+				state={state}
+				title='Form Title'
+			/>
+		</>
+	);
+};
+
+export const KitchenSink = KitchenSinkTemplate.bind({});
+KitchenSink.parameters = { controls: { exclude: [...excludedFormFieldsControls, "headers"] } };
+KitchenSink.args = {
+	headers
+}

--- a/src/forms/FormFieldText/FormFieldText.stories.mdx
+++ b/src/forms/FormFieldText/FormFieldText.stories.mdx
@@ -8,9 +8,3 @@ import * as stories from './FormFieldText.stories';
 ## Props
 
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldText/FormFieldTextTypes.tsx
-
-## FormFieldText Example
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldText/FormFieldText.stories.tsx
+++ b/src/forms/FormFieldText/FormFieldText.stories.tsx
@@ -4,6 +4,7 @@ import FormFieldText, { TextFieldDef } from ".";
 import { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
 import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
+import { ComponentMeta } from "@storybook/react";
 
 // Components
 import AccountCircle from "@mui/icons-material/AccountCircle";
@@ -21,7 +22,7 @@ export default {
 			control: "select",
 		},
 	},
-};
+} as ComponentMeta<typeof FormFieldText>;
 
 const Template = (args) => {
 	const {

--- a/src/forms/FormFieldText/FormFieldText.stories.tsx
+++ b/src/forms/FormFieldText/FormFieldText.stories.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { useMemo } from "react";
 import FormFieldText, { TextFieldDef } from ".";
-import { FieldDef, MosaicFieldProps } from "@root/components/Field";
+import { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
-import { onCancel, renderButtons } from "@root/utils/storyUtils";
+import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
 
 // Components
 import AccountCircle from "@mui/icons-material/AccountCircle";
@@ -13,31 +13,48 @@ export default {
 	component: FormFieldText,
 	argTypes: {
 		size: {
-			options: ["xs", "sm", "md", "lg"]
+			options: ["xs", "sm", "md", "lg"],
+			control: "select",
 		},
 		number: {
-			options: ["number", "text"]
-		}
-	} as unknown as MosaicFieldProps<TextFieldDef>
+			options: ["number", "text"],
+			control: "select",
+		},
+	},
 };
 
 const Template = (args) => {
-	const {size, type, placeholder, maxCharacters, disabled, required, multiline, withIcon, helperText, instructionText, label, fields} = args;
-	const { state, dispatch	} = useForm();
+	const {
+		size,
+		type,
+		placeholder,
+		maxCharacters,
+		disabled,
+		required,
+		multiline,
+		withIcon,
+		helperText,
+		instructionText,
+		label,
+		fields,
+		prefixElement
+	} = args;
+
+	const { state, dispatch } = useForm();
 
 	const playgroundField = useMemo(
 		() =>
 			[
 				{
 					name: "textfield",
-					label: "testing",
+					label,
 					type: "text",
 					required,
 					disabled,
 					maxCharacters: type !== "number" && maxCharacters,
 					size,
 					inputSettings: {
-						prefixElement: withIcon && <AccountCircle />,
+						prefixElement: withIcon && prefixElement,
 						maxCharacters,
 						placeholder,
 						multiline,
@@ -58,7 +75,7 @@ const Template = (args) => {
 			multiline,
 			helperText,
 			instructionText,
-			type
+			type,
 		]
 	);
 
@@ -79,6 +96,7 @@ const Template = (args) => {
 };
 
 export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
 Playground.args = {
 	size: "sm",
 	type: "text",
@@ -87,10 +105,11 @@ Playground.args = {
 	disabled: false,
 	required: false,
 	multiline: false,
-	withIcon: false,
+	withIcon: true,
 	helperText: "Helper text",
 	instructionText: "Instruction text",
-	label: "Label"
+	label: "Label",
+	prefixElement: <AccountCircle />
 };
 
 const kitchenSinkFields = [
@@ -101,10 +120,10 @@ const kitchenSinkFields = [
 		required: false,
 		size: "md",
 		inputSettings: {
-			placeholder: "placeholder"
+			placeholder: "placeholder",
 		},
 		helperText: "Helper text",
-		instructionText: "Instruction text"
+		instructionText: "Instruction text",
 	} as FieldDef<TextFieldDef>,
 	{
 		name: "number",
@@ -114,10 +133,10 @@ const kitchenSinkFields = [
 		size: "md",
 		inputSettings: {
 			placeholder: "number",
-			type: "number"
+			type: "number",
 		},
 		helperText: "Helper text",
-		instructionText: "Instruction text"
+		instructionText: "Instruction text",
 	} as FieldDef<TextFieldDef>,
 	{
 		name: "multiline",
@@ -211,6 +230,7 @@ const kitchenSinkFields = [
 ] as FieldDef<TextFieldDef>[];
 
 export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: [...excludedFormFieldsControls, "size", "number"] } };
 KitchenSink.args = {
 	fields: kitchenSinkFields,
 };

--- a/src/forms/FormFieldTextArea/FormFieldTextArea.stories.mdx
+++ b/src/forms/FormFieldTextArea/FormFieldTextArea.stories.mdx
@@ -9,8 +9,3 @@ import * as stories from './FormFieldTextArea.stories';
 
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldTextArea/FormFieldTextAreaTypes.tsx
 
-## FormFieldTextArea Example
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldTextArea/FormFieldTextArea.stories.tsx
+++ b/src/forms/FormFieldTextArea/FormFieldTextArea.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useMemo } from "react";
-import { TextAreaDef } from ".";
+import FormFieldTextArea, { TextAreaDef } from ".";
 import { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
 import {
@@ -8,17 +8,18 @@ import {
 	onCancel,
 	renderButtons,
 } from "@root/utils/storyUtils";
+import { ComponentMeta } from "@storybook/react";
 
 export default {
 	title: "FormFields/FormFieldTextArea",
-	component: Form,
+	component: FormFieldTextArea,
 	argTypes: {
 		size: {
 			options: ["xs", "sm", "md", "lg"],
 			control: "select",
 		},
 	},
-};
+} as ComponentMeta<typeof FormFieldTextArea>;
 
 const Template = (args) => {
 	const { state, dispatch } = useForm();

--- a/src/forms/FormFieldTextArea/FormFieldTextArea.stories.tsx
+++ b/src/forms/FormFieldTextArea/FormFieldTextArea.stories.tsx
@@ -1,169 +1,173 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import {
-// 	boolean,
-// 	withKnobs,
-// 	text,
-// 	number,
-// 	select,
-// } from "@storybook/addon-knobs";
-// import { TextAreaDef } from ".";
-// import { FieldDef } from "@root/components/Field";
-// import Form, { useForm } from "@root/components/Form";
-// import { onCancel, renderButtons } from "@root/utils/storyUtils";
+import * as React from "react";
+import { useMemo } from "react";
+import { TextAreaDef } from ".";
+import { FieldDef } from "@root/components/Field";
+import Form, { useForm } from "@root/components/Form";
+import {
+	excludedFormFieldsControls,
+	onCancel,
+	renderButtons,
+} from "@root/utils/storyUtils";
 
+export default {
+	title: "FormFields/FormFieldTextArea",
+	component: Form,
+	argTypes: {
+		size: {
+			options: ["xs", "sm", "md", "lg"],
+			control: "select",
+		},
+	},
+};
 
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		label,
+		required,
+		disabled,
+		maxCharacters,
+		size,
+		placeholder,
+		helperText,
+		instructionText,
+		fields
+	} = args;
 
-// export default {
-// 	title: "FormFields/FormFieldTextArea",
-// 	decorators: [withKnobs],
-// }
+	const playgroundField = useMemo(
+		() =>
+			[
+				{
+					name: "regular",
+					label,
+					type: "textArea",
+					required,
+					disabled,
+					maxCharacters,
+					size,
+					inputSettings: {
+						maxCharacters,
+						placeholder,
+					},
+					helperText,
+					instructionText,
+				},
+			] as FieldDef<TextAreaDef>[],
+		[
+			required,
+			disabled,
+			maxCharacters,
+			size,
+			placeholder,
+			helperText,
+			instructionText,
+			label,
+		]
+	);
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields ? fields : playgroundField}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// 	const size = select("Size", ["xs", "sm", "md", "lg"], "sm");
-// 	const placeholder = text("Placeholder", "placeholder");
-// 	const maxCharacters = number("Max characters", 20);
-// 	const disabled = boolean("Disabled", false);
-// 	const required = boolean("Required", false);
-// 	const helperText = text("Helper text", "Helper text");
-// 	const instructionText = text("Instruction text", "Instruction text");
-// 	const label = text("Label", "Label");
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: [...excludedFormFieldsControls, "size"] } };
+Playground.args = {
+	size: "sm",
+	placeholder: "placeholder",
+	maxCharacters: 20,
+	disabled: false,
+	required: false,
+	helperText: "Helper text",
+	instructionText: "Instruction text",
+	label: "Label",
+};
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "regular",
-// 					label,
-// 					type: "textArea",
-// 					required,
-// 					disabled,
-// 					maxCharacters,
-// 					size,
-// 					inputSettings: {
-// 						maxCharacters,
-// 						placeholder,
-// 					},
-// 					helperText,
-// 					instructionText,
-// 				},
-// 			] as FieldDef<TextAreaDef>[],
-// 		[
-// 			required,
-// 			disabled,
-// 			maxCharacters,
-// 			size,
-// 			placeholder,
-// 			helperText,
-// 			instructionText,
-// 			label,
-// 		]
-// 	);
+const kitchenSinkFields = [
+	{
+		name: "regular",
+		label: "Regular example",
+		type: "textArea",
+		size: "md",
+		inputSettings: {
+			placeholder: "placeholder",
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "withMaxChar",
+		label: "Established with a max chars",
+		type: "textArea",
+		maxCharacters: 20,
+		size: "md",
+		inputSettings: {
+			maxCharacters: 20,
+			placeholder: "placeholder",
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "disabledExample",
+		label: "Disabled",
+		type: "textArea",
+		disabled: true,
+		size: "md",
+		inputSettings: {
+			placeholder: "placeholder",
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "xsSize",
+		label: "Size xs",
+		type: "textArea",
+		size: "xs",
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "smSize",
+		label: "Size sm",
+		type: "textArea",
+		size: "sm",
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "mdSize",
+		label: "Size md",
+		type: "textArea",
+		size: "md",
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "lgSize",
+		label: "Size lg",
+		type: "textArea",
+		size: "lg",
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+] as FieldDef<TextAreaDef>[];
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: [...excludedFormFieldsControls, "size"] } };
+KitchenSink.args = {
+	fields: kitchenSinkFields
+}
 
-// const kitchenSinkFields = [
-// 	{
-// 		name: "regular",
-// 		label: "Regular example",
-// 		type: "textArea",
-// 		size: "md",
-// 		inputSettings: {
-// 			placeholder: "placeholder"
-// 		},
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// 	{
-// 		name: "withMaxChar",
-// 		label: "Established with a max chars",
-// 		type: "textArea",
-// 		maxCharacters: 20,
-// 		size: "md",
-// 		inputSettings: {
-// 			maxCharacters: 20,
-// 			placeholder: "placeholder"
-// 		},
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// 	{
-// 		name: "disabledExample",
-// 		label: "Disabled",
-// 		type: "textArea",
-// 		disabled: true,
-// 		size: "md",
-// 		inputSettings: {
-// 			placeholder: "placeholder"
-// 		},
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// 	{
-// 		name: "xsSize",
-// 		label: "Size xs",
-// 		type: "textArea",
-// 		size: "xs",
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// 	{
-// 		name: "smSize",
-// 		label: "Size sm",
-// 		type: "textArea",
-// 		size: "sm",
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// 	{
-// 		name: "mdSize",
-// 		label: "Size md",
-// 		type: "textArea",
-// 		size: "md",
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// 	{
-// 		name: "lgSize",
-// 		label: "Size lg",
-// 		type: "textArea",
-// 		size: "lg",
-// 		helperText: "Helper text",
-// 		instructionText: "Instruction text",
-// 	},
-// ] as FieldDef<TextAreaDef>[];
-
-// export const KitchenSink = (): ReactElement => {
-// 	const {	state, dispatch } = useForm();
-
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title='Form title'
-// 				description='Form description'
-// 				state={state}
-// 				fields={kitchenSinkFields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };

--- a/src/forms/FormFieldTextEditor/FormFieldTextEditor.stories.mdx
+++ b/src/forms/FormFieldTextEditor/FormFieldTextEditor.stories.mdx
@@ -9,9 +9,3 @@ This implementation is based on the [React Jodit WYSIWYG Editor](https://www.npm
 
 ## Props
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/TextEditor/TextEditorTypes.tsx
-
-## TextEditor Example
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
+++ b/src/forms/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
@@ -1,152 +1,155 @@
 // // BUG TO BE FIXED
-// import * as React from "react";
-// import { useMemo, ReactElement } from "react";
-// import { boolean, number, select, text, withKnobs } from "@storybook/addon-knobs";
-// import Form, { useForm } from "@root/components/Form";
-// import { FieldDef } from "@root/components/Field";
-// // import { TextEditorDef } from "./FormFieldTextEditorTypes";
-// import { renderButtons } from "@root/utils/storyUtils";
+import * as React from "react";
+import { useMemo } from "react";
+import Form, { useForm } from "@root/components/Form";
+import { FieldDef } from "@root/components/Field";
+import { TextEditorDef } from "./FormFieldTextEditorTypes";
+import { excludedFormFieldsControls, renderButtons } from "@root/utils/storyUtils";
 
-// export default {
-// 	title: "FormFields/FormFieldTextEditor",
-// 	decorators: [withKnobs],
-// };
+export default {
+	title: "FormFields/FormFieldTextEditor",
+	component: Form,
+	argTypes: {
+		direction: {
+			options: ["ltr", "rtl"],
+			control: "select"
+		},
+	}
+};
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		direction,
+		disabled,
+		helperText,
+		instructionText,
+		label,
+		language,
+		maxCharacters,
+		required,
+		spellcheck,
+		fields
+	} = args;
 
-// 	const disabled = boolean("Disabled", false);
-// 	const label = text("Label", "Label");
-// 	const helperText = text("Helper text", "Helper Text");
-// 	const instructionText = text("Instruction text", "Instruction text");
-// 	const required = boolean("Required", false);
-// 	const toggleLabel = text("Toggle label", "Toggle label");
-// 	const spellcheck = boolean("Spellcheck", false);
-// 	const direction = select("Direction", ["ltr", "rtl"], "ltr");
-// 	const language = text("Language", "en");
-// 	const maxCharacters = number("Max Characters", 100);
+	const playgroundFields = useMemo(
+		() =>
+			[
+				{
+					name: "textEditor",
+					label,
+					type: "textEditor",
+					required,
+					inputSettings: {
+						spellcheck,
+						direction,
+						language,
+						maxCharacters,
+					},
+					disabled,
+					helperText,
+					instructionText,
+				},
+			] as FieldDef<TextEditorDef>[],
+		[
+			direction,
+			required,
+			disabled,
+			label,
+			helperText,
+			instructionText,
+			maxCharacters,
+			spellcheck,
+			language,
+		]
+	);
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "textEditor",
-// 					label,
-// 					type: "textEditor",
-// 					required,
-// 					inputSettings: {
-// 						spellcheck,
-// 						direction,
-// 						language,
-// 						maxCharacters,
-// 					},
-// 					disabled,
-// 					helperText,
-// 					instructionText,
-// 				},
-// 			] as FieldDef<TextEditorDef>[],
-// 		[
-// 			direction,
-// 			required,
-// 			disabled,
-// 			toggleLabel,
-// 			label,
-// 			helperText,
-// 			instructionText,
-// 			maxCharacters,
-// 			spellcheck,
-// 			language
-// 		]
-// 	);
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				title="Form Title"
+				description="This is a description example"
+				state={state}
+				fields={fields ? fields : playgroundFields}
+				dispatch={dispatch}
+				buttons={renderButtons(dispatch)}
+			/>
+		</>
+	);
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				buttons={renderButtons(dispatch)}
-// 			/>
-// 		</>
-// 	);
-// };
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	direction: "ltr",
+	required: false,
+	disabled: false,
+	label: "Label",
+	helperText: "Helper Text",
+	instructionText: "Instruction Text",
+	maxCharacters: 100,
+	spellcheck: false,
+	language: "en"
+};
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const kitchenSinkFields = [
+	{
+		name: "spellCheck",
+		label: "Text editor with spellcheck active",
+		type: "textEditor",
+		required: false,
+		inputSettings: {
+			spellcheck: true,
+		},
+	},
+	{
+		name: "ltr",
+		label: "Text editor with left to right direction",
+		type: "textEditor",
+		required: false,
+		inputSettings: {
+			direction: "ltr",
+		},
+	},
+	{
+		name: "rtl",
+		label: "Text editor with right to left direction",
+		type: "textEditor",
+		required: false,
+		inputSettings: {
+			direction: "rtl",
+		},
+	},
+	{
+		name: "german",
+		label: "Text editor in german (de) language",
+		type: "textEditor",
+		required: false,
+		inputSettings: {
+			language: "de",
+		},
+	},
+	{
+		name: "maxChars",
+		label: "Text editor with max character limit",
+		type: "textEditor",
+		required: false,
+		inputSettings: {
+			maxCharacters: 20,
+		},
+	},
+	{
+		name: "disabled",
+		label: "Disabled text editor",
+		type: "textEditor",
+		required: false,
+		disabled: true,
+	},
+]
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "spellCheck",
-// 					label: "Text editor with spellcheck active",
-// 					type: "textEditor",
-// 					required: false,
-// 					inputSettings: {
-// 						spellcheck: true,
-// 					},
-// 				},
-// 				{
-// 					name: "ltr",
-// 					label: "Text editor with left to right direction",
-// 					type: "textEditor",
-// 					required: false,
-// 					inputSettings: {
-// 						direction: "ltr",
-// 					},
-// 				},
-// 				{
-// 					name: "rtl",
-// 					label: "Text editor with right to left direction",
-// 					type: "textEditor",
-// 					required: false,
-// 					inputSettings: {
-// 						direction: "rtl",
-// 					},
-// 				},
-// 				{
-// 					name: "german",
-// 					label: "Text editor in german (de) language",
-// 					type: "textEditor",
-// 					required: false,
-// 					inputSettings: {
-// 						language: "de",
-// 					},
-// 				},
-// 				{
-// 					name: "maxChars",
-// 					label: "Text editor with max character limit",
-// 					type: "textEditor",
-// 					required: false,
-// 					inputSettings: {
-// 						maxCharacters: 20,
-// 					},
-// 				},
-// 				{
-// 					name: "disabled",
-// 					label: "Disabled text editor",
-// 					type: "textEditor",
-// 					required: false,
-// 					disabled: true,
-// 				},
-// 			] as FieldDef<TextEditorDef>[],
-// 		[]
-// 	);
-
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				title='Text Editor Kitchen Sink'
-// 				description='This is a description example'
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				buttons={renderButtons(dispatch)}
-// 			/>
-// 		</>
-// 	);
-// };
+export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: [...excludedFormFieldsControls, "direction"] } };
+KitchenSink.args = {
+	fields: kitchenSinkFields
+};

--- a/src/forms/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
+++ b/src/forms/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
@@ -3,19 +3,20 @@ import * as React from "react";
 import { useMemo } from "react";
 import Form, { useForm } from "@root/components/Form";
 import { FieldDef } from "@root/components/Field";
-import { TextEditorDef } from "./FormFieldTextEditorTypes";
 import { excludedFormFieldsControls, renderButtons } from "@root/utils/storyUtils";
+import FormFieldTextEditor, { TextEditorDef } from ".";
+import { ComponentMeta } from "@storybook/react";
 
 export default {
 	title: "FormFields/FormFieldTextEditor",
-	component: Form,
+	component: FormFieldTextEditor,
 	argTypes: {
 		direction: {
 			options: ["ltr", "rtl"],
 			control: "select"
 		},
 	}
-};
+} as ComponentMeta<typeof FormFieldTextEditor>;
 
 const Template = (args) => {
 	const { state, dispatch } = useForm();

--- a/src/forms/FormFieldToggleSwitch/FormFieldToggleSwitch.stories.mdx
+++ b/src/forms/FormFieldToggleSwitch/FormFieldToggleSwitch.stories.mdx
@@ -11,8 +11,3 @@ The `FormFieldToggleSwitch` component is built over a wrapper for [MUI Switch](h
 
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/forms/FormFieldToggleSwitch/FormFieldToggleSwitchTypes.tsx
 
-## FormFieldToggleSwitch
-
-<Preview withSource='none'>
-  <stories.Playground />
-</Preview>

--- a/src/forms/FormFieldToggleSwitch/FormFieldToggleSwitch.stories.tsx
+++ b/src/forms/FormFieldToggleSwitch/FormFieldToggleSwitch.stories.tsx
@@ -1,119 +1,112 @@
-// import * as React from "react";
-// import { ReactElement, useMemo } from "react";
-// import { boolean, withKnobs, text } from "@storybook/addon-knobs";
-// import { Meta } from "@storybook/addon-docs/blocks";
+import * as React from "react";
+import { useMemo } from "react";
+import { FormFieldToggleSwitchDef } from ".";
+import Form, { useForm } from "@root/components/Form";
+import { FieldDef } from "@root/components/Field";
+import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
 
-// // Components
-// import { FormFieldToggleSwitchDef } from ".";
-// import Form, { useForm } from "@root/components/Form";
-// import { FieldDef } from "@root/components/Field";
-// // import { onCancel, renderButtons } from "@root/utils/storyUtils";
+export default {
+	title: "FormFields/FormFieldToggleSwitch",
+	component: Form,
+};
 
-// export default {
-// 	title: "FormFields/FormFieldToggleSwitch",
-// 	decorators: [withKnobs],
-// } as Meta;
+const Template = (args) => {
+	const { state, dispatch } = useForm();
+	const {
+		label,
+		required,
+		disabled,
+		toggleLabel,
+		helperText,
+		instructionText,
+		fields
+	} = args;
 
-// export const Playground = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+	const playgroundFields = useMemo(
+		() =>
+			[
+				{
+					name: "toggleSwitch",
+					label: label,
+					type: "toggleSwitch",
+					required: required,
+					disabled: disabled,
+					inputSettings: {
+						toggleLabel: toggleLabel,
+					},
+					helperText: helperText,
+					instructionText: instructionText,
+				},
+			] as FieldDef<FormFieldToggleSwitchDef>[],
+		[required, disabled, toggleLabel, label, helperText, instructionText]
+	);
 
-// 	const disabled = boolean("Disabled", false);
-// 	const label = text("Label", "Label");
-// 	const helperText = text("Helper text", "Helper Text");
-// 	const instructionText = text("Instruction text", "Instruction text");
-// 	const required = boolean("Required", false);
-// 	const toggleLabel = text("Toggle label", "Toggle label");
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title={"Form Title"}
+				description={"This is a description example"}
+				state={state}
+				fields={fields ? fields : playgroundFields}
+				dispatch={dispatch}
+				onCancel={onCancel}
+			/>
+		</>
+	);
+};
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "toggleSwitch",
-// 					label,
-// 					type: "toggleSwitch",
-// 					required,
-// 					disabled,
-// 					inputSettings: {
-// 						toggleLabel,
-// 					},
-// 					helperText,
-// 					instructionText,
-// 				},
-// 			] as FieldDef<FormFieldToggleSwitchDef>[],
-// 		[required, disabled, toggleLabel, label, helperText, instructionText]
-// 	);
+export const Playground = Template.bind({});
+Playground.parameters = { controls: { exclude: excludedFormFieldsControls } };
+Playground.args = {
+	disabled: false,
+	label: "Label",
+	helperText: "Helper Text",
+	instructionText: "Instruction Text",
+	required: false,
+	toggleLabel: "Toggle label",
+};
 
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title={text("Title", "Form Title")}
-// 				description={text("Description", "This is a description example")}
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
 
-// export const KitchenSink = (): ReactElement => {
-// 	const { state, dispatch } = useForm();
+const kitchenSinkFields = [
+	{
+		name: "toggleSwitchDefault",
+		label: "Default example",
+		type: "toggleSwitch",
+		required: false,
+		disabled: false,
+		inputSettings: {
+			toggleLabel: "Toggle label",
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "toggleSwitchDisabled",
+		label: "Disabled example",
+		type: "toggleSwitch",
+		required: false,
+		disabled: true,
+		inputSettings: {
+			toggleLabel: "Toggle label",
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "toggleSwitchWithoutLabel",
+		label: "Toggle switch without label",
+		type: "toggleSwitch",
+		required: false,
+		disabled: false,
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+];
 
-// 	const fields = useMemo(
-// 		() =>
-// 			[
-// 				{
-// 					name: "toggleSwitchDefault",
-// 					label: "Default example",
-// 					type: "toggleSwitch",
-// 					required: false,
-// 					disabled: false,
-// 					inputSettings: {
-// 						toggleLabel: "Toggle label",
-// 					},
-// 					helperText: "Helper text",
-// 					instructionText: "Instruction text",
-// 				},
-// 				{
-// 					name: "toggleSwitchDisabled",
-// 					label: "Disabled example",
-// 					type: "toggleSwitch",
-// 					required: false,
-// 					disabled: true,
-// 					inputSettings: {
-// 						toggleLabel: "Toggle label",
-// 					},
-// 					helperText: "Helper text",
-// 					instructionText: "Instruction text",
-// 				},
-// 				{
-// 					name: "toggleSwitchWithoutLabel",
-// 					label: "Toggle switch without label",
-// 					type: "toggleSwitch",
-// 					required : false,
-// 					disabled: false,
-// 					helperText: "Helper text",
-// 					instructionText: "Instruction text",
-// 				},
-// 			] as FieldDef<FormFieldToggleSwitchDef>[],
-// 		[]
-// 	);
-
-// 	return (
-// 		<>
-// 			<pre>{JSON.stringify(state, null, "  ")}</pre>
-// 			<Form
-// 				buttons={renderButtons(dispatch)}
-// 				title='Form Title'
-// 				description='This is a description example'
-// 				state={state}
-// 				fields={fields}
-// 				dispatch={dispatch}
-// 				onCancel={onCancel}
-// 			/>
-// 		</>
-// 	);
-// };
+export const KitchenSink = Template.bind({});
+KitchenSink.parameters = { controls: { exclude: excludedFormFieldsControls } };
+KitchenSink.args = {
+	fields: kitchenSinkFields
+}

--- a/src/forms/FormFieldToggleSwitch/FormFieldToggleSwitch.stories.tsx
+++ b/src/forms/FormFieldToggleSwitch/FormFieldToggleSwitch.stories.tsx
@@ -1,14 +1,15 @@
 import * as React from "react";
 import { useMemo } from "react";
-import { FormFieldToggleSwitchDef } from ".";
+import FormFieldToggleSwitch, { FormFieldToggleSwitchDef } from ".";
 import Form, { useForm } from "@root/components/Form";
 import { FieldDef } from "@root/components/Field";
 import { excludedFormFieldsControls, onCancel, renderButtons } from "@root/utils/storyUtils";
+import { ComponentMeta } from "@storybook/react";
 
 export default {
 	title: "FormFields/FormFieldToggleSwitch",
-	component: Form,
-};
+	component: FormFieldToggleSwitch,
+} as ComponentMeta<typeof FormFieldToggleSwitch>;
 
 const Template = (args) => {
 	const { state, dispatch } = useForm();

--- a/src/utils/storyUtils.ts
+++ b/src/utils/storyUtils.ts
@@ -28,3 +28,27 @@ export const renderButtons = (dispatch: unknown, show = { showCancel: true, show
 		show: show.showSave
 	},
 ];
+
+export const excludedFormFieldsControls = [
+	"type",
+	"state",
+	"title",
+	"fields",
+	"section",
+	"dispatch",
+	"onCancel",
+	"dialogOpen",
+	"descripton",
+	"getFormValues",
+	"handleDialogClose",
+	"buttons",
+	"description",
+	"sections",
+	"fieldDef",
+	"onChange",
+	"onBlur",
+	"value",
+	"error",
+	"children",
+	"colsInRow",
+];


### PR DESCRIPTION
## What's included?
All the FormFields stories were updated to be compatible with storybook v6

### Notes
- All Form stories except the Playground stories stayed the same because no controls were needed to add.
- The DMS example story was not displaying the content (children) since in the NavWrapper.tsx component the .main CSS class has an ``overflow: hidden;`` It was removed, but it's strange why in our storybook v5 the children were shown despite containing this style.
- Comment this line``#COPY webpack.config.js /app/webpack.config.js`` in the Dockerfile to be able to spin up the container.