### PR TITLE
TAE -MOS-452 - Clicking User Options and then clicking out does not collapse the tool tip

### DIFF
--- a/automation_testing/tests/Components/dataview/data_view.spec.ts
+++ b/automation_testing/tests/Components/dataview/data_view.spec.ts
@@ -132,4 +132,13 @@ test.describe.parallel("Components - Data View", () => {
 		await dataviewPage.headerActionsLocator.waitFor();
 		expect(await dataviewPage.getSpecificPaddingFromElement(dataviewPage.headerActionsLocator)).toBe("8px 24px");
 	});
+
+	test("Validate More actions tooltip is not visible when clicking the button.", async () => {
+		await dataviewPage.waitForDataviewIsVisible();
+		await dataviewPage.moreOptions.first().hover();
+		await expect(dataviewPage.tooltip.first()).toBeVisible();
+		expect(await dataviewPage.tooltip.first().textContent()).toBe("More actions");
+		await dataviewPage.moreOptions.first().click();
+		await expect(dataviewPage.tooltip.first()).not.toBeVisible();
+	});
 });


### PR DESCRIPTION
### Jira Ticket
https://simpleviewtools.atlassian.net/browse/MOS-452

### What's included?
Added scenario validating the issue found.