### PR TITLE
MOS-902 Fixed issue with type guard in FilterDate

### DIFF
--- a/src/components/DataViewFilterDate/DataViewFilterDate.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.tsx
@@ -31,24 +31,25 @@ export default function DataViewFilterDate(props: DataViewFilterDateProps): Reac
 
 	let valueString: string | undefined = undefined;
 
-	if ("rangeStart" in props.data || "rangeEnd" in props.data) {
-		const hasStart = props.data?.rangeStart !== undefined;
-		const hasEnd = props.data?.rangeEnd !== undefined;
-		const startFormat = hasStart ? format(props.data?.rangeStart, dateFormat) : undefined;
-		const endFormat = hasEnd ? format(props.data?.rangeEnd, dateFormat) : undefined;
+	if (props.data)
+		if ("rangeStart" in props.data || "rangeEnd" in props.data) {
+			const hasStart = props.data.rangeStart !== undefined;
+			const hasEnd = props.data.rangeEnd !== undefined;
+			const startFormat = hasStart ? format(props.data.rangeStart, dateFormat) : undefined;
+			const endFormat = hasEnd ? format(props.data.rangeEnd, dateFormat) : undefined;
 
-		if (isSame(props.data?.rangeStart, props.data?.rangeEnd)) {
-			valueString = startFormat;
-		} else if (hasStart && hasEnd) {
-			valueString = `${startFormat} - ${endFormat}`;
-		} else if (hasStart) {
-			valueString = `from ${startFormat}`;
-		} else if (hasEnd) {
-			valueString = `to ${endFormat}`;
+			if (isSame(props.data.rangeStart, props.data.rangeEnd)) {
+				valueString = startFormat;
+			} else if (hasStart && hasEnd) {
+				valueString = `${startFormat} - ${endFormat}`;
+			} else if (hasStart) {
+				valueString = `from ${startFormat}`;
+			} else if (hasEnd) {
+				valueString = `to ${endFormat}`;
+			}
+		} else if ("option" in props.data && props.data.option !== undefined && props.args.options !== undefined) {
+			valueString = props.args.options.filter(option => "option" in props.data ? option.value === props.data.option : undefined)[0].label;
 		}
-	} else if ("option" in props.data && props.data?.option !== undefined && props.args.options !== undefined) {
-		valueString = props.args.options.filter(option => "option" in props.data ? option.value === props.data?.option : undefined)[0].label;
-	}
 
 	return (
 		<StyledWrapper>
@@ -64,10 +65,10 @@ export default function DataViewFilterDate(props: DataViewFilterDateProps): Reac
 				<DataViewFilterDateDropdownContent
 					onClose={onClose}
 					onChange={props.onChange}
-					rangeStart={"rangeStart" in props.data ? props.data?.rangeStart : undefined}
-					rangeEnd={"rangeEnd" in props.data ? props.data?.rangeEnd : undefined}
+					rangeStart={props.data && "rangeStart" in props.data ? props.data?.rangeStart : undefined}
+					rangeEnd={props.data && "rangeEnd" in props.data ? props.data?.rangeEnd : undefined}
 					options={props.args.options}
-					selectedOption={"option" in props.data ? props.data?.option : undefined}
+					selectedOption={props.data && "option" in props.data ? props.data?.option : undefined}
 				/>
 			</DataViewFilterDropdown>
 		</StyledWrapper>

--- a/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
@@ -60,14 +60,18 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 		errorMessage = "End of range cannot be before start of range.";
 	}
 
+	if (state.rangeStart?.toString() === "Invalid Date" || state.rangeEnd?.toString() === "Invalid Date") {
+		errorMessage = "This is not a valid date";
+	}
+
 	const hasError = errorMessage !== undefined;
 
 	const onApply = function() {
-		if (!state.rangeStart || !state.rangeEnd) {
+		if (!state.rangeStart && !state.rangeEnd) {
 			props.onChange(undefined);
 		} else {
 			props.onChange({
-				rangeStart : state.rangeStart,
+				rangeStart: state.rangeStart,
 				rangeEnd: state.rangeEnd
 			});
 		}
@@ -108,7 +112,8 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 
 		setState({
 			...state,
-			[name] : date === null ? undefined : date
+			[name] : date === null ? undefined : date,
+			selectedOption: undefined
 		});
 	}
 


### PR DESCRIPTION
# What's included?
- Added extra condition to verify if data is being propped to the filter.
- Fixed condition that was sending back "undefined" when clicking "onApply".
- Filter now unselecting any magic value when changing the custom values.
- Filter now throwing error when manually typing an invalid date.