### PR TITLE
Mos 967:  Add back capability to Form, DataView and Summary Top

### DIFF
--- a/automation_testing/pages/BasePage.ts
+++ b/automation_testing/pages/BasePage.ts
@@ -36,6 +36,7 @@ export class BasePage {
 	readonly rolePresentationLocator: Locator;
 	readonly deleteIconSelectedOptionChip: Locator;
 	readonly formLocator: Locator;
+	backIconLocator: Locator;
 
 	constructor(page: Page) {
 		this.page = page;

--- a/automation_testing/pages/Components/DataView/DataViewPage.ts
+++ b/automation_testing/pages/Components/DataView/DataViewPage.ts
@@ -61,6 +61,7 @@ export class DataviewPage extends BasePage {
 		this.headerActionsLocator = page.locator(".headerActions");
 		this.dataviewTopComponent = page.locator("//*[@id='root']/div/div/div[1]/div");
 		this.dataviewTableHeadLocator = page.locator("thead th");
+		this.backIconLocator = page.locator(".headerRow button svg[data-testid='icon-button-test']");
 	}
 
 	async validateRecordsNumberInDialogMessage(number: number): Promise<void> {

--- a/automation_testing/pages/Components/Form/PlaygroundPage.ts
+++ b/automation_testing/pages/Components/Form/PlaygroundPage.ts
@@ -96,6 +96,7 @@ export class PlaygroundPage extends BasePage {
 		this.latitudeMapCard = page.locator("#mapCoordinates div span").nth(1);
 		this.longitudeMapCard = page.locator("#mapCoordinates div span").nth(3);
 		this.addressFieldTitle = page.locator("#address [data-testid='address-card-test'] span").first();
+		this.backIconLocator = page.locator("button svg[data-testid='icon-button-test']");
 	}
 
 	async getNumberOfFieldsRequired():Promise<number> {

--- a/automation_testing/pages/Components/SummaryPageTopComponent/SummaryPageTopComponentPage.ts
+++ b/automation_testing/pages/Components/SummaryPageTopComponent/SummaryPageTopComponentPage.ts
@@ -18,5 +18,6 @@ export class SummaryPageTopComponentPage extends BasePage {
 		this.starRateIconUnchecked = page.locator("[data-testid='StarBorderRoundedIcon']");
 		this.starRateIconChecked = page.locator("[data-testid='StarRateRoundedIcon']");
 		this.summaryTopComponent = page.locator("//*[@id='root']/div");
+		this.backIconLocator = page.locator("button svg[data-testid='icon-button-test']").first();
 	}
 }

--- a/automation_testing/tests/Components/SummaryPageTopComponent/summaryPageTopComponent.spec.ts
+++ b/automation_testing/tests/Components/SummaryPageTopComponent/summaryPageTopComponent.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, Page } from "@playwright/test";
 import { SummaryPageTopComponentPage } from "../../../pages/Components/SummaryPageTopComponent/SummaryPageTopComponentPage";
 import theme from "../../../../src/theme";
+import { commonKnobs } from "../../../utils/data/knobs";
 
 test.describe.parallel("Components - SummaryPageTopComponent - Kitchen Sink", () => {
 	let page: Page;
@@ -45,5 +46,12 @@ test.describe.parallel("Components - SummaryPageTopComponent - Kitchen Sink", ()
 		expect(await summaryPage.getSpecificPaddingFromElement(locator, "right")).toBe("24px");
 		expect(await summaryPage.getSpecificPaddingFromElement(locator, "bottom")).toBe("16px");
 		expect(await summaryPage.getSpecificPaddingFromElement(locator, "left")).toBe("24px");
+	});
+
+	test("Validate that when onBack is activated, the back icon is displayed.", async () => {
+		await summaryPage.visit(summaryPage.page_path, [commonKnobs.knobOnBack + true]);
+		await expect(summaryPage.backIconLocator).toBeVisible();
+		await summaryPage.backIconLocator.click();
+		await summaryPage.setDialogValidationListener("Cancelling, going back to previous site");
 	});
 });

--- a/automation_testing/tests/Components/dataview/data_view.spec.ts
+++ b/automation_testing/tests/Components/dataview/data_view.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page } from "@playwright/test";
 import { DataviewPage } from "../../../pages/Components/DataView/DataViewPage";
 import { dataview_data } from "../../../utils/data/dataview_data";
 import theme from "../../../../src/theme";
