### PR TITLE
MOS-876: Form sections pickers scroll behaviour fixed

### DIFF
--- a/src/components/DataView/DataView.test.tsx
+++ b/src/components/DataView/DataView.test.tsx
@@ -9,8 +9,7 @@ describe("DataViewFilterText component", () => {
 	it("Should display Equals comparison filter when the developer has passed an empty string in comparisonDefault", async () => {
 		render(
 			<DataViewFilterText
-				label = "Title with Comparisons"
-				type = "optional"
+				label = "Title with Comparisons:"
 				data = {{}}
 				args = {{
 					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"],
@@ -29,8 +28,7 @@ describe("DataViewFilterText component", () => {
 	it("Should display Not Equal comparison filter when the developer has passed as not_equals string in comparisonDefault", async () => {
 		render(
 			<DataViewFilterText
-				label = "Title with Comparisons"
-				type = "optional"
+				label = "Title with Comparisons:"
 				data = {{}}
 				args = {{
 					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"],
@@ -49,8 +47,7 @@ describe("DataViewFilterText component", () => {
 	it("Should display Equals comparison filter when the developer has not passed the comparisonDefault prop", async () => {
 		render(
 			<DataViewFilterText
-				label = "Title with Comparisons"
-				type = "optional"
+				label = "Title with Comparisons:"
 				data = {{}}
 				args = {{
 					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"]
@@ -69,8 +66,7 @@ describe("DataViewFilterText component", () => {
 		jest.spyOn(console, "error").mockImplementation(() => jest.fn());
 		expect(() => render(
 			<DataViewFilterText
-				label = "Title with Comparisons"
-				type = "optional"
+				label = "Title with Comparisons:"
 				data = {{}}
 				args = {{
 					comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"],

--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -607,12 +607,7 @@ export const FormWithLayout = (props: {height?: string}): ReactElement => {
 			description: "Description for section 3",
 			fields: [
 				// row 1
-				[[], [], []],
-				// row 2
-				[[], [], []],
-				[[]],
-				// row 3
-				[[], []]
+				[["text1"], [], []],
 			]
 		},
 	], [fields]);

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -31,7 +31,6 @@ const Form = (props: FormProps) => {
 
 	const { view } = useWindowResizer(type);
 	const sectionsRef = useRef<HTMLDivElement[]>([]);
-	const contentRef = useRef();
 	const topComponentRef = useRef<HTMLDivElement>();
 	const [topComponentHeight, setTopComponentHeight] = useState<number>();
 	const [sectionsRefs, setSectionsRefs] = useState<HTMLDivElement[]>([]);
@@ -142,15 +141,14 @@ const Form = (props: FormProps) => {
 							}
 							buttons={filteredButtons}
 							sectionsRefs={sectionsRefs}
-							contentRef={contentRef}
 						/>
 					}
 					{view === "BIG_DESKTOP" && sections ? (
 						<Row topComponentHeight={topComponentHeight}>
 							{sections &&
-								<FormNav sectionsRefs={sectionsRefs} contentRef={contentRef} sections={sections} />
+								<FormNav sectionsRefs={sectionsRefs} sections={sections} />
 							}
-							<FormContent view={view} sections={sections} ref={contentRef}>
+							<FormContent view={view} sections={sections}>
 								<FormLayout
 									ref={sectionsRef}
 									state={state}
@@ -162,7 +160,7 @@ const Form = (props: FormProps) => {
 							</FormContent>
 						</Row>
 					) : (
-						<FormContent view={view} sections={sections} ref={contentRef}>
+						<FormContent view={view} sections={sections}>
 							<FormLayout
 								ref={sectionsRef}
 								state={state}

--- a/src/components/Form/Section.tsx
+++ b/src/components/Form/Section.tsx
@@ -68,12 +68,11 @@ const Section = forwardRef((props: SectionPropTypes, ref) => {
 
 	return (
 		<StyledSection
-			ref={ref}
 			hasTitle={title}
 			id={sectionIdx}
 			data-testid="section-test-id"
 		>
-			{title && <StyledTitle>{title}</StyledTitle>}
+			{title && <StyledTitle id={sectionIdx} ref={ref}>{title}</StyledTitle>}
 			{description && <StyledDescription>{description}</StyledDescription>}
 			{rows && (
 				<StyledRows view={view} hasTitle={title}>

--- a/src/forms/FormNav/FormNav.test.tsx
+++ b/src/forms/FormNav/FormNav.test.tsx
@@ -48,7 +48,13 @@ const FormNavExample = (): ReactElement => {
 };
 
 const scrollIntoViewMock = jest.fn();
-
+const mockIntersectionObserver = jest.fn();
+mockIntersectionObserver.mockReturnValue({
+	observe: () => null,
+	unobserve: () => null,
+	disconnect: () => null
+});
+window.IntersectionObserver = mockIntersectionObserver;
 
 describe("FormNav component", () => {
 	beforeEach(() => {

--- a/src/forms/FormNav/FormNav.tsx
+++ b/src/forms/FormNav/FormNav.tsx
@@ -73,42 +73,26 @@ const FormNav = (props: FormNavProps): ReactElement => {
 	 */
 	const handleClick = (e: MouseEvent, idx: number) => {
 		e.preventDefault();
-		const sectionId = sectionsRefs[idx]?.getAttribute("id");
-		sectionsRefs[idx].scrollIntoView({ behavior: "auto", block: "center", inline: "center"});
-		setSelectedTab(Number(sectionId));
+		sectionsRefs[idx].scrollIntoView({ behavior: "smooth", block: "start" });
 	};
 
 	useEffect(() => {
-		const navHighlighter = () => {
-			const scrollY = contentRef.current.scrollTop;
-			if (sectionsRefs.length === 0) {
-				return;
-			}
+		const observer = new IntersectionObserver((entries) => {
+			entries.forEach(entry => {
+				const sectionId = entry?.target.getAttribute("id");
 
-			sectionsRefs?.forEach(current => {
-				const currentSection = current as HTMLDivElement;
-				const sectionHeight = currentSection?.offsetHeight;
-				const sectionTop = currentSection?.offsetTop - 350;
-				const sectionId = currentSection?.getAttribute("id");
-
-				if (
-					scrollY > sectionTop &&
-					scrollY <= sectionTop + sectionHeight
-				) {
+				if (entry.isIntersecting) {
 					setSelectedTab(Number(sectionId));
 				}
-			});
-		};
+			})
+		}, { threshold: 0.9 });
 
-		const navHighlighterDebounced = debounce(navHighlighter, 200, { maxWait: 100 });
+		sectionsRefs?.forEach(section => {
+			observer.observe(section);
+		})
 
-		contentRef?.current?.addEventListener("scroll", navHighlighterDebounced);
-
-		return () => {
-			contentRef?.current?.removeEventListener("scroll", navHighlighterDebounced);
-			navHighlighterDebounced.cancel();
-		};
-	}, [sectionsRefs, contentRef, selectedTab]);
+		return () => observer.disconnect();
+	}, [sectionsRefs])
 
 	return (
 		<FormNavWrapper className="form-nav-wrapper">

--- a/src/forms/FormNav/FormNav.tsx
+++ b/src/forms/FormNav/FormNav.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState, useRef, useEffect, ReactElement, memo } from "react";
+import { useState, useRef, useEffect, ReactElement, memo, MouseEvent } from "react";
 import { debounce } from "lodash";
 import {
 	FormNavWrapper,
@@ -71,9 +71,11 @@ const FormNav = (props: FormNavProps): ReactElement => {
 	 * @param idx
 	 * @param sectionId
 	 */
-	const handleClick = (e, idx: number) => {
+	const handleClick = (e: MouseEvent, idx: number) => {
 		e.preventDefault();
-		sectionsRefs[idx].scrollIntoView({ behavior: "smooth", block: "start", inline: "nearest"});
+		const sectionId = sectionsRefs[idx]?.getAttribute("id");
+		sectionsRefs[idx].scrollIntoView({ behavior: "auto", block: "center", inline: "center"});
+		setSelectedTab(Number(sectionId));
 	};
 
 	useEffect(() => {
@@ -88,6 +90,7 @@ const FormNav = (props: FormNavProps): ReactElement => {
 				const sectionHeight = currentSection?.offsetHeight;
 				const sectionTop = currentSection?.offsetTop - 350;
 				const sectionId = currentSection?.getAttribute("id");
+
 				if (
 					scrollY > sectionTop &&
 					scrollY <= sectionTop + sectionHeight
@@ -105,7 +108,7 @@ const FormNav = (props: FormNavProps): ReactElement => {
 			contentRef?.current?.removeEventListener("scroll", navHighlighterDebounced);
 			navHighlighterDebounced.cancel();
 		};
-	}, [sectionsRefs, contentRef]);
+	}, [sectionsRefs, contentRef, selectedTab]);
 
 	return (
 		<FormNavWrapper className="form-nav-wrapper">

--- a/src/forms/FormNav/FormNav.tsx
+++ b/src/forms/FormNav/FormNav.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { useState, useRef, useEffect, ReactElement, memo, MouseEvent } from "react";
-import { debounce } from "lodash";
 import {
 	FormNavWrapper,
 	FormNavRow,
@@ -15,7 +14,7 @@ import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import { FormNavProps } from "./FormNavTypes";
 
 const FormNav = (props: FormNavProps): ReactElement => {
-	const { sections, sectionsRefs, contentRef } = props;
+	const { sections, sectionsRefs } = props;
 
 	if (sections.length <= 1) return (<></>)
 

--- a/src/forms/FormNav/FormNav.tsx
+++ b/src/forms/FormNav/FormNav.tsx
@@ -84,7 +84,7 @@ const FormNav = (props: FormNavProps): ReactElement => {
 					setSelectedTab(Number(sectionId));
 				}
 			})
-		}, { threshold: 0.9 });
+		}, { threshold: 0.5, rootMargin: '-20px 0px -20%' });
 
 		sectionsRefs?.forEach(section => {
 			observer.observe(section);

--- a/src/forms/FormNav/FormNavTypes.tsx
+++ b/src/forms/FormNav/FormNavTypes.tsx
@@ -6,5 +6,4 @@ export interface Section {
 export interface FormNavProps {
   sections: Section[];
   sectionsRefs?: HTMLDivElement[] | [];
-  contentRef?: any;
 }

--- a/src/forms/TopComponent/TopComponent.test.tsx
+++ b/src/forms/TopComponent/TopComponent.test.tsx
@@ -74,6 +74,13 @@ const TopComponentExample = () => {
 };
 
 const { getByText, getAllByText, getByTestId, queryByTestId, queryByText } = screen;
+const mockIntersectionObserver = jest.fn();
+mockIntersectionObserver.mockReturnValue({
+	observe: () => null,
+	unobserve: () => null,
+	disconnect: () => null
+});
+window.IntersectionObserver = mockIntersectionObserver;
 
 describe("TopComponent", () => {
 	beforeEach(() => {

--- a/src/forms/TopComponent/TopComponent.tsx
+++ b/src/forms/TopComponent/TopComponent.tsx
@@ -26,7 +26,6 @@ const TopComponent = forwardRef<HTMLDivElement, TopComponentProps>((props: TopCo
 		sections,
 		view = "RESPONSIVE",
 		sectionsRefs,
-		contentRef,
 	} = props;
 
 	// State variables
@@ -122,7 +121,6 @@ const TopComponent = forwardRef<HTMLDivElement, TopComponentProps>((props: TopCo
 					sections={sections}
 					view={view}
 					sectionsRefs={sectionsRefs}
-					contentRef={contentRef}
 				/>
 			);
 		if (view === "DESKTOP" || view === "BIG_DESKTOP")
@@ -139,7 +137,6 @@ const TopComponent = forwardRef<HTMLDivElement, TopComponentProps>((props: TopCo
 					buttons={buttons}
 					sections={sections}
 					view={view}
-					contentRef={contentRef}
 				/>
 			);
 

--- a/src/forms/TopComponent/Views/DesktopView.tsx
+++ b/src/forms/TopComponent/Views/DesktopView.tsx
@@ -53,7 +53,6 @@ type DesktopViewProps = {
 	sections: TopComponentProps["sections"];
 	checkbox: JSX.Element;
 	sectionsRefs?: any[];
-	contentRef?: any;
 } & BaseTopComponentProps;
 
 const DesktopView = forwardRef((props: DesktopViewProps, ref): ReactElement => {
@@ -68,7 +67,6 @@ const DesktopView = forwardRef((props: DesktopViewProps, ref): ReactElement => {
 		checkbox,
 		view,
 		sectionsRefs,
-		contentRef,
 	} = props;
 
 	return (
@@ -89,7 +87,7 @@ const DesktopView = forwardRef((props: DesktopViewProps, ref): ReactElement => {
 			</FlexContainer>
 			{(view !== "BIG_DESKTOP" && sections) && (
 				<FlexContainer>
-					<FormNav sectionsRefs={sectionsRefs} sections={sections} contentRef={contentRef}/>
+					<FormNav sectionsRefs={sectionsRefs} sections={sections} />
 				</FlexContainer>
 			)}
 		</DesktopViewColumn>

--- a/src/forms/TopComponent/Views/ResponsiveView.tsx
+++ b/src/forms/TopComponent/Views/ResponsiveView.tsx
@@ -34,7 +34,6 @@ type ResponsiveViewProps = {
 	sections: TopComponentProps["sections"];
 	checkbox: JSX.Element;
 	sectionsRefs?: any[];
-	contentRef?: any;
 } & BaseTopComponentProps;
 
 const ResponsiveView = forwardRef((props: ResponsiveViewProps, ref): ReactElement => {
@@ -48,7 +47,6 @@ const ResponsiveView = forwardRef((props: ResponsiveViewProps, ref): ReactElemen
 		sections,
 		checkbox,
 		sectionsRefs,
-		contentRef,
 		view
 	} = props;
 
@@ -73,7 +71,7 @@ const ResponsiveView = forwardRef((props: ResponsiveViewProps, ref): ReactElemen
 				)}
 			</ResponsiveActionsRow>
 			{sections &&
-				<FormNav sectionsRefs={sectionsRefs} sections={sections} contentRef={contentRef} />
+				<FormNav sectionsRefs={sectionsRefs} sections={sections} />
 			}
 		</ResponsiveViewColumn>
 	);


### PR DESCRIPTION
## What's included?
Changes scroll behavior for the Form sections.

## How to test it?
I've defined sections of different sizes and tested the section highlight when clicking or scrolling. Example of mock sections

```
	const sections = useMemo(() => [
			{
				title: "Section 1",
				description: "Description for section 1",
				fields: [
					// row 1
					[["text1"], ["text2"], ["text3"]],
					// row 2
					[["check"], ["text4"], ["color"]],
					[[]],
					// row 3
					[["toggleSwitch"], ["imageUpload"]]
				]
			},
			{
				title: "Section 4",
				description: "Description for section 3",
				fields: [
					// row 1
					[[], [], []],
					// row 2
					[[], [], []],
					[[]],
					// row 3
					[[], []]
				]
			},
			{
				title: "Section 2",
				description: "Description for section 2",
				fields: [
					// row 1
					[["check"], ["toggleSwitch"], ["color"]],
					// row 2
					[[], [], []],
					// row 3
					[[]],
					// row 4
					[[], ["textEditor"]]
				]
			},
			{
				title: "Section 3",
				description: "Description for section 3",
				fields: [
					// row 1
					[[], [], []],
					// row 2
					[[], [], []],
					[[]],
					// row 3
					[[], []]
				]
			},
			{
				title: "Section 12",
				description: "Description for section 1",
				fields: [
					// row 1
					[["text1"], ["text2"], ["text3"]],
					// row 2
					[["check"], ["text4"], ["color"]],
					[[]],
					// row 3
					[["toggleSwitch"], ["imageUpload"]]
				]
			},
			{
				title: "Section 5",
				description: "Description for section 3",
				fields: [
					// row 1
					[[], [], []],
					// row 2
					[[], [], []],
					[[]],
					// row 3
					[[], []]
				]
			},
		], [fields]);
```