### PR TITLE
Mos 856 Address field country/state updates

### DIFF
--- a/src/components/Chip/Chip.styled.ts
+++ b/src/components/Chip/Chip.styled.ts
@@ -48,8 +48,6 @@ export const StyledDeletableChip = styled(Chip)`
 `;
 
 export const StyledChip = styled(Chip)`
-  color: ${theme.colors.almostBlack};
-
   &.MuiChip-root {
     background-color: ${pr => {
 		if (pr.selected && !pr.disabled) {
@@ -59,6 +57,7 @@ export const StyledChip = styled(Chip)`
 		}
 		return theme.colors.gray200;
 	}};
+	color: ${theme.colors.almostBlack};
 
     &:hover {
       background-color: ${pr => pr.selected ? theme.newColors.darkerSimplyGold["100"] : theme.colors.simplyGray};

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import * as stories from './Form.stories';
-// import * as addressStories from '../FormFieldAddress/Address.stories';
 
 <Meta title='Components/Form/Readme' />
 
@@ -340,7 +339,7 @@ const fields = useMemo(
 * **id** - `string` optional - Follows the same rules as any other html element id.
 * **defaultValue** - `<U>` optional - Value to be used in case no initial value is loaded from a data base. This value should be of the same type as from its corresponding field (see data of each specific field).
 * **pairedFields** - `array` of `string` optional - Array of field names to be linked to this field. When a field is being validated, it will check if it has any associated paired field. If there's one, the validators defined for each paired field will be executed. For a practical example check the [date range validator example](#validatedaterange).
-* **onChangeCb** * - `(value?: any) => void` optional - Callback that will be executed when the field triggers an onChange event.
+* **onChangeCb** - `(value?: any) => void` optional - Callback that will be executed when the field triggers an onChange event.
 
 ### How to use in a form?
 ```ts
@@ -394,6 +393,8 @@ const fields = useMemo(
 	* **amountShipping** - `number` optional - When defined, limits the amount of address type of "shipping". Takes precedence over amountPerType.
 	* **amountPhysical** - `number` optional - When defined, limits the amount of address type of "physical". Takes precedence over amountPerType.
 	* **amountBilling** - `number` optional - When defined, limits the amount of address type of "billing". Takes precedence over amountPerType.
+	* **getOptionsCountries** - `() => Promise<MosaicLabelValue[]>` required - Option for getting the options for the countries dropdown.
+	* **getOptionsStates** - `(country: string) => Promise<MosaicLabelValue[]>` required - Option for getting the options for the states dropdown, it receives a country code as parameter.
 
 ### How to use in a form?
 ```ts

--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -32,6 +32,7 @@ import { FormFieldCheckboxDef } from "@root/forms/FormFieldCheckbox";
 import { TextAreaDef } from "@root/forms/FormFieldTextArea";
 import { ButtonProps } from "@root/components/Button";
 import { NavWrapper } from "@root/components/LeftNav/NavWrapper";
+import { getOptionsCountries, getOptionsStates } from "@root/forms/FormFieldAddress/utils/optionGetters";
 
 export default {
 	title: "Components/Form",
@@ -325,6 +326,10 @@ export const Playground = (): ReactElement => {
 					name: "address",
 					label: "Address field",
 					type: "address",
+					inputSettings: {
+						getOptionsCountries,
+						getOptionsStates,
+					},
 					disabled,
 					required
 				},

--- a/src/forms/FormFieldAddress/Address.stories.tsx
+++ b/src/forms/FormFieldAddress/Address.stories.tsx
@@ -4,6 +4,7 @@ import { boolean, number, text, withKnobs } from "@storybook/addon-knobs";
 import { onCancel, renderButtons } from "@root/utils/storyUtils";
 import { FieldDef } from "../../components/Field";
 import Form, { useForm } from "@root/components/Form";
+import { getOptionsCountries, getOptionsStates } from "./utils/optionGetters";
 
 export default {
 	title: "FormFields/FormFieldAddress",
@@ -34,12 +35,24 @@ export const Playground = (): ReactElement => {
 						amountPerType,
 						amountShipping,
 						amountPhysical,
-						amountBilling
+						amountBilling,
+						getOptionsCountries,
+						getOptionsStates,
 					},
 				},
 			] as FieldDef[]
 		),
-		[disabled, label, required, amountPerType, amountShipping, amountPhysical, amountBilling]
+		[
+			disabled,
+			label,
+			required,
+			amountPerType,
+			amountShipping,
+			amountPhysical,
+			amountBilling,
+			getOptionsCountries,
+			getOptionsStates
+		]
 	);
 
 	return (

--- a/src/forms/FormFieldAddress/AddressTypes.tsx
+++ b/src/forms/FormFieldAddress/AddressTypes.tsx
@@ -46,11 +46,12 @@ export interface AddressDrawerProps {
 	setIsEditing: Dispatch<SetStateAction<boolean>>;
 	value: IAddress[];
 	addressTypes?: MosaicLabelValue[];
-
 	hasUnsavedChanges?: boolean;
 	handleUnsavedChanges?: (val: boolean) => void;
 	dialogOpen?: boolean;
 	handleDialogClose?: (val: boolean) => void;
+	getOptionsCountries: AddressFieldDef["getOptionsCountries"];
+	getOptionsStates: AddressFieldDef["getOptionsStates"];
 }
 
 export type AddressFieldDef = {
@@ -58,4 +59,6 @@ export type AddressFieldDef = {
 	amountShipping?: number;
 	amountBilling?: number;
 	amountPhysical?: number;
+	getOptionsCountries(): Promise<MosaicLabelValue[]>;
+	getOptionsStates(country: string): Promise<MosaicLabelValue[]>;
 }

--- a/src/forms/FormFieldAddress/FormFieldAddress.tsx
+++ b/src/forms/FormFieldAddress/FormFieldAddress.tsx
@@ -223,6 +223,8 @@ const FormFieldAddress = (props: MosaicFieldProps<AddressFieldDef, IAddress[]>):
 					dialogOpen={dialogOpen}
 					handleDialogClose={handleDialogClose}
 					addressTypes={addressTypes}
+					getOptionsCountries={fieldDef.inputSettings?.getOptionsCountries}
+					getOptionsStates={fieldDef.inputSettings?.getOptionsStates}
 				/>
 			</Drawer>
 		</div>

--- a/src/forms/FormFieldAddress/utils/optionGetters.ts
+++ b/src/forms/FormFieldAddress/utils/optionGetters.ts
@@ -1,0 +1,21 @@
+import { MosaicLabelValue } from "@root/types";
+import countriesWithStates from "@root/forms/FormFieldAddress/utils/trimmedCountriesStates.json";
+
+export const getOptionsCountries = async (): Promise<MosaicLabelValue[]> => {
+	return Promise.resolve(countriesWithStates.map((country) => ({
+		label: country.name,
+		value: country.iso2,
+	})));
+};
+
+export const getOptionsStates = async (countryValue: string | undefined): Promise<MosaicLabelValue[]> => {
+	const selectedCountry = countriesWithStates?.find(
+		(c) => c.iso2 === countryValue
+	);
+
+	if (selectedCountry) {
+		return Promise.resolve(selectedCountry.states.map((state) => ({ label: state.name, value: state.code })));
+	}
+
+	return Promise.resolve([]);
+};


### PR DESCRIPTION
# What's included?
- Updated FormFieldAddress types to now require getOptionsCountries and getOptionsStates callbacks.
- Updated AdressDrawer to get the corresponding country and state options from these callbacks rather than the countries JSON file.
- Updated Form and Address stories and unit tests to include the new props.
- Created a utils file that exports those 2 helper functions to be reused both in stories and unit tests.