### PR TITLE
MOS-884: Apply styles to Filter Text

### DIFF
--- a/src/components/DataViewFilterDropdown/DataViewFilterDropdown.styled.ts
+++ b/src/components/DataViewFilterDropdown/DataViewFilterDropdown.styled.ts
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+import theme from "@root/theme";
+import Popover from "@mui/material/Popover";
+
+export const StyledWrapper = styled.div`
+	font-family: ${theme.fontFamily};
+	padding: 10px;
+	border-radius: 5px;
+	border: 1px solid ${theme.newColors.grey2["100"]};
+	background: white;
+`;
+
+export const StyledPopover = styled(Popover)`
+	.MuiPaper-root {
+		box-shadow: 0px 2px 6px ${theme.newColors.almostBlack["20"]};
+	}
+`;

--- a/src/components/DataViewFilterDropdown/DataViewFilterDropdown.tsx
+++ b/src/components/DataViewFilterDropdown/DataViewFilterDropdown.tsx
@@ -1,17 +1,6 @@
 import React, { useState, useEffect } from "react";
-import styled from "styled-components";
+import { StyledPopover, StyledWrapper } from "./DataViewFilterDropdown.styled";
 // import jsvalidator from "jsvalidator";
-import Popover from "@mui/material/Popover";
-
-import theme from "@root/theme";
-
-const StyledWrapper = styled.div`
-	font-family: ${theme.fontFamily};
-	padding: 10px;
-	border-radius: 8px;
-	background: white;
-`
-
 interface DataViewFilterDropdownProps {
 	anchorEl?: any;
 	onExited?: any;
@@ -60,7 +49,7 @@ function DataViewFilterDropdown(props: DataViewFilterDropdownProps) {
 	}
 
 	return (
-		<Popover
+		<StyledPopover
 			anchorEl={props.anchorEl}
 			onClose={props.onClose}
 			open={Boolean(props.anchorEl)}
@@ -74,7 +63,7 @@ function DataViewFilterDropdown(props: DataViewFilterDropdownProps) {
 			<StyledWrapper>
 				{props.children}
 			</StyledWrapper>
-		</Popover>
+		</StyledPopover>
 	)
 }
 

--- a/src/components/DataViewFilterText/DataViewFilterText.styled.ts
+++ b/src/components/DataViewFilterText/DataViewFilterText.styled.ts
@@ -1,6 +1,8 @@
 import styled from "styled-components";
 
 export const StyledContents = styled.div`
+	margin: 0px 6px;
+
 	& > .inputRow {
 		display: flex;
 		align-items: center;

--- a/src/forms/FormFieldText/FormFieldText.styled.tsx
+++ b/src/forms/FormFieldText/FormFieldText.styled.tsx
@@ -28,7 +28,14 @@ export const StyledTextField = styled(({ fieldSize, ...rest }) => (
   }
 
   input.MuiOutlinedInput-input {
+    color: ${theme.newColors.almostBlack["100"]};
     height: ${theme.fieldSpecs.inputText.height};
+		font-weight: 400;
+  }
+
+  input::placeholder {
+    color: ${theme.newColors.grey3["100"]};
+		font-weight: 400;
   }
 
   input,

--- a/src/forms/FormFieldText/FormFieldText.styled.tsx
+++ b/src/forms/FormFieldText/FormFieldText.styled.tsx
@@ -15,11 +15,11 @@ export const StyledTextField = styled(({ fieldSize, ...rest }) => (
   &.MuiFormControl-root {
     background-color: ${pr => pr.disabled ? "#fff" : theme.colors.gray100};
     &:hover {
-      background-color: ${pr => pr.disabled ? "transparent" : theme.colors.grayHover};
+    	background-color: ${pr => pr.disabled ? "transparent" : theme.colors.grayHover};
 
-      & fieldset {
-				border-color: ${theme.colors.simplyGray};
-			}
+    	& fieldset {
+			border-color: ${theme.colors.simplyGray};
+		}
     }
   }
 
@@ -30,12 +30,12 @@ export const StyledTextField = styled(({ fieldSize, ...rest }) => (
   input.MuiOutlinedInput-input {
     color: ${theme.newColors.almostBlack["100"]};
     height: ${theme.fieldSpecs.inputText.height};
-		font-weight: 400;
+	font-weight: 400;
   }
 
   input::placeholder {
     color: ${theme.newColors.grey3["100"]};
-		font-weight: 400;
+	font-weight: 400;
   }
 
   input,


### PR DESCRIPTION
## What's included?
Fixes the following points found by QA

- Verify input-placeholder style(font-family, font-color, font-size,font-weight).

Font family and font size were correct

-  Filter unfolded- Search style should be:

Border: 1px solid rgba(240, 242, 245, 1).
 
Box-shadow: 0px 2px 6px 0px rgba(26, 26, 26, 0.25). This color is our almostBlack, but we have not defined a variant opacity of 25%, so the value chosen was with 20% opacity since is the closest one.
 
Border-radius 5px.