### PR TITLE
MOS-955: Remove maxCharacter prop from FieldDefBase

### DIFF
--- a/src/components/Field/Field.test.tsx
+++ b/src/components/Field/Field.test.tsx
@@ -121,7 +121,9 @@ describe("Field char counter", () => {
 						name: "fieldTest",
 						type: "text",
 						label: "Label",
-						maxCharacters: 20,
+						inputSettings: {
+							maxCharacters: 20,
+						}
 					}}
 					value={inputValue}
 					colsInRow={1}

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -94,14 +94,14 @@ const Field = ({
 			>
 				{
 					((fieldDef?.label && fieldDef?.label?.length > 0)
-						|| fieldDef?.maxCharacters
+						|| fieldDef?.inputSettings?.maxCharacters
 						|| (fieldDef?.instructionText && renderAsTooltip))
 					&&
 					<Label
 						disabled={fieldDef?.disabled}
 						required={fieldDef?.required}
 						htmlFor={fieldDef?.name}
-						maxCharacters={fieldDef?.maxCharacters}
+						maxCharacters={fieldDef?.inputSettings?.maxCharacters}
 						value={value}
 						tooltip={renderAsTooltip}
 						instructionText={fieldDef?.instructionText}

--- a/src/components/Field/FieldTypes.tsx
+++ b/src/components/Field/FieldTypes.tsx
@@ -92,10 +92,6 @@ export interface FieldDefBase<Type, T = any, U = any> {
 	 */
 	inputSettings?: T;
 	/**
-	 * Used to show and limit the characters.
-	 */
-	maxCharacters?: number;
-	/**
 	 * Defined between 100, 280, 450, and 620 px.
 	 */
 	size?: string;

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -322,7 +322,6 @@ const fields = useMemo(
 * **instructionText** - `string` optional - Instructions about how to fill the current field.
 * **disabled** - `boolean` optional - Flag that indicates whether the field can be filled or readonly.
 * **inputSettings** - `object` optional - Specific props for each specific field (Please see the Props section of each field).
-* **maxCharacters** - `number` optional - When defined, displays the max amount of characters allowed for this field next to the label (only applies for FormFieldText).
 * **size** - `string` optional - Size of the field. Could be either one of the predefined sizes, or a custom size. This property can be internally overwritten if the field is placed inside of a row with other fields.
 	* **xs** = 100px
 	* **sm** = 280px
@@ -355,7 +354,6 @@ const fields = useMemo(
 				instructionText: "This is an example of an instruction text",
 				disabled: false,
 				inputSettings: {}, //Please see inputSettings of each field
-				maxCharacters: 20,
 				size: "sm",
 				className: "myClassName",
 				style: {{ marginTop: "5px", }},
@@ -800,7 +798,6 @@ const fields: FieldDef[] = useMemo(
 			{
 				//...all generic field props,
 				type: "text",
-				maxCharacters: 20,
 				size: "md",
 				inputSettings: {
 					prefixElement: <AccountCircle />,

--- a/src/forms/FormFieldText/FormFieldText.stories.tsx
+++ b/src/forms/FormFieldText/FormFieldText.stories.tsx
@@ -45,7 +45,6 @@ export const Playground = (): ReactElement => {
 					type: "text",
 					required,
 					disabled,
-					maxCharacters: maxCharacters,
 					size,
 					inputSettings: {
 						prefixElement: withIcon && <AccountCircle />,
@@ -138,7 +137,6 @@ const kitchenSinkfields: FieldDef[] = [
 		type: "text",
 		required: false,
 		size: "md",
-		maxCharacters: 20,
 		inputSettings: {
 			maxCharacters: 20,
 			placeholder: "placeholder",


### PR DESCRIPTION
# What's include?
- Removed extra maxCharacters fieldDef from FormFieldText component