-import { dataviewKnobs as knob } from "../../../utils/data/knobs";
+import { dataviewKnobs as knob, commonKnobs } from "../../../utils/data/knobs";
 
 test.describe.parallel("Components - Data View - Playground", () => {
 	let page: Page;
@@ -139,5 +139,13 @@ test.describe.parallel("Components - Data View - Playground", () => {
 		expect(await dataviewPage.checkboxRow.count()).toEqual(await getNumberOfResultVisible() + 1);
 		await dataviewPage.paginationComponent.selectResultOption(50);
 		expect(await dataviewPage.checkboxRow.count()).toEqual(await getNumberOfResultVisible() + 1);
+	});
+
+	test("Validate that when onBack is activated, the back icon is displayed.", async () => {
+		await dataviewPage.visit(dataviewPage.page_path, [commonKnobs.knobOnBack + true]);
+		await dataviewPage.waitForDataviewIsVisible();
+		await expect(dataviewPage.backIconLocator).toBeVisible();
+		await dataviewPage.backIconLocator.click();
+		await dataviewPage.setDialogValidationListener("Cancelling, going back to previous site");
 	});
 });

--- a/automation_testing/tests/Components/form/playground.spec.ts
+++ b/automation_testing/tests/Components/form/playground.spec.ts
@@ -119,4 +119,11 @@ test.describe.parallel("Components - Form - Playground", () => {
 		await playgroundPage.simpleText.waitFor();
 		await playgroundPage.validateFormIsEmpty(grey2Color);
 	});
+
+	test("Validate that when onBack is activated, the back icon is displayed.", async () => {
+		await playgroundPage.visit(playgroundPage.page_path, [commonKnobs.knobOnBack + true]);
+		await expect(playgroundPage.backIconLocator).toBeVisible();
+		await playgroundPage.backIconLocator.click();
+		await playgroundPage.setDialogValidationListener("Cancelling, going back to previous site");
+	});
 });

