### PR TITLE
MOS-900: Form disable logic on load not disabling correctly

### DIFF
--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -457,7 +457,14 @@ export const Playground = (): ReactElement => {
 
 	const sectionsAmount = sections.slice(0, showSections)
 
-	const onLoad = useCallback(async () => {
+	/**
+	 * Function that prepopulates the form. Includes
+	 * an artificial delay just to show how the form
+	 * is disabled while fields values are being resolved.
+	 */
+	const getFormValues = useCallback(async () => {
+		await new Promise((res) => setTimeout(res, 1000));
+
 		return {
 			...prepopulateValues
 		};
@@ -483,7 +490,7 @@ export const Playground = (): ReactElement => {
 					state={state}
 					fields={fields}
 					dispatch={dispatch}
-					getFormValues={loadReady && onLoad}
+					getFormValues={loadReady && getFormValues}
 					sections={showSections > 0 && sectionsAmount}
 					buttons={renderButtons(dispatch, { showCancel, showSave })}
 				/>

--- a/src/components/Form/Form.test.tsx
+++ b/src/components/Form/Form.test.tsx
@@ -446,7 +446,7 @@ describe("REDUCERS: FORM_RESET", () => {
 					validating: {},
 					custom: {},
 					validForm: false,
-					disabled: null,
+					disabled: false,
 				},
 			},
 		}
@@ -857,10 +857,6 @@ describe("DISPATCHERS: setFormValues", () => {
 				}],
 				calls: [
 					{
-						type: "FORM_START_DISABLE",
-						value: true,
-					},
-					{
 						type: "FIELD_ON_CHANGE",
 						name: "field1",
 						value: "value1",
@@ -870,6 +866,35 @@ describe("DISPATCHERS: setFormValues", () => {
 						name: "field2",
 						value: "value2",
 					},
+				]
+			}
+		},
+	];
+
+	runTests(tests, "dispatch");
+});
+
+describe("DISPATCHERS: disableForm", () => {
+	const tests = [
+		{
+			name: "Disables the form",
+			args: {
+				action: "disableForm",
+				args: [true],
+				calls: [
+					{
+						type: "FORM_START_DISABLE",
+						value: true,
+					}
+				]
+			}
+		},
+		{
+			name: "Enables the form",
+			args: {
+				action: "disableForm",
+				args: [false],
+				calls: [
 					{
 						type: "FORM_END_DISABLE",
 						value: false,

--- a/src/components/Form/Form.test.tsx
+++ b/src/components/Form/Form.test.tsx
@@ -880,7 +880,7 @@ describe("DISPATCHERS: disableForm", () => {
 			name: "Disables the form",
 			args: {
 				action: "disableForm",
-				args: [true],
+				args: [{ disabled: true }],
 				calls: [
 					{
 						type: "FORM_START_DISABLE",
@@ -893,7 +893,7 @@ describe("DISPATCHERS: disableForm", () => {
 			name: "Enables the form",
 			args: {
 				action: "disableForm",
-				args: [false],
+				args: [{ disabled: false }],
 				calls: [
 					{
 						type: "FORM_END_DISABLE",

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -66,9 +66,9 @@ const Form = (props: FormProps) => {
 	useEffect(() => {
 		const loadFormValues = async () => {
 			let values: MosaicObject;
+			await dispatch(formActions.disableForm({ disabled: true }));
 
 			if (getFormValues) {
-				await dispatch(formActions.disableForm(true));
 				values = await getFormValues();
 			} else {
 				fields.forEach(field => {
@@ -90,7 +90,7 @@ const Form = (props: FormProps) => {
 				);
 			}
 
-			await dispatch(formActions.disableForm(false));
+			await dispatch(formActions.disableForm({ disabled: false }));
 		}
 
 		loadFormValues();

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -68,6 +68,7 @@ const Form = (props: FormProps) => {
 			let values: MosaicObject;
 
 			if (getFormValues) {
+				await dispatch(formActions.disableForm(true));
 				values = await getFormValues();
 			} else {
 				fields.forEach(field => {
@@ -78,14 +79,18 @@ const Form = (props: FormProps) => {
 						};
 					}
 				});
+
 			}
 
-			if (values)
+			if (values) {
 				await dispatch(
 					formActions.setFormValues({
 						values
 					})
 				);
+			}
+
+			await dispatch(formActions.disableForm(false));
 		}
 
 		loadFormValues();

--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -168,11 +168,6 @@ export const formActions = {
 	},
 	setFormValues({ values }: { values: MosaicObject }) {
 		return async function (dispatch): Promise<void> {
-			await dispatch({
-				type: "FORM_START_DISABLE",
-				value: true,
-			});
-
 			for (const [key, value] of Object.entries(values)) {
 				await dispatch(
 					formActions.setFieldValue({
@@ -181,13 +176,16 @@ export const formActions = {
 					})
 				);
 			}
-
-			await dispatch({
-				type: "FORM_END_DISABLE",
-				value: false,
-			});
 		}
 	},
+	disableForm(disabled: boolean) {
+		return async function (dispatch): Promise<void> {
+			await dispatch({
+				type: disabled ? "FORM_START_DISABLE" : "FORM_END_DISABLE",
+				value: disabled,
+			});
+		}
+	}
 };
 
 export default formActions;

--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -178,7 +178,7 @@ export const formActions = {
 			}
 		}
 	},
-	disableForm(disabled: boolean) {
+	disableForm({ disabled = false }: { disabled: boolean }) {
 		return async function (dispatch): Promise<void> {
 			await dispatch({
 				type: disabled ? "FORM_START_DISABLE" : "FORM_END_DISABLE",

--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -7,7 +7,7 @@ type State = {
 	validating: any;
 	custom: unknown;
 	validForm: boolean;
-	disabled: unknown;
+	disabled: boolean;
 }
 
 type Action = {
@@ -51,6 +51,7 @@ export function coreReducer(state: State, action: Action): State {
 			}
 		};
 	case "FORM_START_DISABLE":
+		//console.log("Action value", action.value)
 		return {
 			...state,
 			disabled: action.value
@@ -73,7 +74,7 @@ export function coreReducer(state: State, action: Action): State {
 			validating: {},
 			custom: {},
 			validForm: false,
-			disabled: null,
+			disabled: false,
 		}
 	default:
 		return state;
@@ -101,7 +102,7 @@ export function useForm(): UseFormReturn {
 			validating: {},
 			custom: {},
 			validForm: false,
-			disabled: null,
+			disabled: false,
 		},
 		extraArgs.current
 	);


### PR DESCRIPTION
## What's included?

Disabling form logic changed when it is prepopulated.

## How to test it?

Go to the Form playground story and prepopulate it. You should see the screen block for a second and then all the fields filled.