### PR TITLE
MOS-870: Fix styles found during QA process

### DIFF
--- a/src/components/DataView/DataViewTBody.tsx
+++ b/src/components/DataView/DataViewTBody.tsx
@@ -8,7 +8,7 @@ import { MosaicObject } from "@root/types";
 
 const StyledTBody = styled.tbody`
 	& > tr {
-		border-bottom: ${theme.borders.lightGray};
+		border-bottom: 1px solid ${theme.newColors.grey2["100"]};
 
 		& > td:first-child {
 			padding-left: 8px;

--- a/src/components/DataView/DataViewTHead.tsx
+++ b/src/components/DataView/DataViewTHead.tsx
@@ -18,23 +18,23 @@ const StyledWrapper = styled.thead`
 `
 
 const StyledTh = styled.th`
-	font-size: 14px;
-	text-align: left;
-	font-weight: 400;
-	padding: 12px 32px 12px 0px;
-	height: 40px;
-	color: ${theme.colors.gray700};
-	position: sticky;
-	top: 0;
-	z-index: 2;
 	background-color: ${theme.colors.gray200};
+	color: ${theme.newColors.almostBlack["100"]};
+	font-size: 14px;
+	font-weight: 510;
+	height: 40px;
+	padding: 12px 32px 12px 0px;
+	position: sticky;
+	text-align: left;
+	top: 0;
 	white-space: nowrap;
+	z-index: 2;
 
 	&:first-child {
 		padding-left: 8px;
 	}
 	&:last-child {
-		padding-right: 8px;
+		padding-right: 8px !important;
 	}
 
 	${/* Borders on sticky elements don't carry through, so we put them on the :after element */""}