--- a/automation_testing/utils/data/knobs.ts
+++ b/automation_testing/utils/data/knobs.ts
@@ -2,7 +2,8 @@ export const commonKnobs = {
 	knobShowState: "knob-Show%20state=",
 	knobRequired: "knob-Required=",
 	knobDisabled: "knob-Disabled=",
-	knobShowOptions:"knob-Show%20options="
+	knobShowOptions:"knob-Show%20options=",
+	knobOnBack: "knob-onBack="
 }
 
 export const cardKnobs = {

--- a/src/components/DataView/DataView.stories.mdx
+++ b/src/components/DataView/DataView.stories.mdx
@@ -60,6 +60,7 @@ The other non-converted props are listed below:
 * **onSavedViewGetOptions** - `function` -  A callback function which is used to provide an array of views to the SavedView component. Useful when loading a list of saved views from a user profile.
 * **onCheckChange** - `function` -  A callback function which is invoked when a row is selected, useful to tell the parent component which rows are checked.
 * **onCheckAllPagesChange** - `function(checkAllPages: boolean)` -  Callback used to update the state of the checkedAllPages prop.
+* **onBack** - `function` - optional - Callback used to go back to the previous screen / element / drawer. When passed a left arrow will render to the left of the title.
 
 ## Feature - View Switcher
 

--- a/src/components/DataView/DataView.stories.tsx
+++ b/src/components/DataView/DataView.stories.tsx
@@ -402,6 +402,7 @@ const StyledDiv = styled.div`
 `;
 
 export const Playground = (): ReactElement => {
+	const onBack = boolean("onBack", false);
 	const savedViewAllowSharedViewSave = boolean("savedViewAllowSharedViewSave", true);
 	const bulkActions = boolean("bulkActions", true);
 	const bulkAllActions = boolean("bulkAllActions", true);
@@ -551,6 +552,7 @@ export const Playground = (): ReactElement => {
 
 	const gridConfig: DataViewProps = {
 		title: "Your Uploads",
+		onBack: onBack ? () => alert("Cancelling, going back to previous site") : undefined,
 		columns: (display === "list" || display === undefined) ? listColumns : gridColumns,
 		gridColumnsMap,
 		primaryActions: primaryActions ? [

--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -250,6 +250,7 @@ function DataView (props: DataViewProps): ReactElement  {
 					<div className="headerRow title">
 						<DataViewTitleBar
 							title={props.title}
+							onBack={props.onBack}
 							buttons={props.buttons}
 							savedViewEnabled={savedViewEnabled}
 							savedView={props.savedView}

--- a/src/components/DataView/DataViewTitleBar/DataViewTitleBar.styled.ts
+++ b/src/components/DataView/DataViewTitleBar/DataViewTitleBar.styled.ts
@@ -24,17 +24,7 @@ export const StyledWrapper = styled.div`
 		margin-right: 0px;
 	}
 
-	& > .left > h1 {
-		color: ${theme.newColors.almostBlack["100"]};
-		font-family: ${theme.museoFont};
-		font-size: 28px;
-		font-weight: 250;
-		line-height: 33px;
-		margin-bottom: 0px;
+	& > .left h1 {
 		margin-right: 16px;
-		max-width: 916px;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
 	}
 `;

--- a/src/components/DataView/DataViewTitleBar/DataViewTitleBar.styled.ts
+++ b/src/components/DataView/DataViewTitleBar/DataViewTitleBar.styled.ts
@@ -25,6 +25,8 @@ export const StyledWrapper = styled.div`
 	}
 
 	& > .left h1 {
+		line-height: 33px;
 		margin-right: 16px;
+		max-width: 916px;
 	}
 `;

--- a/src/components/DataView/DataViewTitleBar/DataViewTitleBar.tsx
+++ b/src/components/DataView/DataViewTitleBar/DataViewTitleBar.tsx
@@ -1,11 +1,10 @@
 import React, { useMemo } from "react";
 import ButtonRow from "../../ButtonRow";
 import DataViewViewControls from "../DataViewViewControls";
-import { H1 } from "../../Typography";
 import DataViewFilters from "../DataViewFilters";
 import { DataViewTitleBarProps } from "./DataViewTitleBarTypes";
 import { TitleBarWrapper, StyledWrapper } from "./DataViewTitleBar.styled";
-
+import TitleWrapper from "@root/forms/TopComponent/Utils/TitleWrapper";
 
 function DataViewTitleBar(props: DataViewTitleBarProps) {
 	const buttons = useMemo(() => {
@@ -24,7 +23,12 @@ function DataViewTitleBar(props: DataViewTitleBarProps) {
 		<TitleBarWrapper>
 			<StyledWrapper>
 				<div className="left">
-					{props.title && <H1>{props.title}</H1>}
+					{props.title &&
+						<TitleWrapper
+							title={props.title}
+							onBack={props.onBack}
+						/>
+					}
 					{props.savedViewEnabled && (
 						<DataViewViewControls
 							savedView={props.savedView}

--- a/src/components/DataView/DataViewTitleBar/DataViewTitleBarTypes.ts
+++ b/src/components/DataView/DataViewTitleBar/DataViewTitleBarTypes.ts
@@ -20,4 +20,5 @@ export interface DataViewTitleBarProps {
 	filters?: DataViewProps["filters"]
 	activeFilters?: DataViewProps["activeFilters"];
 	onActiveFiltersChange?: DataViewProps["onActiveFiltersChange"];
+	onBack?: DataViewProps["onBack"];
 }

--- a/src/components/DataView/DataViewTypes.ts
+++ b/src/components/DataView/DataViewTypes.ts
@@ -242,5 +242,6 @@ export interface DataViewProps {
 	onSavedViewRemove?: dataViewOnSavedViewRemove
 	onSavedViewGetOptions?: dataViewOnSavedViewGetOptions
 	onCheckChange?: dataViewOnCheckChange;
-	onCheckAllPagesChange?: dataViewOnCheckAllPagesChange
+	onCheckAllPagesChange?: dataViewOnCheckAllPagesChange;
+	onBack?: () => void;
 }

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -23,6 +23,7 @@ functionality and not how to make a form work.
 * **getFormValues** - `() => Promise<MosaicObject>` optional - Function that will run once the form renders to prepopulate the fields. This should return an object where the key is the name of the field, and the value is the value to prepopulate the field.
 * **buttons** - `ButtonAttrs` optional - Array of buttons that will be rendered at the TopComponent. Each button object can be configured based on the button's props (see [ButtonAttrs type](#buttonattrs-type) and [ActionAdditional type](#actionadditional-type) `['show']`).
 * **handleDialogClose** - `(val: boolean) => void` optional - Function that will get called when closing the dialog (see explanaition of the dialogOpen prop).
+* **onBack** - `() => void` - optional - Callback used to go back to the previous screen / element / drawer. When passed a left arrow will render to the left of the title.
 
 ## useForm Hook
 - In order to create and work with the `Form` component it's required to create an instance of the useForm hook per form.

--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -68,6 +68,7 @@ export const Playground = (): ReactElement => {
 	const { setImage, setVideo, setDocument, setLink, handleRemove } = useImageVideoLinkDocumentBrowsing(dispatch, "imageVideoDocumentLink");
 
 	const showState = boolean("Show state", false);
+	const onBack = boolean("onBack", false);
 	const prepopulate = boolean("Prepopulate", false);
 	const defaultValuesKnob = select("Default Values", ["None", "Has Defaults"], "None");
 	const showGetFormValues = select("GetFormValues", ["None", "Returns Undefined", "Returns Data"], "Returns Data");
@@ -652,6 +653,7 @@ export const Playground = (): ReactElement => {
 			<div style={{height: "100vh"}}>
 				<Form
 					title={text("Title", "Form Title")}
+					onBack={onBack ? () => alert("Cancelling, going back to previous site") : undefined}
 					description={text("Description", "This is a description example")}
 					state={state}
 					fields={fields}

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -21,6 +21,7 @@ const Form = (props: FormProps) => {
 		type,
 		state,
 		title,
+		onBack,
 		fields,
 		sections,
 		dispatch,
@@ -167,6 +168,7 @@ const Form = (props: FormProps) => {
 						<TopComponent
 							ref={topComponentRef}
 							title={title}
+							onBack={onBack}
 							type={type}
 							description={description}
 							onCancel={cancel}

--- a/src/components/Form/FormTypes.tsx
+++ b/src/components/Form/FormTypes.tsx
@@ -15,6 +15,7 @@ export interface FormProps {
 	type?: "drawer";
 	state: any;
 	title?: string;
+	onBack?: () => void;
 	fields: FieldDef[];
 	sections?: SectionDef[];
 	dispatch: any;

--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponent.stories.tsx
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponent.stories.tsx
@@ -27,6 +27,7 @@ export const Example = (): ReactElement => {
 	const [checked, setChecked] = useState<boolean>(false);
 
 	const title = text("Title", "Laudantium est optio voluptas");
+	const onBack = boolean("onBack", false);
 	const img = boolean("Image", false);
 	const showFavorite = boolean("Show star", true);
 	const showMainActions = boolean("Main actions", true);
@@ -134,6 +135,7 @@ export const Example = (): ReactElement => {
 	return (
 		<SummaryPageTopComponent
 			title={title}
+			onBack={onBack ? () => alert("Cancelling, going back to previous site") : undefined}
 			favorite={showFavorite && favorite}
 			img={img && "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1436900668/clients/grandrapids/Covered%20bridge%20in%20Ada_19c2ee0d-a43b-4aab-b102-65a0db32288b.jpg"}
 			mainActions={showMainActions && mainActions}

--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponent.styled.tsx
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponent.styled.tsx
@@ -36,18 +36,6 @@ export const ContainerTitle = styled.div`
     flex-wrap: wrap;
 `;
 
-export const Title = styled.p`
-    font-size: 28px;
-    font-weight: ${theme.fontWeight.light};
-    max-width: 650px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-	margin: 0px;
-	padding: 0px;
-	font-family: ${theme.museoFont} !important;
-`;
-
 export const CheckedStar = styled(StarRateRounded)`
 	margin-left: 12px;
     color: ${theme.newColors.simplyGold["100"]};

--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponent.tsx
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponent.tsx
@@ -6,7 +6,6 @@ import {
 	StyledSummaryPageTopComponent,
 	Container,
 	Row,
-	Title,
 	ContainerItems,
 	Item,
 	ContainerTitle,
@@ -18,10 +17,12 @@ import {
 import Image from "@root/components/Image";
 import Button from "../Button";
 import { filterAction } from "../DataView/utils/bulkActionsUtils";
+import TitleWrapper from "@root/forms/TopComponent/Utils/TitleWrapper";
 
 const SumaryPageTopComponent = (props: SummaryPageTopComponentTypes): ReactElement => {
 	const {
 		title,
+		onBack,
 		favorite,
 		img,
 		mainActions,
@@ -59,9 +60,7 @@ const SumaryPageTopComponent = (props: SummaryPageTopComponentTypes): ReactEleme
 			<Container>
 				<Row>
 					<ContainerTitle>
-						<Title>
-							{title}
-						</Title>
+						<TitleWrapper title={title} onBack={onBack} />
 						{
 							favorite &&
 								<>

--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponentTypes.ts
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponentTypes.ts
@@ -38,4 +38,5 @@ export interface SummaryPageTopComponentTypes {
 	// 	href: ButtonProps["href"];
 	// 	onClick?: ButtonProps["onClick"];
 	// }[];
+	onBack?: () => void;
   }

--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponentTypes.ts
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponentTypes.ts
@@ -38,5 +38,8 @@ export interface SummaryPageTopComponentTypes {
 	// 	href: ButtonProps["href"];
 	// 	onClick?: ButtonProps["onClick"];
 	// }[];
+	/**
+	 * Optional. If present, the Back icon is displayed on the left side of the title.
+	*/
 	onBack?: () => void;
   }

--- a/src/forms/TopComponent/TopComponent.tsx
+++ b/src/forms/TopComponent/TopComponent.tsx
@@ -31,6 +31,7 @@ const TopComponent = forwardRef<HTMLDivElement, TopComponentProps>((props: TopCo
 		onCancel,
 		showActive,
 		title,
+		onBack,
 		tooltipInfo,
 		sections,
 		sectionsRefs,
@@ -83,6 +84,7 @@ const TopComponent = forwardRef<HTMLDivElement, TopComponentProps>((props: TopCo
 			ref={ref}
 			sectionsRefs={sectionsRefs}
 			title={title}
+			onBack={onBack}
 			description={description}
 			showActive={showActive}
 			tooltipInfo={tooltipInfo}
@@ -101,6 +103,7 @@ const TopComponent = forwardRef<HTMLDivElement, TopComponentProps>((props: TopCo
 				ref={ref}
 				buttons={buttons}
 				title={title}
+				onBack={onBack}
 				description={description}
 				helpIcon={helpIcon}
 				checkbox={checkbox}
@@ -114,6 +117,7 @@ const TopComponent = forwardRef<HTMLDivElement, TopComponentProps>((props: TopCo
 			<ResponsiveView
 				ref={ref}
 				title={title}
+				onBack={onBack}
 				description={description}
 				showActive={showActive}
 				tooltipInfo={tooltipInfo}

--- a/src/forms/TopComponent/TopComponentTypes.tsx
+++ b/src/forms/TopComponent/TopComponentTypes.tsx
@@ -16,6 +16,10 @@ export type BaseTopComponentProps = {
 	/**
 	 * Optional description for the current form.
 	 */
+	onBack?: () => void;
+	/**
+	 * Optional. If present, the Back icon is displayed on the left side of the title.
+	 */
 	description?: string;
 	/**
 	 * If present, the help icon is display with the

--- a/src/forms/TopComponent/TopComponentTypes.tsx
+++ b/src/forms/TopComponent/TopComponentTypes.tsx
@@ -16,11 +16,11 @@ export type BaseTopComponentProps = {
 	/**
 	 * Optional description for the current form.
 	 */
-	onBack?: () => void;
+	description?: string;
 	/**
 	 * Optional. If present, the Back icon is displayed on the left side of the title.
-	 */
-	description?: string;
+	*/
+	onBack?: () => void;
 	/**
 	 * If present, the help icon is display with the
 	 * string defined with this prop.

--- a/src/forms/TopComponent/Utils/TitleWrapper.tsx
+++ b/src/forms/TopComponent/Utils/TitleWrapper.tsx
@@ -6,10 +6,14 @@ import styled from "styled-components";
 
 // Utils
 import theme, { BREAKPOINTS, Views } from "@root/theme/theme";
+import Button from "@root/components/Button";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 
 const BIG_SCREEN_BREAKPOINT = BREAKPOINTS.topComponent.bigScreenView + "px";
 
 export const FormTitle = styled.span`
+	display: flex;
+	align-items: center;
 	font-family: ${theme.museoFont};
 	color: ${theme.newColors.almostBlack["100"]};
 	font-size: ${pr => pr.type && pr.type === Views.drawer ? "20px" : "28px"};
@@ -50,12 +54,17 @@ export const TitleRow = styled.div`
 		margin-right: auto;
 		`
 }
+
+	& .back-button > button{
+		margin: 0px 8px 0px -2px !important;
+	}
 `;
 
 type TitleWrapperProps = {
 	title: string;
-	description: string;
-	view: string
+	description?: string;
+	view?: string;
+	onBack?: () => void;
 }
 
 const TitleWrapper = (props: TitleWrapperProps): ReactElement => {
@@ -67,7 +76,13 @@ const TitleWrapper = (props: TitleWrapperProps): ReactElement => {
 
 	return (
 		<TitleRow view={view}>
-			<FormTitle>{title}</FormTitle>
+			<FormTitle>
+				{
+					props.onBack &&
+						<Button className="back-button" color="black" variant="icon" mIcon={ChevronLeftIcon} onClick={props.onBack}/>
+				}
+				{title}
+			</FormTitle>
 			{description && <Description>{description}</Description>}
 		</TitleRow>
 	);

--- a/src/forms/TopComponent/Views/DesktopView.tsx
+++ b/src/forms/TopComponent/Views/DesktopView.tsx
@@ -38,6 +38,7 @@ type DesktopViewProps = {
 const DesktopView = forwardRef((props: DesktopViewProps, ref): ReactElement => {
 	const {
 		title,
+		onBack,
 		description,
 		tooltipInfo,
 		buttons,
@@ -55,6 +56,7 @@ const DesktopView = forwardRef((props: DesktopViewProps, ref): ReactElement => {
 			<FlexContainer>
 				<TitleWrapper
 					title={title}
+					onBack={onBack}
 					description={description}
 					view={view}
 				/>

--- a/src/forms/TopComponent/Views/MobileView.tsx
+++ b/src/forms/TopComponent/Views/MobileView.tsx
@@ -54,6 +54,7 @@ const MobileView = forwardRef<HTMLDivElement, MobileViewProps>((props: MobileVie
 		buttons,
 		onCancel,
 		title,
+		onBack,
 		description,
 		showActive,
 		tooltipInfo,
@@ -76,6 +77,7 @@ const MobileView = forwardRef<HTMLDivElement, MobileViewProps>((props: MobileVie
 			</MobileActionsRow>
 			<TitleWrapper
 				title={title}
+				onBack={onBack}
 				description={description}
 				view={view}
 			/>

--- a/src/forms/TopComponent/Views/ResponsiveView.tsx
+++ b/src/forms/TopComponent/Views/ResponsiveView.tsx
@@ -30,6 +30,7 @@ type ResponsiveViewProps = {
 const ResponsiveView = forwardRef((props: ResponsiveViewProps, ref): ReactElement => {
 	const {
 		title,
+		onBack,
 		description,
 		tooltipInfo,
 		helpIcon,
@@ -47,6 +48,7 @@ const ResponsiveView = forwardRef((props: ResponsiveViewProps, ref): ReactElemen
 			<Row className={view}>
 				<TitleWrapper
 					title={title}
+					onBack={onBack}
 					description={description}
 					view={view}
 				/>


### PR DESCRIPTION
# What's included?
- Updated TittleWrapper component so it receives "onBack" prop
- Added onBack knobs to DataView, Form, and SummaryPageTopComponent