### PR TITLE
MOS-886: Show descriptive error for invalid column or active filter

### DIFF
--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -259,6 +259,20 @@ function DataView (props: DataViewProps): ReactElement  {
 		checkedAllPages : false
 	});
 
+	/**
+	 * Checks if a provided active filter is a
+	 * valid filter based on the name.
+	 */
+	useEffect(() => {
+		props?.activeFilters?.forEach(activeFilter => {
+			const filterFound = props?.filters?.find(val => val.name === activeFilter);
+
+			if (!filterFound) {
+				throw new Error(`Active filter "${activeFilter}" is not a valid filter.`)
+			}
+		})
+	}, [props.activeFilters, props.filters]);
+
 	// set defaults
 	const display = props.display || "list";
 	const displayOptions = useMemo(() => props.displayOptions || [display], [display, props.displayOptions]);
@@ -366,6 +380,11 @@ function DataView (props: DataViewProps): ReactElement  {
 	const activeColumnObjs = useMemo(() => {
 		return activeColumns.map(name => {
 			const column = props.columns.find(val => val.name === name);
+
+			if (!column) {
+				throw new Error(`Active column "${name}" is not defined in the columns list.`)
+			}
+
 			return column;
 		});
 	}, [activeColumns, props.columns]);

--- a/src/components/DataView/DataViewFilters.tsx
+++ b/src/components/DataView/DataViewFilters.tsx
@@ -33,7 +33,6 @@ function DataViewFilters(props: DataViewFiltersProps) {
 		dropdownOpen : false
 	});
 
-
 	const activeFilters = props.activeFilters || [];
 
 	const active = props.filters.filter(val => activeFilters.includes(val.name));

--- a/src/components/DataView/example/DataViewKitchenSink.tsx
+++ b/src/components/DataView/example/DataViewKitchenSink.tsx
@@ -218,7 +218,7 @@ const filters: {
 			comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"]
 		}
 	}
-]
+];
 
 const rootDefaultView: DataViewProps["savedView"] = {
 	id: "default",
@@ -236,7 +236,7 @@ const rootDefaultView: DataViewProps["savedView"] = {
 		activeFilters: [],
 		activeColumns: ["image", "title", "categories", "created"]
 	}
-}
+};
 
 const listColumns = [
 	{


### PR DESCRIPTION
## What's included?

Throws a descriptive error when an invalid column or active filter is passed to the DataView, indicating which column or filter is not valid.

## How to test it?

In DataViewKitchenSink.tsx add a random value to activeFilters or activeColumns and the custom error should be displayed.

```
const rootDefaultView: DataViewProps["savedView"] = {
	id: "default",
	label: "All",
	type: "default",
	state: {
		limit: 25,
		skip: 0,
		filter: {},
		sort: {
			name: "title",
			dir: "asc"
		},
		display: "list",
		activeFilters: ["foo"], <---
		activeColumns: ["image", "title", "categories", "created", "bar"] <---
	}
};
```