### PR TITLE
MOS-848: Update all references to simply gray

### DIFF
--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -314,7 +314,7 @@ export const types = {
 	gray_outlined: styled(GrayOnWhite)`
     & > button {
       background-color: white;
-      border: 2px solid ${theme.colors.simplyGray};
+      border: 2px solid ${theme.newColors.simplyGrey["100"]};
       border-radius: 0;
       font-size: 14px;
       text-transform: uppercase;
@@ -322,7 +322,7 @@ export const types = {
 
     .MuiButton-outlined.Mui-disabled {
       background-color: white;
-      border: 2px solid ${theme.colors.simplyGray};
+      border: 2px solid ${theme.newColors.simplyGrey["100"]};
       color: ${theme.newColors.almostBlack["100"]};
       opacity: 0.5;
     }
@@ -330,7 +330,7 @@ export const types = {
     & > button:hover {
       background-color: ${theme.colors.gray200};
       color: ${theme.newColors.almostBlack["100"]};
-			border: 2px solid ${theme.colors.simplyGray};
+			border: 2px solid ${theme.newColors.simplyGrey["100"]};
     }
   `,
 	teal_outlined: styled(TealOnWhite)`

--- a/src/components/Chip/Chip.styled.ts
+++ b/src/components/Chip/Chip.styled.ts
@@ -60,7 +60,7 @@ export const StyledChip = styled(Chip)`
 	color: ${theme.newColors.almostBlack["100"]};
 
     &:hover {
-      background-color: ${pr => pr.selected ? theme.newColors.darkerSimplyGold["100"] : theme.colors.simplyGray};
+      background-color: ${pr => pr.selected ? theme.newColors.darkerSimplyGold["100"] : theme.newColors.simplyGrey["100"]};
     }
 
     &:focus {

--- a/src/components/Field/InstructionText.styled.ts
+++ b/src/components/Field/InstructionText.styled.ts
@@ -2,7 +2,7 @@ import styled from "styled-components"
 import theme from "@root/theme";
 
 export const InstructionTextWrapper = styled.div`
-  border-left: 1px solid ${theme.newColors.simplyGrey["100"]};
+  border-left: ${theme.borders.simplyGrey};
   height: 51px;
   margin-left: auto;
   margin-top: 44px;

--- a/src/components/Field/InstructionText.styled.ts
+++ b/src/components/Field/InstructionText.styled.ts
@@ -2,7 +2,7 @@ import styled from "styled-components"
 import theme from "@root/theme";
 
 export const InstructionTextWrapper = styled.div`
-  border-left: ${theme.borders.simplyGray};
+  border-left: 1px solid ${theme.newColors.simplyGrey["100"]};
   height: 51px;
   margin-left: auto;
   margin-top: 44px;

--- a/src/components/InstructionText/InstructionText.styled.ts
+++ b/src/components/InstructionText/InstructionText.styled.ts
@@ -2,7 +2,7 @@ import styled from "styled-components"
 import theme from "@root/theme";
 
 export const InstructionTextWrapper = styled.div`
-  border-left: 1px solid ${theme.newColors.simplyGrey["100"]};
+  border-left: ${theme.borders.simplyGrey};
   height: 51px;
   margin-left: auto;
   margin-top: 44px;

--- a/src/components/InstructionText/InstructionText.styled.ts
+++ b/src/components/InstructionText/InstructionText.styled.ts
@@ -2,7 +2,7 @@ import styled from "styled-components"
 import theme from "@root/theme";
 
 export const InstructionTextWrapper = styled.div`
-  border-left: ${theme.borders.simplyGray};
+  border-left: 1px solid ${theme.newColors.simplyGrey["100"]};
   height: 51px;
   margin-left: auto;
   margin-top: 44px;

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -114,7 +114,7 @@ export const Example = (): ReactElement => {
 
 const StyledInput = styled.input`
 	background-color: ${theme.colors.gray100};
-	border: 1px solid ${theme.newColors.simplyGrey["100"]};
+	border: ${theme.borders.simplyGrey};
 	height: 47px;
 	border-radius: 0;
 `;

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -114,7 +114,7 @@ export const Example = (): ReactElement => {
 
 const StyledInput = styled.input`
 	background-color: ${theme.colors.gray100};
-	border: 1px solid ${theme.colors.simplyGray};
+	border: 1px solid ${theme.newColors.simplyGrey["100"]};
 	height: 47px;
 	border-radius: 0;
 `;

--- a/src/components/Snackbar/Snackbar.styled.tsx
+++ b/src/components/Snackbar/Snackbar.styled.tsx
@@ -53,7 +53,7 @@ export const ActionWrapper = styled.div`
 
 export const StyledCloseIcon = styled(CloseIcon)`
   &.MuiSvgIcon-root {
-    color: ${theme.colors.simplyGray};
+    color: ${theme.newColors.simplyGrey["100"]};
     font-size: 16px;
   }
 `;

--- a/src/components/ToggleSwitch/ToggleSwitch.styled.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.styled.tsx
@@ -27,7 +27,7 @@ export const StyledSwitch = styled(Switch)`
     padding: 10px;
 
     &:hover {
-      background-color: ${theme.colors.simplyGrayOpacity};
+      background-color: ${theme.newColors.simplyGrey["20"]};
     }
   }
 
@@ -40,7 +40,7 @@ export const StyledSwitch = styled(Switch)`
   }
 
   .MuiSwitch-track {
-    background-color: ${theme.colors.simplyGray};
+    background-color: ${theme.newColors.simplyGrey["100"]};
     opacity: 1;
     height: 14px;
     width: 34px;
@@ -57,7 +57,7 @@ export const StyledSwitch = styled(Switch)`
   }
 
   .MuiSwitch-switchBase.Mui-disabled + .MuiSwitch-track {
-    background-color: ${theme.colors.simplyGray};
+    background-color: ${theme.newColors.simplyGrey["100"]};
     opacity: 0.5;
   }
 `;

--- a/src/forms/FormFieldAddress/AddressCard/AddressCard.styled.tsx
+++ b/src/forms/FormFieldAddress/AddressCard/AddressCard.styled.tsx
@@ -34,7 +34,7 @@ export const ButtonsWrapper = styled.div`
   margin-top: auto;
 
   span:first-child {
-    border-right: 1px solid ${theme.colors.simplyGray};
+    border-right: 1px solid ${theme.newColors.simplyGrey["100"]};
     padding-right: 16px;
   }
 

--- a/src/forms/FormFieldAddress/AddressCard/AddressCard.styled.tsx
+++ b/src/forms/FormFieldAddress/AddressCard/AddressCard.styled.tsx
@@ -34,7 +34,7 @@ export const ButtonsWrapper = styled.div`
   margin-top: auto;
 
   span:first-child {
-    border-right: 1px solid ${theme.newColors.simplyGrey["100"]};
+    border-right: ${theme.borders.simplyGrey};
     padding-right: 16px;
   }
 

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelection.styled.tsx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelection.styled.tsx
@@ -25,7 +25,7 @@ export const StyledInput = styled.input`
 export const InputWrapper = styled.div`
   align-items: center;
   background-color: ${theme.colors.gray100};
-  border: 1px solid ${theme.newColors.simplyGrey["100"]};
+  border: ${theme.borders.simplyGrey};
   display: flex;
   height: 49px;
   justify-content: space-between;

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelection.styled.tsx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelection.styled.tsx
@@ -25,7 +25,7 @@ export const StyledInput = styled.input`
 export const InputWrapper = styled.div`
   align-items: center;
   background-color: ${theme.colors.gray100};
-  border: 1px solid ${theme.colors.simplyGray};
+  border: 1px solid ${theme.newColors.simplyGrey["100"]};
   display: flex;
   height: 49px;
   justify-content: space-between;

--- a/src/forms/FormFieldColorPicker/ColorPicker.styled.tsx
+++ b/src/forms/FormFieldColorPicker/ColorPicker.styled.tsx
@@ -3,7 +3,7 @@ import theme from "@root/theme";
 
 export const ColorContainer = styled.div`
   background: ${theme.colors.gray100};
-  border: 1px solid ${theme.colors.simplyGray};
+  border: 1px solid ${theme.newColors.simplyGrey["100"]};
   margin-bottom: ${(pr) => (pr.displayColorPicker ? "8px" : 0)};
   opacity: ${(pr) => (pr.disabled ? 0.5 : 1)};
   padding: 10px;

--- a/src/forms/FormFieldColorPicker/ColorPicker.styled.tsx
+++ b/src/forms/FormFieldColorPicker/ColorPicker.styled.tsx
@@ -3,7 +3,7 @@ import theme from "@root/theme";
 
 export const ColorContainer = styled.div`
   background: ${theme.colors.gray100};
-  border: 1px solid ${theme.newColors.simplyGrey["100"]};
+  border: ${theme.borders.simplyGrey};
   margin-bottom: ${(pr) => (pr.displayColorPicker ? "8px" : 0)};
   opacity: ${(pr) => (pr.disabled ? 0.5 : 1)};
   padding: 10px;

--- a/src/forms/FormFieldDate/DatePicker/DatePicker.styled.tsx
+++ b/src/forms/FormFieldDate/DatePicker/DatePicker.styled.tsx
@@ -75,7 +75,7 @@ export const DatePickerWrapper = styled.div`
 
 		& fieldset {
 			border-radius: 0;
-			border: ${pr => pr.isPickerOpen ? `1px solid ${theme.newColors.almostBlack["100"]}` : `1px solid ${theme.newColors.simplyGrey["100"]}`};
+			border: ${pr => pr.isPickerOpen ? `1px solid ${theme.newColors.almostBlack["100"]}` : theme.borders.simplyGrey};
 		}
 
 			.MuiOutlinedInput-input {

--- a/src/forms/FormFieldDate/DatePicker/DatePicker.styled.tsx
+++ b/src/forms/FormFieldDate/DatePicker/DatePicker.styled.tsx
@@ -69,13 +69,13 @@ export const DatePickerWrapper = styled.div`
 		&:hover {
 			background-color: ${theme.colors.gray200};
 			& fieldset {
-				border-color: ${theme.colors.simplyGray};
+				border-color: ${theme.newColors.simplyGrey["100"]};
 			}
 		}
 
 		& fieldset {
 			border-radius: 0;
-			border: ${pr => pr.isPickerOpen ? `1px solid ${theme.newColors.almostBlack["100"]}` : `1px solid ${theme.colors.simplyGray}`};
+			border: ${pr => pr.isPickerOpen ? `1px solid ${theme.newColors.almostBlack["100"]}` : `1px solid ${theme.newColors.simplyGrey["100"]}`};
 		}
 
 			.MuiOutlinedInput-input {

--- a/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.styled.tsx
+++ b/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.styled.tsx
@@ -15,7 +15,7 @@ export const PhoneInputWrapper = styled.div`
       width: 280px;
       &:focus {
         color: ${theme.newColors.almostBlack["100"]};
-        border-color: ${theme.colors.simplyGray};
+        border-color: ${theme.newColors.simplyGrey["100"]};
         box-shadow: none;
       }
       &:focus + .flag-dropdown {
@@ -25,7 +25,7 @@ export const PhoneInputWrapper = styled.div`
     }
 
     .flag-dropdown {
-      border-right: 1px solid ${theme.colors.simplyGray};
+      border-right: 1px solid ${theme.newColors.simplyGrey["100"]};
       &:focus-within {
         border: ${theme.borders.black};
         border-radius: 0px;

--- a/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.styled.tsx
+++ b/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.styled.tsx
@@ -25,7 +25,7 @@ export const PhoneInputWrapper = styled.div`
     }
 
     .flag-dropdown {
-      border-right: 1px solid ${theme.newColors.simplyGrey["100"]};
+      border-right: ${theme.borders.simplyGrey};
       &:focus-within {
         border: ${theme.borders.black};
         border-radius: 0px;

--- a/src/forms/FormFieldText/FormFieldText.styled.tsx
+++ b/src/forms/FormFieldText/FormFieldText.styled.tsx
@@ -17,7 +17,7 @@ export const StyledTextField = styled(({ fieldSize, ...rest }) => (
     &:hover {
     	background-color: ${pr => pr.disabled ? "transparent" : theme.colors.grayHover};
 		& fieldset {
-			border-color: ${theme.colors.simplyGray};
+			border-color: ${theme.newColors.simplyGrey["100"]};
 		}
     }
 
@@ -69,7 +69,7 @@ export const StyledTextField = styled(({ fieldSize, ...rest }) => (
 
   fieldset {
     border-radius: 0px;
-	border-color: ${theme.colors.simplyGray};
+	border-color: ${theme.newColors.simplyGrey["100"]};
   }
 
   & .MuiOutlinedInput-root {

--- a/src/forms/FormFieldTextArea/FormFieldTextArea.styled.tsx
+++ b/src/forms/FormFieldTextArea/FormFieldTextArea.styled.tsx
@@ -57,7 +57,7 @@ export const StyledTextArea = styled(({ fieldSize, ...rest }) => (
     }
 
     &:hover fieldset {
-			border-color: ${theme.colors.simplyGray};
+			border-color: ${theme.newColors.simplyGrey["100"]};
 		}
   }
 

--- a/src/forms/FormFieldTextEditor/FormFieldTextEditor.styled.ts
+++ b/src/forms/FormFieldTextEditor/FormFieldTextEditor.styled.ts
@@ -11,7 +11,7 @@ export const EditorWrapper = styled.div`
 		background-color: white !important;
 		border-radius: 0px !important;
 		margin-bottom: 8px !important;
-		border: ${(pr) => (pr.error ? theme.borders.error : `1px solid ${theme.newColors.simplyGrey["100"]}`)} !important;
+		border: ${(pr) => (pr.error ? theme.borders.error : theme.borders.simplyGrey)} !important;
 	}
 
 	.jodit-workplace {
@@ -22,7 +22,7 @@ export const EditorWrapper = styled.div`
 		color: ${theme.newColors.almostBlack["100"]};
 		border: ${(pr) => {
 		if (pr.error) return theme.borders.error;
-		return `1px solid ${theme.newColors.simplyGrey["100"]}`;
+		return theme.borders.simplyGrey;
 	}} !important;
 
 		& .jodit-wysiwyg {
@@ -56,7 +56,7 @@ export const EditorWrapper = styled.div`
 		border-radius: 0px !important;
 		border: ${(pr) => {
 		if (pr.error) return theme.borders.error;
-		return `1px solid ${theme.newColors.simplyGrey["100"]}`;
+		return theme.borders.simplyGrey;
 	}} !important;
 		border-top: none !important;
 		font-family: ${theme.fontFamily};

--- a/src/forms/FormFieldTextEditor/FormFieldTextEditor.styled.ts
+++ b/src/forms/FormFieldTextEditor/FormFieldTextEditor.styled.ts
@@ -11,7 +11,7 @@ export const EditorWrapper = styled.div`
 		background-color: white !important;
 		border-radius: 0px !important;
 		margin-bottom: 8px !important;
-		border: ${(pr) => (pr.error ? theme.borders.error : theme.borders.simplyGray)} !important;
+		border: ${(pr) => (pr.error ? theme.borders.error : `1px solid ${theme.newColors.simplyGrey["100"]}`)} !important;
 	}
 
 	.jodit-workplace {
@@ -22,7 +22,7 @@ export const EditorWrapper = styled.div`
 		color: ${theme.newColors.almostBlack["100"]};
 		border: ${(pr) => {
 		if (pr.error) return theme.borders.error;
-		return theme.borders.simplyGray;
+		return `1px solid ${theme.newColors.simplyGrey["100"]}`;
 	}} !important;
 
 		& .jodit-wysiwyg {
@@ -56,7 +56,7 @@ export const EditorWrapper = styled.div`
 		border-radius: 0px !important;
 		border: ${(pr) => {
 		if (pr.error) return theme.borders.error;
-		return theme.borders.simplyGray;
+		return `1px solid ${theme.newColors.simplyGrey["100"]}`;
 	}} !important;
 		border-top: none !important;
 		font-family: ${theme.fontFamily};

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -122,7 +122,7 @@ const borders = {
 	gray : "1px solid rgba(0, 0, 0, .15)",
 	fieldGray : "1px solid #CCCCCC",
 	error : "1px solid #B10000",
-	simplyGray: "1px solid #BEBEBE"
+	simplyGrey: `1px solid ${newColors.simplyGrey["100"]}`
 };
 
 export default {


### PR DESCRIPTION
## What's included?

Replaces simplyGray references with the new color syntax.

## Notes

simplyGrayOpacity (190, 190, 190, 0.3) was replaced with the variant using 0.2 opacity since we do not have a 0.3 variant.