### PR TITLE
MOS-957: Favorite shouldn't be required on SummaryPageTopComponent

### DIFF
--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponentTypes.ts
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponentTypes.ts
@@ -7,9 +7,9 @@ export interface SummaryPageTopComponentTypes {
 	 */
     title: string;
     /**
-	 * Mandatory favorite to show favorite icon or no favorite icon.
+	 * Optional favorite to show favorite icon or no favorite icon.
 	 */
-	favorite: {
+	favorite?: {
 		checked: boolean;
 		onClick: (checked: boolean) => void;
 	};


### PR DESCRIPTION
# What's include?
- Updated to optional the favorite prop for SummaryPageTopcomponent