### PR TITLE
MOS-942: Invariant failed draggable requires a draggable id

### DIFF
--- a/src/components/DataView/DataViewTr/DataViewTr.tsx
+++ b/src/components/DataView/DataViewTr/DataViewTr.tsx
@@ -14,7 +14,7 @@ function DataViewTr(props: DataViewTrProps) {
 	return (
 		<Draggable
 			key={props.row.id}
-			draggableId={props.row.id}
+			draggableId={props.originalRowData.id.toString()}
 			index={props.rowIdx}
 			isDragDisabled={!props?.onReorder}
 		>

--- a/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.test.tsx
+++ b/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.test.tsx
@@ -7,7 +7,7 @@ import FormFieldPhoneSelectionDropdown from "./FormFieldPhoneSelectionDropdown";
 
 afterEach(cleanup);
 
-const { getByText, queryByPlaceholderText, getByTitle } = screen;
+const { getByText, getByTitle } = screen;
 
 const FormFieldPhoneSelectionDropdownExample = () => {
 	const [value, setValue] = useState("No value");


### PR DESCRIPTION
## What's included?

Uses the original data id and it's converted to a string to avoid this warning even when a number is used as an id.

## How it was tested?
Look for the Accessibility record raw data within the ´rawData.json´ file and modify its id to a number

![image](https://user-images.githubusercontent.com/87880265/214605588-90f84656-035f-402a-9568-aabc91fce9e7.png)
 
Inspect the console and the warning should not appear.