### PR TITLE
MOS-838: Update references to simply gold

### DIFF
--- a/automation_testing/pages/BasePage.ts
+++ b/automation_testing/pages/BasePage.ts
@@ -147,4 +147,8 @@ export class BasePage {
 	async getBackgroundColorFromElement(element: Locator): Promise<string> {
 		return await ((element).evaluate(el => getComputedStyle(el).backgroundColor));
 	}
+
+	async getColorFromElement(element: Locator): Promise<string> {
+		return await ((element).evaluate(el => getComputedStyle(el).color));
+	}
 }

--- a/automation_testing/pages/BasePage.ts
+++ b/automation_testing/pages/BasePage.ts
@@ -143,4 +143,8 @@ export class BasePage {
 	async getHeightFromElement(element: Locator): Promise<string> {
 		return await ((element).evaluate(el => getComputedStyle(el).height));
 	}
+
+	async getBackgroundColorFromElement(element: Locator): Promise<string> {
+		return await ((element).evaluate(el => getComputedStyle(el).backgroundColor));
+	}
 }

--- a/automation_testing/pages/Components/Checkbox/CheckboxPage.ts
+++ b/automation_testing/pages/Components/Checkbox/CheckboxPage.ts
@@ -8,13 +8,16 @@ export class CheckboxPage extends BasePage {
 	readonly page: Page;
 	readonly checkboxList: Locator;
 	readonly checkboxLabel: Locator;
-
+	readonly checkboxInput: Locator;
+	readonly checkboxIcon: Locator;
 
 	constructor(page: Page) {
 		super(page);
 		this.page = page;
 		this.checkboxList = page.locator(".listItem");
 		this.checkboxLabel = page.locator("label[data-testid='label-test-id']");
+		this.checkboxInput = this.checkboxList.locator("input[type='checkbox']");
+		this.checkboxIcon = page.locator("span[data-testid='checkbox-test-id']");
 	}
 
 	async visitPage(): Promise<void> {

--- a/automation_testing/pages/Components/Chip/ChipPage.ts
+++ b/automation_testing/pages/Components/Chip/ChipPage.ts
@@ -1,0 +1,23 @@
+import { Locator, Page } from "@playwright/test";
+import { BasePage } from "../../BasePage";
+
+export class ChipPage extends BasePage {
+
+	readonly page_path = "components-chip--kitchen-sink";
+
+	readonly page: Page;
+	readonly chip: Locator;
+	readonly deletableChip: Locator;
+
+
+	constructor(page: Page) {
+		super(page);
+		this.page = page;
+		this.chip = page.locator("[data-testid='chip-testid']");
+		this.deletableChip = page.locator("[data-testid='delete-chip-testid']");
+	}
+
+	async visitPage(): Promise<void> {
+		await this.visit(this.page_path, this.page.locator("h1:has-text('Chip')"));
+	}
+}

--- a/automation_testing/pages/Components/RadioButton/RadioButtonPage.ts
+++ b/automation_testing/pages/Components/RadioButton/RadioButtonPage.ts
@@ -1,0 +1,22 @@
+import { Locator, Page } from "@playwright/test";
+import { BasePage } from "../../BasePage";
+
+export class RadioButtonPage extends BasePage {
+
+	readonly page_path = "components-radiobutton--group";
+
+	readonly page: Page;
+	readonly radioButtonSpan: Locator;
+	readonly radioButtonInput: Locator;
+
+	constructor(page: Page) {
+		super(page);
+		this.page = page;
+		this.radioButtonSpan = page.locator("[data-testid='radio-button-test']");
+		this.radioButtonInput = page.locator("input[type='radio']");
+	}
+
+	async visitPage(): Promise<void> {
+		await this.visit(this.page_path, this.radioButtonInput.first());
+	}
+}

--- a/automation_testing/pages/Components/SummaryPageTopComponent/SummaryPageTopComponentPage.ts
+++ b/automation_testing/pages/Components/SummaryPageTopComponent/SummaryPageTopComponentPage.ts
@@ -7,11 +7,13 @@ export class SummaryPageTopComponentPage extends BasePage {
 
 	readonly page: Page;
 	readonly summaryTitle: Locator;
+	readonly starRate: Locator;
 
 	constructor(page: Page) {
 		super(page);
 		this.page = page;
 		this.summaryTitle = page.locator("#root p").nth(0);
+		this.starRate = page.locator("[data-testid='StarRateRoundedIcon']");
 	}
 
 	async visitPage(): Promise<void> {

--- a/automation_testing/pages/Components/SummaryPageTopComponent/SummaryPageTopComponentPage.ts
+++ b/automation_testing/pages/Components/SummaryPageTopComponent/SummaryPageTopComponentPage.ts
@@ -7,13 +7,15 @@ export class SummaryPageTopComponentPage extends BasePage {
 
 	readonly page: Page;
 	readonly summaryTitle: Locator;
-	readonly starRate: Locator;
+	readonly starRateIconUnchecked: Locator;
+	readonly starRateIconChecked: Locator;
 
 	constructor(page: Page) {
 		super(page);
 		this.page = page;
 		this.summaryTitle = page.locator("#root p").nth(0);
-		this.starRate = page.locator("[data-testid='StarRateRoundedIcon']");
+		this.starRateIconUnchecked = page.locator("[data-testid='StarBorderRoundedIcon']");
+		this.starRateIconChecked = page.locator("[data-testid='StarRateRoundedIcon']");
 	}
 
 	async visitPage(): Promise<void> {

--- a/automation_testing/pages/Components/ToggleSwitch/ToggleSwitchPage.ts
+++ b/automation_testing/pages/Components/ToggleSwitch/ToggleSwitchPage.ts
@@ -1,0 +1,22 @@
+import { Locator, Page } from "@playwright/test";
+import { BasePage } from "../../BasePage";
+
+export class ToggleSwitchPage extends BasePage {
+
+	readonly page_path = "components-toggleswitch--example";
+
+	readonly page: Page;
+	readonly toggleSpan: Locator;
+	readonly toggleInput: Locator;
+
+	constructor(page: Page) {
+		super(page);
+		this.page = page;
+		this.toggleSpan = page.locator("//*[@id='root']/label/span[1]/span[1]");
+		this.toggleInput = page.locator("input[type='checkbox']");
+	}
+
+	async visitPage(): Promise<void> {
+		await this.visit(this.page_path, this.toggleInput);
+	}
+}

--- a/automation_testing/tests/Components/Button/button.spec.ts
+++ b/automation_testing/tests/Components/Button/button.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, Page } from "@playwright/test";
 import { ButtonPage } from "../../../pages/Components/Button/ButtonPage";
+import theme from "../../../../src/theme"
 
 test.describe("Components - Button - Kitchen Sink", () => {
 	let page: Page;
@@ -48,5 +49,13 @@ test.describe("Components - Button - Kitchen Sink", () => {
 	test("Validate Button Popover on Hover.", async () => {
 		await buttonPage.buttonThatTriggersPopoverOnHover.hover();
 		await expect(page.locator("text=Popover Content")).toBeVisible();
+	});
+
+	test("Validate Button has simplyGold background.", async () => {
+		const expectBgColor = (theme.newColors.simplyGold["100"]);
+		expect(await buttonPage.getBackgroundColorFromElement(buttonPage.button.nth(8))).toBe(expectBgColor);
+		expect(await buttonPage.getBackgroundColorFromElement(buttonPage.button.nth(9))).toBe(expectBgColor);
+		expect(await buttonPage.getBackgroundColorFromElement(buttonPage.button.nth(18))).toBe(expectBgColor);
+		expect(await buttonPage.getBackgroundColorFromElement(buttonPage.button.nth(19))).toBe(expectBgColor);
 	});
 });

--- a/automation_testing/tests/Components/Button/button.spec.ts
+++ b/automation_testing/tests/Components/Button/button.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, Page } from "@playwright/test";
 import { ButtonPage } from "../../../pages/Components/Button/ButtonPage";
-import theme from "../../../../src/theme"
+import theme from "../../../../src/theme";
 
 test.describe("Components - Button - Kitchen Sink", () => {
 	let page: Page;

--- a/automation_testing/tests/Components/Checkbox/checkbox.spec.ts
+++ b/automation_testing/tests/Components/Checkbox/checkbox.spec.ts
@@ -23,7 +23,7 @@ test.describe("Components - Checkbox - Kitchen Sink", () => {
 		}
 	});
 
-	test("Validate Checkbox has simplyGold background.", async () => {
+	test("Validate Checkbox has simplyGold color.", async () => {
 		const expectBgColor = (theme.newColors.simplyGold["100"]).split("rgb")[1];
 		const numberOfCheckboxs = await checkboxPage.checkboxInput.count();
 		for (let i = 0; i < numberOfCheckboxs; i++) {

--- a/automation_testing/tests/Components/Checkbox/checkbox.spec.ts
+++ b/automation_testing/tests/Components/Checkbox/checkbox.spec.ts
@@ -1,5 +1,6 @@
 import { test, Page } from "@playwright/test";
 import { CheckboxPage } from "../../../pages/Components/Checkbox/CheckboxPage";
+import theme from "../../../../src/theme";
 
 test.describe("Components - Checkbox - Kitchen Sink", () => {
 	let page: Page;
@@ -19,6 +20,15 @@ test.describe("Components - Checkbox - Kitchen Sink", () => {
 		const numberOfLabels = await checkboxPage.checkboxLabel.count();
 		for (let i = 0; i < numberOfLabels; i++) {
 			await checkboxPage.validateFontColorFromElement(checkboxPage.checkboxLabel.nth(i), "#3B424E", true);
+		}
+	});
+
+	test("Validate Checkbox has simplyGold background.", async () => {
+		const expectBgColor = (theme.newColors.simplyGold["100"]).split("rgb")[1];
+		const numberOfCheckboxs = await checkboxPage.checkboxInput.count();
+		for (let i = 0; i < numberOfCheckboxs; i++) {
+			await checkboxPage.checkboxInput.nth(i).check();
+			await checkboxPage.validateFontColorFromElement(checkboxPage.checkboxIcon.nth(i), expectBgColor, false);
 		}
 	});
 });

--- a/automation_testing/tests/Components/Chip/chip.spec.ts
+++ b/automation_testing/tests/Components/Chip/chip.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect, Page } from "@playwright/test";
+import { ChipPage } from "../../../pages/Components/Chip/ChipPage";
+import theme from "../../../../src/theme";
+
+test.describe("Components - Chip - Kitchen Sink", () => {
+	let page: Page;
+	let chipPage: ChipPage;
+
+	test.beforeAll(async ({ browser }) => {
+		page = await browser.newPage();
+		chipPage = new ChipPage(page);
+		await chipPage.visitPage();
+	});
+
+	test.afterAll(async ({ browser }) => {
+		await browser.close();
+	});
+
+	test("Validate Chip has simplyGold background.", async () => {
+		const expectBgColor = (theme.newColors.simplyGold["100"]);
+		const expectDisabledBgColor = (theme.newColors.simplyGold["60"]);
+		expect(await chipPage.getBackgroundColorFromElement(chipPage.chip.nth(1))).toBe(expectBgColor);
+		expect(await chipPage.getBackgroundColorFromElement(chipPage.chip.nth(3))).toBe(expectDisabledBgColor);
+		expect(await chipPage.getBackgroundColorFromElement(chipPage.deletableChip)).toBe(expectBgColor);
+	});
+});

--- a/automation_testing/tests/Components/RadioButton/radioButton.spec.ts
+++ b/automation_testing/tests/Components/RadioButton/radioButton.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect, Page } from "@playwright/test";
+import { RadioButtonPage } from "../../../pages/Components/RadioButton/RadioButtonPage";
+import theme from "../../../../src/theme";
+
+test.describe("Components - RadioButton - Group", () => {
+	let page: Page;
+	let radioButtonPage: RadioButtonPage;
+
+	test.beforeAll(async ({ browser }) => {
+		page = await browser.newPage();
+		radioButtonPage = new RadioButtonPage(page);
+		await radioButtonPage.visitPage();
+	});
+
+	test.afterAll(async ({ browser }) => {
+		await browser.close();
+	});
+
+	test("Validate Chip has simplyGold color.", async () => {
+		const expectColor = (theme.newColors.simplyGold["100"]);
+		await radioButtonPage.radioButtonInput.first().check();
+		expect(await radioButtonPage.getColorFromElement(radioButtonPage.radioButtonSpan.first())).toBe(expectColor);
+	});
+});

--- a/automation_testing/tests/Components/SummaryPageTopComponent/summaryPageTopComponent.spec.ts
+++ b/automation_testing/tests/Components/SummaryPageTopComponent/summaryPageTopComponent.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, Page } from "@playwright/test";
 import { SummaryPageTopComponentPage } from "../../../pages/Components/SummaryPageTopComponent/SummaryPageTopComponentPage";
+import theme from "../../../../src/theme";
 
 test.describe("Components - SummaryPageTopComponent - Kitchen Sink", () => {
 	let page: Page;
@@ -23,5 +24,11 @@ test.describe("Components - SummaryPageTopComponent - Kitchen Sink", () => {
 	test("Validate the font of the title.", async () => {
 		const titleFonts = await summaryPage.getFontFamilyFromElement(summaryPage.summaryTitle);
 		expect(titleFonts).toContain("Museo-Sans");
+	});
+
+	test("Validate Star has simplyGold color.", async () => {
+		const expectColor = (theme.newColors.simplyGold["100"]);
+		await summaryPage.starRateIconUnchecked.click();
+		expect(await summaryPage.getColorFromElement(summaryPage.starRateIconChecked)).toBe(expectColor);
 	});
 });

--- a/automation_testing/tests/Components/ToggleSwitch/toggleSwitch.spec.ts
+++ b/automation_testing/tests/Components/ToggleSwitch/toggleSwitch.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect, Page } from "@playwright/test";
+import { ToggleSwitchPage } from "../../../pages/Components/ToggleSwitch/ToggleSwitchPage";
+import theme from "../../../../src/theme";
+
+test.describe("Components - ToggleSwitch - Example", () => {
+	let page: Page;
+	let togglePage: ToggleSwitchPage;
+
+	test.beforeAll(async ({ browser }) => {
+		page = await browser.newPage();
+		togglePage = new ToggleSwitchPage(page);
+		await togglePage.visitPage();
+	});
+
+	test.afterAll(async ({ browser }) => {
+		await browser.close();
+	});
+
+	test("Validate Toggle has simplyGold color.", async () => {
+		const expectColor = (theme.newColors.simplyGold["100"]);
+		await togglePage.toggleInput.click();
+		expect(await togglePage.getColorFromElement(togglePage.toggleSpan)).toBe(expectColor);
+	});
+});

--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -209,7 +209,7 @@ const textButtonStyles = {
 export const types = {
 	yellow_contained: styled(BlackOnYellow)`
     & > button {
-      background-color: ${theme.colors.simplyGold};
+      background-color: ${theme.newColors.simplyGold["100"]};
       border-radius: 0;
       font-size: 14px;
       text-transform: uppercase;
@@ -217,12 +217,12 @@ export const types = {
 
     .MuiButton-contained.Mui-disabled {
       color: ${theme.colors.almostBlack};
-      background-color: ${theme.colors.simplyGold};
+      background-color: ${theme.newColors.simplyGold["100"]};
       opacity: 0.5;
     }
 
     & > button:hover {
-      background-color: ${theme.colors.simplyGoldHover};
+      background-color: ${theme.newColors.simplyGold["100"]};
       color: ${theme.colors.almostBlack};
     }
   `,

--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -222,7 +222,7 @@ export const types = {
     }
 
     & > button:hover {
-      background-color: ${theme.newColors.simplyGold["100"]};
+      background-color: ${theme.newColors.darkerSimplyGold["100"]};
       color: ${theme.colors.almostBlack};
     }
   `,

--- a/src/components/Checkbox/Checkbox.styled.ts
+++ b/src/components/Checkbox/Checkbox.styled.ts
@@ -13,7 +13,7 @@ export const StyledFormControlLabel = styled(MUIFormControlLabel)`
 
   & > span.checked,
   & > span.MuiCheckbox-indeterminate {
-    color: ${theme.colors.simplyGold};
+    color: ${theme.newColors.simplyGold["100"]};
     opacity: ${(pr) => (pr.disabled ? "50%" : "100%")};
   }
 
@@ -29,7 +29,7 @@ export const StyledCheckbox = styled(MUICheckbox)`
     color: ${theme.colors.almostBlack};
 
     &.Mui-checked {
-      color: ${theme.colors.simplyGold};
+      color: ${theme.newColors.simplyGold["100"]};
     }
   }
 

--- a/src/components/Chip/Chip.styled.ts
+++ b/src/components/Chip/Chip.styled.ts
@@ -11,19 +11,19 @@ const chipFont = `
 export const StyledDeletableChip = styled(Chip)`
   &.MuiChip-root {
     background-color: ${pr => pr.disabled ?
-		theme.colors.simplyGoldDisabled
-		: theme.colors.simplyGold};
+		theme.newColors.simplyGold["60"]
+		: theme.newColors.simplyGold["100"]};
     color: ${theme.colors.almostBlack};
     max-width: 186px;
 
     &:hover {
       background-color: ${pr => pr.disabled ?
-		theme.colors.simplyGoldDisabled
-		: theme.colors.simplyGoldHover};
+		theme.newColors.simplyGold["60"]
+		: theme.newColors.darkerSimplyGold["100"]};
     }
 
     &:focus {
-      background-color: ${theme.colors.simplyGold};
+      background-color: ${theme.newColors.simplyGold["100"]};
     }
     padding: 8px 16px;
   }
@@ -53,19 +53,19 @@ export const StyledChip = styled(Chip)`
   &.MuiChip-root {
     background-color: ${pr => {
 		if (pr.selected && !pr.disabled) {
-			return theme.colors.simplyGold;
+			return theme.newColors.simplyGold["100"];
 		} else if (pr.selected && pr.disabled) {
-			return theme.colors.simplyGoldDisabled;
+			return theme.newColors.simplyGold["60"];
 		}
 		return theme.colors.gray200;
 	}};
 
     &:hover {
-      background-color: ${pr => pr.selected ? theme.colors.simplyGoldHover : theme.colors.simplyGray};
+      background-color: ${pr => pr.selected ? theme.newColors.darkerSimplyGold["100"] : theme.colors.simplyGray};
     }
 
     &:focus {
-      background-color: ${pr => pr.selected ? theme.colors.simplyGold : theme.colors.gray200};
+      background-color: ${pr => pr.selected ? theme.newColors.simplyGold["100"] : theme.colors.gray200};
     }
 
     padding: 8px 16px;

--- a/src/components/RadioButton/RadioButton.styled.tsx
+++ b/src/components/RadioButton/RadioButton.styled.tsx
@@ -10,7 +10,7 @@ export const StyledRadioButton = styled(Radio)`
     color: ${theme.colors.almostBlack};
 
     &.Mui-checked {
-      color: ${theme.colors.simplyGold};
+      color: ${theme.newColors.simplyGold["100"]};
     }
   }
 

--- a/src/components/SideNav/SideNav.styled.tsx
+++ b/src/components/SideNav/SideNav.styled.tsx
@@ -81,7 +81,7 @@ export const Badge = styled.span`
 
 export const BadgeWrapper = styled.div`
 	align-items: center;
-	background-color: ${theme.colors.simplyGold};
+	background-color: ${theme.newColors.simplyGold["100"]};
 	border-radius: 20px;
 	display: flex;
 	height: 20px;

--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponent.styled.tsx
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponent.styled.tsx
@@ -55,7 +55,7 @@ export const Title = styled.p`
 
 export const CheckedStar = styled(StarRateRounded)`
 	margin-left: 12px;
-    color: ${theme.colors.simplyGold};
+    color: ${theme.newColors.simplyGold["100"]};
 `;
 
 export const UncheckedStar = styled(StarBorder)`

--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponent.styled.tsx
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponent.styled.tsx
@@ -34,11 +34,6 @@ export const ContainerTitle = styled.div`
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-
-	& > .favorite-icon {
-		color: ${theme.colors.gray};
-		margin-left: 12px;
-	}
 `;
 
 export const Title = styled.p`

--- a/src/components/ToggleSwitch/ToggleSwitch.styled.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.styled.tsx
@@ -20,7 +20,7 @@ export const StyledSwitch = styled(Switch)`
 
   .MuiSwitch-colorPrimary.Mui-checked,
   .MuiSwitch-colorPrimary.Mui-disabled.Mui-checked {
-    color: ${theme.colors.simplyGold};
+    color: ${theme.newColors.simplyGold["100"]};
   }
 
   .MuiSwitch-colorPrimary {
@@ -34,7 +34,7 @@ export const StyledSwitch = styled(Switch)`
   .MuiSwitch-colorPrimary {
     &.Mui-checked {
       &:hover {
-        background-color: ${theme.colors.simplyGoldOpacity};
+        background-color: ${theme.newColors.simplyGold["20"]};
       }
     }
   }

--- a/src/components/ToggleSwitch/ToggleSwitch.styled.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.styled.tsx
@@ -48,12 +48,12 @@ export const StyledSwitch = styled(Switch)`
   }
 
   .MuiSwitch-colorPrimary.Mui-checked + .MuiSwitch-track {
-    background-color: #fdb92459;
+    background-color: ${theme.newColors.simplyGold["40"]};
     opacity: 1;
   }
 
   .MuiSwitch-colorPrimary.Mui-disabled.Mui-checked + .MuiSwitch-track {
-    background-color: #fdb92459;
+    background-color: ${theme.newColors.simplyGold["40"]};
   }
 
   .MuiSwitch-switchBase.Mui-disabled + .MuiSwitch-track {

--- a/src/forms/FormFieldChipSingleSelect/FormFieldChipSingleSelect.test.tsx
+++ b/src/forms/FormFieldChipSingleSelect/FormFieldChipSingleSelect.test.tsx
@@ -3,6 +3,7 @@ import { useMemo, ReactElement } from "react";
 import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
 import "@testing-library/jest-dom/extend-expect";
+import theme from "@root/theme";
 
 //Components
 import Form, { useForm, formActions } from "@root/components/Form";
@@ -100,7 +101,7 @@ describe("FormFieldChipSingleSelect component", () => {
 		const chipElements = getAllByRole("button") as HTMLInputElement[];
 		fireEvent.click(chipElements[1]);
 
-		expect(window.getComputedStyle(chipElements[1]).backgroundColor).toBe("rgb(253, 185, 36)");
+		expect(window.getComputedStyle(chipElements[1]).backgroundColor).toBe(theme.newColors.simplyGold["100"]);
 		expect(window.getComputedStyle(chipElements[2]).backgroundColor).toBe("rgb(240, 242, 245)");
 		expect(window.getComputedStyle(chipElements[3]).backgroundColor).toBe("rgb(240, 242, 245)");
 	});


### PR DESCRIPTION
## What's included?
Update references to the simplyGold color

Components that were updated
- Checkbox
- Button
- Chip
- RadioButton
- SideNav
- SummaryPageTopComponent
- ToggleSwitch - This won't have opacity

Since the new colors are plain RGB values and not RGBA the background when hovering over the switch thumb will not have opacity. I tried to add the opacity by doing something like the following but the tumb was also affected by the opacity of the background color

```
.MuiSwitch-colorPrimary {
    &.Mui-checked {
      &:hover {
        background-color: ${theme.newColors.simplyGold["100"]};
	opacity: 30%
      }
    }
  }
```

### Previous
![image](https://user-images.githubusercontent.com/87880265/199764406-0122318d-c1a0-41cc-b01b-9a50025427f9.png)


### Updated
![image](https://user-images.githubusercontent.com/87880265/199763268-f12b0cd0-8de2-4023-a19f-726dd3a3e03e.png)

