### PR TITLE
MOS-947: BulkActions shouldn't be required to render checkboxes in DataView

### DIFF
--- a/automation_testing/tests/Components/dataview/data_view.spec.ts
+++ b/automation_testing/tests/Components/dataview/data_view.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, Page } from "@playwright/test";
 import { DataviewPage } from "../../../pages/Components/DataView/DataViewPage";
 import { dataview_data } from "../../../utils/data/dataview_data";
 import theme from "../../../../src/theme";
+import { dataviewKnobs as knob } from "../../../utils/data/knobs";
 
 test.describe.parallel("Components - Data View - Playground", () => {
 	let page: Page;
@@ -20,6 +21,10 @@ test.describe.parallel("Components - Data View - Playground", () => {
 	test.afterAll(async ({ browser }) => {
 		browser.close;
 	});
+
+	async function getNumberOfResultVisible() {
+		return Number(await dataviewPage.paginationComponent.resultAmount.textContent());
+	}
 
 	test("Validate Create New alert message.", async () => {
 		dataviewPage.setDialogValidationListener("CREATE NEW");
@@ -63,7 +68,6 @@ test.describe.parallel("Components - Data View - Playground", () => {
 		await dataviewPage.setDialogValidationListener("DOWNLOAD");
 		await (await dataviewPage.getFirstRowCheckbox()).click();
 		await dataviewPage.downloadBtn.click();
-
 	});
 
 	test("Select all records", async () => {
@@ -127,5 +131,13 @@ test.describe.parallel("Components - Data View - Playground", () => {
 		for (let i = 0; i < await dataviewPage.dataviewTableHeadLocator.count(); i++) {
 			expect(await dataviewPage.getBackgroundColorFromElement(dataviewPage.dataviewTableHeadLocator.nth(i))).toBe(expectedColor);
 		}
+	});
+
+	test("Validate that when bulk actions are deactivated, the checkboxes should remain visible.", async () => {
+		await dataviewPage.visit(dataviewPage.page_path, [knob.knobBulkActions + false, knob.knobBulkAllActions + false]);
+		await dataviewPage.waitForDataviewIsVisible();
+		expect(await dataviewPage.checkboxRow.count()).toEqual(await getNumberOfResultVisible() + 1);
+		await dataviewPage.paginationComponent.selectResultOption(50);
+		expect(await dataviewPage.checkboxRow.count()).toEqual(await getNumberOfResultVisible() + 1);
 	});
 });

--- a/automation_testing/utils/data/knobs.ts
+++ b/automation_testing/utils/data/knobs.ts
@@ -24,3 +24,8 @@ export const uploadKnobs = {
 	knobUploadLimit: "knob-Limit=",
 	knobTriggerErrorsWhenLoading: "knob-Trigger%20errors%20when%20loading="
 }
+
+export const dataviewKnobs = {
+	knobBulkAllActions: "knob-bulkAllActions=",
+	knobBulkActions: "knob-bulkActions="
+}

--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -93,9 +93,7 @@ function DataView (props: DataViewProps): ReactElement  {
 
 	const checkboxEnabled =
 		props.checked !== undefined &&
-		props.onCheckChange !== undefined &&
-		validBulkActions !== undefined &&
-		validBulkActions?.length > 0
+		props.onCheckChange !== undefined
 	;
 
 	const onCheckAllClick = function() {

--- a/src/components/DataView/DataViewTHead.tsx
+++ b/src/components/DataView/DataViewTHead.tsx
@@ -183,7 +183,7 @@ function DataViewTHead(props: DataViewTHeadProps) {
 				}
 				{
 					props.onCheckAllClick &&
-					<StyledTh key="_bulk" className="bulk">
+					<StyledTh key="_bulk" className="bulk" colSpan={(props.bulkActions?.length <= 0 && props.anyChecked) && props.columns.length + 2}>
 						<Checkbox
 							checked={props.allChecked}
 							indeterminate={!props.allChecked && props.anyChecked}


### PR DESCRIPTION
# What's include?
- Removed validBulkActions conditions from dataView