### PR TITLE
Mos 902 Add pre-filled magic values to the date filter

### DIFF
--- a/src/components/DataViewFilterDate/DataViewFilterDate.stories.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.stories.tsx
@@ -19,6 +19,22 @@ export const example = (): ReactElement => {
 			value: "today",
 		},
 		{
+			label: "Yesterday",
+			value: "yesterday",
+		},
+		{
+			label: "Tomorrow",
+			value: "tomorrow",
+		},
+		{
+			label: "Last year",
+			value: "last_year",
+		},
+		{
+			label: "Last 2 years",
+			value: "last_2_years",
+		},
+		{
 			label: "Last 3 years",
 			value: "last_3_years",
 		}
@@ -32,7 +48,7 @@ export const example = (): ReactElement => {
 
 	return (
 		<DataViewFilterDate
-			label="Testing"
+			label="Date filter example"
 			data={state}
 			args={{ options: showOptions ? options : undefined}}
 			onRemove={onRemove}

--- a/src/components/DataViewFilterDate/DataViewFilterDate.stories.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.stories.tsx
@@ -1,13 +1,28 @@
 import * as React from "react";
 import { useState, ReactElement } from "react";
+import { boolean, withKnobs } from "@storybook/addon-knobs";
 import DataViewFilterDate from "./DataViewFilterDate";
+import { MosaicLabelValue } from "@root/types";
 
 export default {
-	title : "Components/DataViewFilterDate"
+	title : "Components/DataViewFilterDate",
+	decorators: [withKnobs],
 }
 
 export const example = (): ReactElement => {
 	const [state, setState] = useState({});
+
+	const showOptions = boolean("Show options", false);
+	const options: MosaicLabelValue[] = [
+		{
+			label: "Today",
+			value: "today",
+		},
+		{
+			label: "Last 3 years",
+			value: "last_3_years",
+		}
+	];
 
 	const onChange = function(data) {
 		setState(data);
@@ -19,7 +34,7 @@ export const example = (): ReactElement => {
 		<DataViewFilterDate
 			label="Testing"
 			data={state}
-			args={{}}
+			args={{ options: showOptions ? options : undefined}}
 			onRemove={onRemove}
 			onChange={onChange}
 		/>

--- a/src/components/DataViewFilterDate/DataViewFilterDate.test.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.test.tsx
@@ -62,9 +62,9 @@ describe("DataViewFilterDate", () => {
 		const filterButton = await screen.findByText("Date filter example");
 		expect(filterButton).toBeInTheDocument();
 
-		act(() =>
-			filterButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
-		);
+		act(() => {
+			filterButton.dispatchEvent(new MouseEvent("click", {bubbles: true}));
+		});
 
 		const dropdownContent = await screen.findByTestId("dataview-filter-date-dropdown-content");
 		expect(dropdownContent).toBeInTheDocument();
@@ -75,9 +75,9 @@ describe("DataViewFilterDate", () => {
 		});
 
 		const applyButton = await screen.findByText("Apply");
-		act(() =>
+		act(() => {
 			applyButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
-		);
+		});
 
 		const actualResult = (await screen.findByRole("button")).textContent;
 		const expectedResult = "Date filter example|from 1/1/2023";
@@ -92,9 +92,9 @@ describe("DataViewFilterDate", () => {
 		const filterButton = await screen.findByText("Date filter example");
 		expect(filterButton).toBeInTheDocument();
 
-		act(() =>
+		act(() => {
 			filterButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
-		);
+		});
 
 		const dropdownContent = await screen.findByTestId("dataview-filter-date-dropdown-content");
 		expect(dropdownContent).toBeInTheDocument();
@@ -105,9 +105,9 @@ describe("DataViewFilterDate", () => {
 		});
 
 		const applyButton = await screen.findByText("Apply");
-		act(() =>
+		act(() => {
 			applyButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
-		);
+		});
 
 		const actualResult = (await screen.findByRole("button")).textContent;
 		const expectedResult = "Date filter example|to 1/1/2023";
@@ -122,9 +122,9 @@ describe("DataViewFilterDate", () => {
 		const filterButton = await screen.findByText("Date filter example");
 		expect(filterButton).toBeInTheDocument();
 
-		act(() =>
+		act(() => {
 			filterButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
-		);
+		});
 
 		const dropdownContent = await screen.findByTestId("dataview-filter-date-dropdown-content");
 		expect(dropdownContent).toBeInTheDocument();
@@ -140,9 +140,9 @@ describe("DataViewFilterDate", () => {
 		});
 
 		const applyButton = await screen.findByText("Apply");
-		act(() =>
+		act(() => {
 			applyButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
-		);
+		});
 
 		const actualResult = (await screen.findByRole("button")).textContent;
 		const expectedResult = "Date filter example|12/31/2022 - 1/1/2023";
@@ -157,9 +157,9 @@ describe("DataViewFilterDate", () => {
 		const filterButton = await screen.findByText("Date filter example");
 		expect(filterButton).toBeInTheDocument();
 
-		act(() =>
+		act(() => {
 			filterButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
-		);
+		});
 
 		const dropdownContent = await screen.findByTestId("dataview-filter-date-dropdown-content");
 		expect(dropdownContent).toBeInTheDocument();
@@ -190,9 +190,9 @@ describe("DataViewFilterDate", () => {
 		const filterButton = await screen.findByText("Date filter example");
 		expect(filterButton).toBeInTheDocument();
 
-		act(() =>
+		act(() => {
 			filterButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
-		);
+		});
 
 		const dropdownContent = await screen.findByTestId("dataview-filter-date-dropdown-content");
 		expect(dropdownContent).toBeInTheDocument();
@@ -201,9 +201,9 @@ describe("DataViewFilterDate", () => {
 		const randomMagicValueIdx = Math.floor(Math.random() * magicValues.length);
 		const magicValueSelected = magicValues[randomMagicValueIdx];
 
-		act(() =>
+		act(() => {
 			magicValueSelected.dispatchEvent(new MouseEvent("click", {bubbles: true}))
-		);
+		});
 
 		const actualResult = (await screen.findByRole("button")).textContent;
 		const expectedResult = `Date filter example|${magicValueSelected.textContent}`;

--- a/src/components/DataViewFilterDate/DataViewFilterDate.test.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.test.tsx
@@ -1,0 +1,212 @@
+import * as React from "react";
+import "@testing-library/jest-dom";
+import { screen, cleanup, render, act, fireEvent } from "@testing-library/react";
+import DataViewFilterDate from "./DataViewFilterDate";
+import { MosaicLabelValue } from "@root/types";
+import { useState } from "react";
+
+afterEach(cleanup);
+
+const DataViewFilterDateExample = ({showOptions}: {showOptions?: boolean}) => {
+	const [state, setState] = useState({});
+	const options: MosaicLabelValue[] = [
+		{
+			label: "Today",
+			value: "today",
+		},
+		{
+			label: "Yesterday",
+			value: "yesterday",
+		},
+		{
+			label: "Tomorrow",
+			value: "tomorrow",
+		},
+		{
+			label: "Last year",
+			value: "last_year",
+		},
+		{
+			label: "Last 2 years",
+			value: "last_2_years",
+		},
+		{
+			label: "Last 3 years",
+			value: "last_3_years",
+		}
+	];
+
+	const onChange = function(data) {
+		setState(data);
+	}
+
+	const onRemove = () => undefined;
+
+	return (
+		<DataViewFilterDate
+			label="Date filter example"
+			data={state}
+			args={{ options: showOptions ? options : undefined}}
+			onRemove={onRemove}
+			onChange={onChange}
+		/>
+	)
+}
+
+describe("DataViewFilterDate", () => {
+	it("Should select a from date", async () => {
+		await act(async () => {
+			render(<DataViewFilterDateExample />);
+		});
+
+		const filterButton = await screen.findByText("Date filter example");
+		expect(filterButton).toBeInTheDocument();
+
+		act(() =>
+			filterButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+		);
+
+		const dropdownContent = await screen.findByTestId("dataview-filter-date-dropdown-content");
+		expect(dropdownContent).toBeInTheDocument();
+
+		const fromInput = (await screen.findAllByRole("textbox"))[0];
+		await act(async () => {
+			fireEvent.change(fromInput, { target: { value: "01012023" } });
+		});
+
+		const applyButton = await screen.findByText("Apply");
+		act(() =>
+			applyButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+		);
+
+		const actualResult = (await screen.findByRole("button")).textContent;
+		const expectedResult = "Date filter example|from 1/1/2023";
+		expect(actualResult).toEqual(expectedResult);
+	});
+
+	it("Should select a from date", async () => {
+		await act(async () => {
+			render(<DataViewFilterDateExample />);
+		});
+
+		const filterButton = await screen.findByText("Date filter example");
+		expect(filterButton).toBeInTheDocument();
+
+		act(() =>
+			filterButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+		);
+
+		const dropdownContent = await screen.findByTestId("dataview-filter-date-dropdown-content");
+		expect(dropdownContent).toBeInTheDocument();
+
+		const toInput = (await screen.findAllByRole("textbox"))[1];
+		await act(async () => {
+			fireEvent.change(toInput, { target: { value: "01012023" } });
+		});
+
+		const applyButton = await screen.findByText("Apply");
+		act(() =>
+			applyButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+		);
+
+		const actualResult = (await screen.findByRole("button")).textContent;
+		const expectedResult = "Date filter example|to 1/1/2023";
+		expect(actualResult).toEqual(expectedResult);
+	});
+
+	it("Should select a valid range", async () => {
+		await act(async () => {
+			render(<DataViewFilterDateExample />);
+		});
+
+		const filterButton = await screen.findByText("Date filter example");
+		expect(filterButton).toBeInTheDocument();
+
+		act(() =>
+			filterButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+		);
+
+		const dropdownContent = await screen.findByTestId("dataview-filter-date-dropdown-content");
+		expect(dropdownContent).toBeInTheDocument();
+
+		const fromInput = (await screen.findAllByRole("textbox"))[0];
+		await act(async () => {
+			fireEvent.change(fromInput, { target: { value: "12312022" } });
+		});
+
+		const toInput = (await screen.findAllByRole("textbox"))[1];
+		await act(async () => {
+			fireEvent.change(toInput, { target: { value: "01012023" } });
+		});
+
+		const applyButton = await screen.findByText("Apply");
+		act(() =>
+			applyButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+		);
+
+		const actualResult = (await screen.findByRole("button")).textContent;
+		const expectedResult = "Date filter example|12/31/2022 - 1/1/2023";
+		expect(actualResult).toEqual(expectedResult);
+	});
+
+	it("Should throw an error when selecting an invalid range", async () => {
+		await act(async () => {
+			render(<DataViewFilterDateExample />);
+		});
+
+		const filterButton = await screen.findByText("Date filter example");
+		expect(filterButton).toBeInTheDocument();
+
+		act(() =>
+			filterButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+		);
+
+		const dropdownContent = await screen.findByTestId("dataview-filter-date-dropdown-content");
+		expect(dropdownContent).toBeInTheDocument();
+
+		const fromInput = (await screen.findAllByRole("textbox"))[0];
+		await act(async () => {
+			fireEvent.change(fromInput, { target: { value: "01012023" } });
+		});
+
+		const toInput = (await screen.findAllByRole("textbox"))[1];
+		await act(async () => {
+			fireEvent.change(toInput, { target: { value: "12312022" } });
+		});
+
+		const applyButton = await screen.findByText("Apply");
+		expect(applyButton).toHaveProperty("disabled");
+
+		const actualResult = (await screen.findByTestId("dataview-filter-date-error")).textContent;
+		const expectedResult = "Error: End of range cannot be before start of range.";
+		expect(actualResult).toEqual(expectedResult);
+	});
+
+	it("Should select a magic value", async () => {
+		await act(async () => {
+			render(<DataViewFilterDateExample showOptions={true} />);
+		});
+
+		const filterButton = await screen.findByText("Date filter example");
+		expect(filterButton).toBeInTheDocument();
+
+		act(() =>
+			filterButton.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+		);
+
+		const dropdownContent = await screen.findByTestId("dataview-filter-date-dropdown-content");
+		expect(dropdownContent).toBeInTheDocument();
+
+		const magicValues = await screen.findAllByRole("menuitem");
+		const randomMagicValueIdx = Math.floor(Math.random() * magicValues.length);
+		const magicValueSelected = magicValues[randomMagicValueIdx];
+
+		act(() =>
+			magicValueSelected.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+		);
+
+		const actualResult = (await screen.findByRole("button")).textContent;
+		const expectedResult = `Date filter example|${magicValueSelected.textContent}`;
+		expect(actualResult).toEqual(expectedResult);
+	});
+});

--- a/src/components/DataViewFilterDate/DataViewFilterDate.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.tsx
@@ -29,21 +29,26 @@ export default function DataViewFilterDate(props: DataViewFilterDateProps): Reac
 		setAnchorEl(null);
 	}
 
-	const hasStart = props.data.rangeStart !== undefined;
-	const hasEnd = props.data.rangeEnd !== undefined;
-	const startFormat = hasStart ? format(props.data.rangeStart, dateFormat) : undefined;
-	const endFormat = hasEnd ? format(props.data.rangeEnd, dateFormat) : undefined;
-
 	let valueString: string | undefined = undefined;
 
-	if (isSame(props.data.rangeStart, props.data.rangeEnd)) {
-		valueString = startFormat;
-	} else if (hasStart && hasEnd) {
-		valueString = `${startFormat} - ${endFormat}`;
-	} else if (hasStart) {
-		valueString = `from ${startFormat}`;
-	} else if (hasEnd) {
-		valueString = `to ${endFormat}`;
+	if ("rangeStart" in props.data || "rangeEnd" in props.data) {
+		const hasStart = props.data.rangeStart !== undefined;
+		const hasEnd = props.data.rangeEnd !== undefined;
+		const startFormat = hasStart ? format(props.data.rangeStart, dateFormat) : undefined;
+		const endFormat = hasEnd ? format(props.data.rangeEnd, dateFormat) : undefined;
+
+		if (isSame(props.data.rangeStart, props.data.rangeEnd)) {
+			valueString = startFormat;
+		} else if (hasStart && hasEnd) {
+			valueString = `${startFormat} - ${endFormat}`;
+		} else if (hasStart) {
+			valueString = `from ${startFormat}`;
+		} else if (hasEnd) {
+			valueString = `to ${endFormat}`;
+		}
+	} else if ("option" in props.data) {
+		if (props.data.option !== undefined)
+			valueString = props.data.option;
 	}
 
 	return (
@@ -60,8 +65,9 @@ export default function DataViewFilterDate(props: DataViewFilterDateProps): Reac
 				<DataViewFilterDateDropdownContent
 					onClose={onClose}
 					onChange={props.onChange}
-					rangeStart={props.data.rangeStart}
-					rangeEnd={props.data.rangeEnd}
+					rangeStart={"rangeStart" in props.data && props.data.rangeStart}
+					rangeEnd={"rangeEnd" in props.data && props.data.rangeEnd}
+					options={props.args.options}
 				/>
 			</DataViewFilterDropdown>
 		</StyledWrapper>

--- a/src/components/DataViewFilterDate/DataViewFilterDate.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.tsx
@@ -46,9 +46,8 @@ export default function DataViewFilterDate(props: DataViewFilterDateProps): Reac
 		} else if (hasEnd) {
 			valueString = `to ${endFormat}`;
 		}
-	} else if ("option" in props.data) {
-		if (props.data.option !== undefined)
-			valueString = props.data.option;
+	} else if ("option" in props.data && props.data.option !== undefined && props.args.options !== undefined) {
+		valueString = props.args.options.filter(option => "option" in props.data ? option.value === props.data.option : undefined)[0].label;
 	}
 
 	return (
@@ -65,9 +64,10 @@ export default function DataViewFilterDate(props: DataViewFilterDateProps): Reac
 				<DataViewFilterDateDropdownContent
 					onClose={onClose}
 					onChange={props.onChange}
-					rangeStart={"rangeStart" in props.data && props.data.rangeStart}
-					rangeEnd={"rangeEnd" in props.data && props.data.rangeEnd}
+					rangeStart={"rangeStart" in props.data ? props.data.rangeStart : undefined}
+					rangeEnd={"rangeEnd" in props.data ? props.data.rangeEnd : undefined}
 					options={props.args.options}
+					selectedOption={"option" in props.data ? props.data.option : undefined}
 				/>
 			</DataViewFilterDropdown>
 		</StyledWrapper>

--- a/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
@@ -109,11 +109,11 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 	}
 
 	return (
-		<StyledFilterDate>
+		<StyledFilterDate data-testid="dataview-filter-date-dropdown-content">
 			{
 				"options" in props && props.options &&
 				<>
-					<ul className="options">
+					<ul className="options" data-testid="dataview-filter-date-options-list">
 						{
 							props.options.map(option =>
 								<MenuItem
@@ -130,7 +130,7 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 				</>
 			}
 			<StyledMainContent>
-				<div>
+				<div data-testid="dataview-filter-date-inputs">
 					<div className="inputRow">
 						<div className="startRange">
 							<h5>{`${t("mosaic:common.date_from")}`}</h5>
@@ -165,7 +165,7 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 					</div>
 					{
 						hasError &&
-						<div className="errorMessage">
+						<div className="errorMessage" data-testid="dataview-filter-date-error">
 							<h5>Error: {errorMessage}</h5>
 						</div>
 					}

--- a/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
@@ -7,6 +7,7 @@ import theme from "@root/theme";
 import { DataViewFilterDateDropdownContentProps } from "./DataViewFilterDateTypes";
 import { useMosaicTranslation } from "@root/i18n";
 import DatePickerCustom from "@root/forms/FormFieldDate/DatePicker";
+import MenuSelect from "../MenuSelect";
 
 const StyledContents = styled.div`
 	& > .inputRow h5 {
@@ -33,7 +34,7 @@ const StyledContents = styled.div`
 export default function DataViewFilterDateDropdownContent(props: DataViewFilterDateDropdownContentProps): ReactElement {
 	const [state, setState] = useState({
 		rangeStart : props.rangeStart,
-		rangeEnd : props.rangeEnd
+		rangeEnd : props.rangeEnd,
 	});
 
 	const { t } = useMosaicTranslation();
@@ -45,11 +46,15 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 
 	const hasError = errorMessage !== undefined;
 
-	const onApply = function() {
-		props.onChange({
-			rangeStart : state.rangeStart,
-			rangeEnd: state.rangeEnd
-		});
+	const onApply = function(val?: string) {
+		if (state.rangeStart || state.rangeEnd)
+			props.onChange({
+				rangeStart : state.rangeStart,
+				rangeEnd: state.rangeEnd
+			});
+
+		if (val)
+			props.onChange({option: val});
 
 		props.onClose();
 	}
@@ -86,6 +91,10 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 
 	return (
 		<StyledContents>
+			{
+				props.options &&
+				<MenuSelect options={props.options} onChange={onApply} value={props.options[0].value} />
+			}
 			<div className="inputRow">
 				<div className="startRange">
 					<h5>{`${t("mosaic:common.date_from")}`}</h5>

--- a/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
@@ -7,20 +7,26 @@ import theme from "@root/theme";
 import { DataViewFilterDateDropdownContentProps } from "./DataViewFilterDateTypes";
 import { useMosaicTranslation } from "@root/i18n";
 import DatePickerCustom from "@root/forms/FormFieldDate/DatePicker";
-import MenuSelect from "../MenuSelect";
+import { StyledHr, StyledVerticalHr } from "../DataViewFilterMultiselect/DataViewFilterMultiselect.styled";
+import MenuItem from "../MenuItem";
 
-const StyledContents = styled.div`
-	& > .inputRow h5 {
+const StyledMainContent = styled.div`
+	padding: 6px;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+
+	& > div > .inputRow h5 {
 		margin-top:0;
 		margin-bottom: 8px;
 	}
 
-	& > .inputRow {
+	& > div > .inputRow {
 		display: flex;
 		align-items: center;
 	}
 
-	& > .inputRow div.startRange {
+	& > div > .inputRow div.startRange {
 		margin-right: 10px;
 	}
 
@@ -31,10 +37,20 @@ const StyledContents = styled.div`
 	}
 `;
 
+const StyledFilterDate = styled.div`
+	display: flex;
+	flex-direction: row;
+	& .options {
+		padding: 0px;
+    	margin: -10px;
+	}
+`;
+
 export default function DataViewFilterDateDropdownContent(props: DataViewFilterDateDropdownContentProps): ReactElement {
 	const [state, setState] = useState({
-		rangeStart : props.rangeStart,
-		rangeEnd : props.rangeEnd,
+		rangeStart : "rangeStart" in props ? props.rangeStart : undefined,
+		rangeEnd : "rangeStart" in props ? props.rangeEnd : undefined,
+		selectedOption: "selectedOption" in props ? props.selectedOption : undefined,
 	});
 
 	const { t } = useMosaicTranslation();
@@ -46,15 +62,17 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 
 	const hasError = errorMessage !== undefined;
 
-	const onApply = function(val?: string) {
-		if (state.rangeStart || state.rangeEnd)
-			props.onChange({
-				rangeStart : state.rangeStart,
-				rangeEnd: state.rangeEnd
-			});
+	const onApply = function() {
+		props.onChange({
+			rangeStart : state.rangeStart,
+			rangeEnd: state.rangeEnd
+		});
 
-		if (val)
-			props.onChange({option: val});
+		props.onClose();
+	}
+
+	const onOptionSelect = (optionValue: string) => {
+		props.onChange({option: optionValue});
 
 		props.onClose();
 	}
@@ -64,7 +82,8 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 		setState({
 			...state,
 			rangeStart : undefined,
-			rangeEnd : undefined
+			rangeEnd : undefined,
+			selectedOption: undefined,
 		});
 	}
 
@@ -90,50 +109,72 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 	}
 
 	return (
-		<StyledContents>
+		<StyledFilterDate>
 			{
-				props.options &&
-				<MenuSelect options={props.options} onChange={onApply} value={props.options[0].value} />
+				"options" in props && props.options &&
+				<>
+					<ul className="options">
+						{
+							props.options.map(option =>
+								<MenuItem
+									key={`${option.label}-${option.value}`}
+									label={option.label}
+									selected={state.selectedOption === option.value}
+									color="blue"
+									onClick={() => onOptionSelect(option.value)}
+								/>
+							)
+						}
+					</ul>
+					<StyledVerticalHr margin={"-10px 10px"}/>
+				</>
 			}
-			<div className="inputRow">
-				<div className="startRange">
-					<h5>{`${t("mosaic:common.date_from")}`}</h5>
-					<DatePickerCustom
-						onChange={getOnChange("rangeStart")}
-						value={state.rangeStart || null}
-						fieldDef={{
-							name: "",
-							label: "",
-							type: "",
-							inputSettings: {
-								placeholder: t("mosaic:DataViewFilterDate.choose_a_date___")
-							},
-						}}
-					/>
+			<StyledMainContent>
+				<div>
+					<div className="inputRow">
+						<div className="startRange">
+							<h5>{`${t("mosaic:common.date_from")}`}</h5>
+							<DatePickerCustom
+								onChange={getOnChange("rangeStart")}
+								value={state.rangeStart || null}
+								fieldDef={{
+									name: "",
+									label: "",
+									type: "",
+									inputSettings: {
+										placeholder: t("mosaic:DataViewFilterDate.choose_a_date___")
+									},
+								}}
+							/>
+						</div>
+						<div className="endRange">
+							<h5>{`${t("mosaic:common.date_to")}`}</h5>
+							<DatePickerCustom
+								onChange={getOnChange("rangeEnd")}
+								value={state.rangeEnd || null}
+								fieldDef={{
+									name: "",
+									label: "",
+									type: "",
+									inputSettings: {
+										placeholder: t("mosaic:DataViewFilterDate.choose_a_date___")
+									},
+								}}
+							/>
+						</div>
+					</div>
+					{
+						hasError &&
+						<div className="errorMessage">
+							<h5>Error: {errorMessage}</h5>
+						</div>
+					}
 				</div>
-				<div className="endRange">
-					<h5>{`${t("mosaic:common.date_to")}`}</h5>
-					<DatePickerCustom
-						onChange={getOnChange("rangeEnd")}
-						value={state.rangeEnd || null}
-						fieldDef={{
-							name: "",
-							label: "",
-							type: "",
-							inputSettings: {
-								placeholder: t("mosaic:DataViewFilterDate.choose_a_date___")
-							},
-						}}
-					/>
+				<div>
+					<StyledHr margin={"16px -16px"} />
+					<DataViewFilterDropdownButtons onApply={onApply} onClear={onClear} disableApply={hasError}/>
 				</div>
-			</div>
-			{
-				hasError &&
-				<div className="errorMessage">
-					<h5>Error: {errorMessage}</h5>
-				</div>
-			}
-			<DataViewFilterDropdownButtons onApply={onApply} onClear={onClear} disableApply={hasError}/>
-		</StyledContents>
+			</StyledMainContent>
+		</StyledFilterDate>
 	)
 }

--- a/src/components/DataViewFilterDate/DataViewFilterDateTypes.ts
+++ b/src/components/DataViewFilterDate/DataViewFilterDateTypes.ts
@@ -22,10 +22,17 @@ export interface DataViewFilterDateProps extends DataViewFilterProps {
 	args: { options?: MosaicLabelValue[] }
 }
 
-export interface DataViewFilterDateDropdownContentProps {
-	options?: MosaicLabelValue[]
+interface DataViewFilterDateDropdownContentOptions {
+	options?: MosaicLabelValue[],
+	selectedOption?: string,
+}
+
+interface DataViewFilterDateDropdownContentRange {
 	rangeStart?: Date
 	rangeEnd?: Date
+}
+
+export type DataViewFilterDateDropdownContentProps = {
 	onChange: DataViewFilterDateOnChange
 	onClose: () => void
-}
+} & (DataViewFilterDateDropdownContentOptions | DataViewFilterDateDropdownContentRange)

--- a/src/components/DataViewFilterDate/DataViewFilterDateTypes.ts
+++ b/src/components/DataViewFilterDate/DataViewFilterDateTypes.ts
@@ -1,9 +1,16 @@
+import { MosaicLabelValue } from "@root/types";
 import { DataViewFilterProps } from "../DataView";
 
-export interface DataViewFilterDateData {
+interface DataViewFilterDateRange {
 	rangeStart?: Date,
 	rangeEnd?: Date
 }
+
+interface DataViewFilterDateOption {
+	option: string;
+}
+
+type DataViewFilterDateData = DataViewFilterDateRange | DataViewFilterDateOption;
 
 export interface DataViewFilterDateOnChange {
 	(value: DataViewFilterDateData): void
@@ -12,9 +19,11 @@ export interface DataViewFilterDateOnChange {
 export interface DataViewFilterDateProps extends DataViewFilterProps {
 	data: DataViewFilterDateData,
 	onChange: DataViewFilterDateOnChange
+	args: { options?: MosaicLabelValue[] }
 }
 
 export interface DataViewFilterDateDropdownContentProps {
+	options?: MosaicLabelValue[]
 	rangeStart?: Date
 	rangeEnd?: Date
 	onChange: DataViewFilterDateOnChange

--- a/src/components/DataViewFilterMultiselect/DataViewFilterMultiselect.styled.tsx
+++ b/src/components/DataViewFilterMultiselect/DataViewFilterMultiselect.styled.tsx
@@ -83,10 +83,10 @@ export const PopoverP = styled.p`
 
 export const StyledHr = styled.hr`
 	border: 2px solid ${theme.newColors.grey2[100]};
-	margin: 0px -16px;
+	margin:  ${pr => pr.margin ?? "0px -16px"};
 `;
 
 export const StyledVerticalHr = styled.hr`
 	border: 2px solid ${theme.newColors.grey2[100]};
-	margin: -32px 0px 0px 0px;
+	margin: ${pr => pr.margin ?? "-32px 0px 0px 0px"};
 `


### PR DESCRIPTION
# What's included?
- Added "magic values" functionality to DataViewFilterDate. This works by passing an options array (of MosaicLabelValues) to the arguments of the filter.
- Filter will now return { option: string } when one of the magic values get selected or { rangeStart: date, rangeEnd: date } when manually adding the dates.
- Clicking on one of the magic values will automatically select the option. Users don't have to click on "Apply"
- Updated types and interfaces to better match what's required.