### PR TITLE
MOS-958: Chip should not show "click" pointer if onClick is not passed

### DIFF
--- a/automation_testing/pages/BasePage.ts
+++ b/automation_testing/pages/BasePage.ts
@@ -254,4 +254,8 @@ export class BasePage {
 			return await ((element).evaluate(el => getComputedStyle(el).border));
 		}
 	}
+
+	async getCursorFromElement(element: Locator): Promise<string> {
+		return await ((element).evaluate(el => getComputedStyle(el).cursor));
+	}
 }

--- a/automation_testing/pages/Components/Chip/ChipPage.ts
+++ b/automation_testing/pages/Components/Chip/ChipPage.ts
@@ -6,12 +6,24 @@ export class ChipPage extends BasePage {
 	readonly page_path = "components-chip--kitchen-sink";
 
 	readonly page: Page;
+	readonly basicChipWithOnClickNotSelected: Locator;
+	readonly basicChipWithOnClickSelected: Locator;
+	readonly basicChipWithoutOnClickNotSelected: Locator;
+	readonly basicChipWithoutOnClickSelected: Locator;
 	readonly deletableChip: Locator;
+	readonly disabledChipNotSelected: Locator;
+	readonly disabledChipSelected: Locator;
 
 
 	constructor(page: Page) {
 		super(page);
 		this.page = page;
+		this.basicChipWithOnClickNotSelected = this.chipTestIDLocator.first();
+		this.basicChipWithOnClickSelected = this.chipTestIDLocator.nth(1);
+		this.basicChipWithoutOnClickNotSelected = this.chipTestIDLocator.nth(2);
+		this.basicChipWithoutOnClickSelected = this.chipTestIDLocator.nth(3);
 		this.deletableChip = page.locator("[data-testid='delete-chip-testid']");
+		this.disabledChipNotSelected = this.chipTestIDLocator.nth(4);
+		this.disabledChipSelected = this.chipTestIDLocator.nth(5);
 	}
 }

--- a/automation_testing/tests/Components/Chip/chip.spec.ts
+++ b/automation_testing/tests/Components/Chip/chip.spec.ts
@@ -17,10 +17,11 @@ test.describe.parallel("Components - Chip - Kitchen Sink", () => {
 	});
 
 	test("Validate Chip has simplyGold background.", async () => {
-		const expectedColor = (theme.newColors.simplyGold["100"]);
-		const expectedDisabledBgColor = (theme.newColors.simplyGold["60"]);
-		expect(await chipPage.getBackgroundColorFromElement(chipPage.chipTestIDLocator.nth(1))).toBe(expectedColor);
-		expect(await chipPage.getBackgroundColorFromElement(chipPage.chipTestIDLocator.nth(3))).toBe(expectedDisabledBgColor);
+		const expectedColor = theme.newColors.simplyGold["100"];
+		const expectedDisabledBgColor = theme.newColors.simplyGold["60"];
+		expect(await chipPage.getBackgroundColorFromElement(chipPage.basicChipWithOnClickSelected)).toBe(expectedColor);
+		expect(await chipPage.getBackgroundColorFromElement(chipPage.basicChipWithoutOnClickSelected)).toBe(expectedColor);
+		expect(await chipPage.getBackgroundColorFromElement(chipPage.disabledChipSelected)).toBe(expectedDisabledBgColor);
 		expect(await chipPage.getBackgroundColorFromElement(chipPage.deletableChip)).toBe(expectedColor);
 	});
 
@@ -34,7 +35,16 @@ test.describe.parallel("Components - Chip - Kitchen Sink", () => {
 
 	test("Validate Chip has grey2 background.", async () => {
 		const expectedColor = theme.newColors.grey2["100"];
-		expect(await chipPage.getBackgroundColorFromElement(chipPage.chipTestIDLocator.nth(0))).toBe(expectedColor);
-		expect(await chipPage.getBackgroundColorFromElement(chipPage.chipTestIDLocator.nth(2))).toBe(expectedColor);
+		expect(await chipPage.getBackgroundColorFromElement(chipPage.basicChipWithOnClickNotSelected)).toBe(expectedColor);
+		expect(await chipPage.getBackgroundColorFromElement(chipPage.basicChipWithoutOnClickNotSelected)).toBe(expectedColor);
+	});
+
+	test("Validate type of Cursor for Chip", async () => {
+		const expectedCursorWithOnClick = "pointer";
+		const expectedCursorWithoutOnClick = "default";
+		expect(await chipPage.getCursorFromElement(chipPage.basicChipWithOnClickNotSelected)).toBe(expectedCursorWithOnClick);
+		expect(await chipPage.getCursorFromElement(chipPage.basicChipWithOnClickSelected)).toBe(expectedCursorWithOnClick);
+		expect(await chipPage.getCursorFromElement(chipPage.basicChipWithoutOnClickNotSelected)).toBe(expectedCursorWithoutOnClick);
+		expect(await chipPage.getCursorFromElement(chipPage.basicChipWithoutOnClickSelected)).toBe(expectedCursorWithoutOnClick);
 	});
 });

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -18,7 +18,8 @@ const KitchenSinkContainerChip = styled.div`
 `;
 
 export const Playground = (): ReactElement => {
-	const deletable = boolean("Deletable", false);
+	const deletable = boolean("onDelete", false);
+	const clickable = boolean("onClick", false);
 
 	return (
 		deletable ?
@@ -32,6 +33,7 @@ export const Playground = (): ReactElement => {
 				label={text("Label", "Label")}
 				disabled={boolean("Disabled", false)}
 				selected={boolean("Selected", false)}
+				onClick={clickable ? () => alert("onClick") : null}
 			/>
 	)
 };
@@ -44,7 +46,19 @@ export const KitchenSink = (): ReactElement => {
 	return (
 		<KitchenSinkContainerChip>
 			<h1>Chip</h1>
-			<h2>Basic Chip</h2>
+			<h2>Basic Chip with onClick</h2>
+			<Chip
+				label={"Label"}
+				disabled={false}
+				onClick={() => alert("onClick")}
+			/>
+			<Chip
+				label={"Label"}
+				disabled={false}
+				selected={true}
+				onClick={() => alert("onClick")}
+			/>
+			<h2>Basic Chip without onClick</h2>
 			<Chip
 				label={"Label"}
 				disabled={false}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -29,8 +29,6 @@ const Chip = (props: ChipsProps & HTMLAttributes<HTMLDivElement>): ReactElement 
 			required={required}
 			disabled={disabled}
 			selected={selected}
-			clickable
-			disableRipple
 			onClick={onClick}
 			data-testid="chip-testid"
 		/>


### PR DESCRIPTION
# What's include?
- Removed clickable and disableRipple from Chip component
- Added onClick knob to playground story 
- Added new chips examples to kitchensink