### PR TITLE
MOS-947: Fix bulk actions display on grid view

### DIFF
--- a/src/components/DataView/DataView.stories.tsx
+++ b/src/components/DataView/DataView.stories.tsx
@@ -413,6 +413,7 @@ export const Playground = (): ReactElement => {
 	const displayList = boolean("displayList", true);
 	const displayGrid = boolean("displayGrid", true);
 	const draggableRows = boolean("draggableRows", true);
+	const showCheckboxes = boolean("Show Checkboxes", true);
 	const defaultView: DataViewProps["savedView"] = {
 		...rootDefaultView,
 		state: {
@@ -688,14 +689,14 @@ export const Playground = (): ReactElement => {
 				filter
 			});
 		},
-		checked: checkedState.checked,
+		checked: showCheckboxes ? checkedState.checked : undefined,
 		checkedAllPages: checkedState.checkedAllPages,
-		onCheckChange: (checked) => {
+		onCheckChange: showCheckboxes ? (checked) => {
 			setCheckedState((prev) => ({
 				...prev,
 				checked
 			}));
-		},
+		} : undefined,
 		onCheckAllPagesChange: (checkedAllPages) => {
 			setCheckedState((prev) => ({
 				...prev,

--- a/src/components/DataView/DataViewActionsRow/DataViewActionsRow.tsx
+++ b/src/components/DataView/DataViewActionsRow/DataViewActionsRow.tsx
@@ -39,13 +39,12 @@ const DataViewActionsRow = (props: DataViewActionsRowProps): ReactElement => {
 		return limitOptions || [25, 50, 100];
 	}, [limitOptions]);
 
-
 	const hasSortControl = onSortChange !== undefined && sort !== undefined;
 
 	return (
 		<DataViewActionsRowWrapper className={`${display}`}>
 			{
-				display === "grid" && bulkActions?.length > 0 && (
+				display === "grid" && (
 					<LeftControlsContainer>
 						{onCheckAllClick &&
 							<Checkbox
@@ -59,7 +58,7 @@ const DataViewActionsRow = (props: DataViewActionsRowProps): ReactElement => {
 								<DataViewBulkActionsButtonsRow
 									data={props.data}
 									checked={checked}
-									bulkActions={props.bulkActions}
+									bulkActions={bulkActions}
 									checkedAllPages={props.checkedAllPages}
 								/>
 							)

--- a/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
+++ b/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
@@ -49,7 +49,7 @@ function DataViewDisplayGrid(props: DataViewDisplayGridProps) {
 							<div
 								className={`
 									cell
-									${props.checked[i] ? "checked" : ""}
+									${props.checked?.[i] ? "checked" : ""}
 								`}
 								key={i}
 							>

--- a/src/components/DataView/DataViewTHead.tsx
+++ b/src/components/DataView/DataViewTHead.tsx
@@ -183,7 +183,7 @@ function DataViewTHead(props: DataViewTHeadProps) {
 				}
 				{
 					props.onCheckAllClick &&
-					<StyledTh key="_bulk" className="bulk" colSpan={(props.bulkActions?.length <= 0 && props.anyChecked) && props.columns.length + 2}>
+					<StyledTh key="_bulk" className="bulk" colSpan={(props.bulkActions?.length <= 0 && props.anyChecked) ? props.columns.length + 2 : 1}>
 						<Checkbox
 							checked={props.allChecked}
 							indeterminate={!props.allChecked && props.anyChecked}


### PR DESCRIPTION
## What's included?

- Fixes the conditionally displayed of bulkActions on the Grid view.
- Fixes DOM warning about the `th` `colsSpan`  attribute seen as a boolean instead of a number
- Adds validation to `checked` prop that caused Grid view to break since this prop is optional.