@@ -45,7 +45,6 @@ const StyledTh = styled.th`
 		right: 0;
 		bottom: 0;
 		left: 0;
-		border-bottom: ${theme.colors.gray200};
 		pointer-events: none;
 	}
 
@@ -75,12 +74,8 @@ const StyledTh = styled.th`
 	}
 
 	&.active {
-		color: ${theme.colors.gray800};
-		font-weight: 700;
-	}
-
-	&.active:after {
-		border-bottom: 1px solid ${theme.colors.gray800};
+		color: ${theme.newColors.almostBlack["100"]};
+		font-weight: 510;
 	}
 
 	&.active > .columnHeader > .icon {

--- a/src/components/DataView/DataViewTd.tsx
+++ b/src/components/DataView/DataViewTd.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from "react";
 import { DraggableProvided } from "react-beautiful-dnd";
 import styled from "styled-components";
+import theme from "@root/theme";
 
 import { BodyText } from "../Typography";
 
@@ -22,10 +23,6 @@ const StyledTd = styled.td`
 		padding-left: 32px;
 	}
 
-	&.bold {
-		font-weight: bold;
-	}
-
 	&.italic {
 		font-style: italic;
 	}
@@ -42,7 +39,12 @@ const StyledTd = styled.td`
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
-`
+	& > div {
+		color: ${theme.newColors.almostBlack["100"]};
+		font-weight: 400;
+	}
+`;
+
 interface DataViewTdProps {
 	expandCell?: any;
 	paddingRight?: any;
@@ -64,7 +66,6 @@ function DataViewTd(props: DataViewTdProps) {
 	const expandCell = props.expandCell !== undefined ? props.expandCell : false;
 	const paddingRight = props.paddingRight !== undefined ? props.paddingRight : false;
 	const paddingLeft = props.paddingLeft !== undefined ? props.paddingLeft : false;
-	const bold = props.bold !== undefined ? props.bold : false;
 	const italic = props.italic !== undefined ? props.italic : false;
 	const strikeThrough = props.strikeThrough !== undefined ? props.strikeThrough : false;
 	const noWrap = props.noWrap !== undefined ? props.noWrap : false;
@@ -78,7 +79,6 @@ function DataViewTd(props: DataViewTdProps) {
 				${expandCell ? "expandCell" : ""}
 				${paddingRight ? "paddingRight" : ""}
 				${paddingLeft ? "paddingLeft" : ""}
-				${bold ? "bold" : ""}
 				${italic ? "italic" : ""}
 				${strikeThrough ? "strikeThrough" : ""}
 			`}

--- a/src/components/DataView/DataViewTd.tsx
+++ b/src/components/DataView/DataViewTd.tsx
@@ -23,6 +23,10 @@ const StyledTd = styled.td`
 		padding-left: 32px;
 	}
 
+	&.bold {
+		font-weight: bold;
+	}
+
 	&.italic {
 		font-style: italic;
 	}
@@ -66,6 +70,7 @@ function DataViewTd(props: DataViewTdProps) {
 	const expandCell = props.expandCell !== undefined ? props.expandCell : false;
 	const paddingRight = props.paddingRight !== undefined ? props.paddingRight : false;
 	const paddingLeft = props.paddingLeft !== undefined ? props.paddingLeft : false;
+	const bold = props.bold !== undefined ? props.bold : false;
 	const italic = props.italic !== undefined ? props.italic : false;
 	const strikeThrough = props.strikeThrough !== undefined ? props.strikeThrough : false;
 	const noWrap = props.noWrap !== undefined ? props.noWrap : false;
@@ -79,6 +84,7 @@ function DataViewTd(props: DataViewTdProps) {
 				${expandCell ? "expandCell" : ""}
 				${paddingRight ? "paddingRight" : ""}
 				${paddingLeft ? "paddingLeft" : ""}
+				${bold ? "bold" : ""}
 				${italic ? "italic" : ""}
 				${strikeThrough ? "strikeThrough" : ""}
 			`}

--- a/src/components/DataView/DataViewTr/DataViewTr.tsx
+++ b/src/components/DataView/DataViewTr/DataViewTr.tsx
@@ -7,6 +7,7 @@ import { Draggable } from "react-beautiful-dnd";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import { TableRow } from "./DataViewTr.styled";
 import { DataViewTrProps } from "./DataViewTrTypes";
+import theme from "@root/theme";
 
 //TODO PROPS
 function DataViewTr(props: DataViewTrProps) {
@@ -22,7 +23,7 @@ function DataViewTr(props: DataViewTrProps) {
 					{
 						props?.onReorder &&
 						<DataViewTd key="_draggable" draggableProvider={provider} paddingRight={true}>
-							<DragIndicatorIcon style={{display: "flex"}}/>
+							<DragIndicatorIcon style={{display: "flex", color: theme.newColors.almostBlack["100"]}}/>
 						</DataViewTd>
 					}
 					{
@@ -49,7 +50,6 @@ function DataViewTr(props: DataViewTrProps) {
 									className={column.style && column.style.bold && "bold"}
 									paddingRight={true}
 									expandCell={true}
-									bold={column.style && column.style.bold}
 									italic={column.style && column.style.italic}
 									strikeThrough={column.style && column.style.strikeThrough}
 									noWrap={column.style && column.style.noWrap}

--- a/src/components/DataView/DataViewTr/DataViewTr.tsx
+++ b/src/components/DataView/DataViewTr/DataViewTr.tsx
@@ -50,6 +50,7 @@ function DataViewTr(props: DataViewTrProps) {
 									className={column.style && column.style.bold && "bold"}
 									paddingRight={true}
 									expandCell={true}
+									bold={column.style && column.style.bold}
 									italic={column.style && column.style.italic}
 									strikeThrough={column.style && column.style.strikeThrough}
 									noWrap={column.style && column.style.noWrap}

--- a/src/components/DataView/example/DataViewKitchenSink.tsx
+++ b/src/components/DataView/example/DataViewKitchenSink.tsx
@@ -6,7 +6,7 @@ import { boolean, select } from "@storybook/addon-knobs";
 import AddIcon from "@mui/icons-material/Add";
 import CreateIcon from "@mui/icons-material/Create";
 import DeleteIcon from "@mui/icons-material/Delete";
-import CloudDownloadIcon from "@mui/icons-material/CloudDownload";
+import GetAppIcon from "@mui/icons-material/GetApp";
 
 import JSONDB from "@root/utils/JSONDB";
 import LocalStorageDB from "@root/utils/LocalStorageDB";
@@ -583,7 +583,7 @@ function DataViewKitchenSink(): ReactElement {
 				name: "download",
 				color: "black",
 				variant: "icon",
-				mIcon: CloudDownloadIcon,
+				mIcon: GetAppIcon,
 				onClick: function ({ data }) {
 					alert(`DOWNLOAD ${data.map(val => val.id)}`);
 				}

--- a/src/components/DataView/example/DataViewKitchenSink.tsx
+++ b/src/components/DataView/example/DataViewKitchenSink.tsx
@@ -263,9 +263,6 @@ const listColumns = [
 	{
 		name: "title",
 		label: "Title",
-		style: {
-			bold: true
-		},
 		sortable: true
 	},
 	{
@@ -329,9 +326,6 @@ const listColumns = [
 		name: "bold",
 		label: "Style - bold",
 		column: "content_owner",
-		style: {
-			bold: true
-		}
 	},
 	{
 		name: "italic",


### PR DESCRIPTION
## What's included?

- The right padding of the table header should be 8px.
- Font-color for table header should be #1A1A1A and the font-weight should be 510.
- Font-color for each row should be #1A1A1A and the font-weight should be 400.
- The drag and drop icon color should be #1A1A1A in the table, fin the columns settings it is correct.
- Title column should not have the black line below and the name of the column should not go in bold either.
- Change download icon
- Bottom border color of each row should be solid rgba(240, 242, 245, 1).
