### PR TITLE
MOS-977: Use SideNav in the Form on a big desktop view

### DIFF
--- a/automation_testing/pages/Components/SideNav/SideNavPage.ts
+++ b/automation_testing/pages/Components/SideNav/SideNavPage.ts
@@ -17,23 +17,4 @@ export class SideNavPage extends BasePage {
 		this.sections = page.locator("[data-testid='section-wrapper']");
 		this.navLocator = page.locator("nav");
 	}
-
-	async getLocatorOfSelectedSection(sectionTitle: string): Promise<Locator> {
-		const sectionText =  this.sections.locator("div");
-		for (let i = 0; i < await sectionText.count(); i++) {
-			if (await sectionText.nth(i).textContent() == sectionTitle) {
-				return sectionText.nth(i);
-			}
-		}
-	}
-
-	async selectSpecificSection(sectionToSelect: string): Promise<void> {
-		const sections =  this.sections.locator("div");
-		for (let i = 0; i < await sections.count(); i++) {
-			if (await sections.nth(i).textContent() == sectionToSelect) {
-				await sections.nth(i).click({force: true});
-				break;
-			}
-		}
-	}
 }

--- a/automation_testing/pages/Components/SideNav/SideNavPage.ts
+++ b/automation_testing/pages/Components/SideNav/SideNavPage.ts
@@ -8,12 +8,14 @@ export class SideNavPage extends BasePage {
 	readonly page: Page;
 	readonly title: Locator;
 	readonly sections: Locator;
+	readonly navLocator: Locator;
 
 	constructor(page: Page) {
 		super(page);
 		this.page = page;
 		this.title = page.locator("#root h1");
 		this.sections = page.locator("[data-testid='section-wrapper']");
+		this.navLocator = page.locator("nav");
 	}
 
 	async getLocatorOfSelectedSection(sectionTitle: string): Promise<Locator> {

--- a/automation_testing/tests/Components/SideNav/sideNav.spec.ts
+++ b/automation_testing/tests/Components/SideNav/sideNav.spec.ts
@@ -6,6 +6,7 @@ import { commonKnobs as knob } from "../../../utils/data/knobs";
 test.describe.parallel("Components - SideNav", () => {
 	let page: Page;
 	let sideNavPage: SideNavPage;
+	const expectsimplyGoldBorderColor = theme.newColors.simplyGold["100"];
 
 	test.beforeAll(async ({ browser }) => {
 		page = await browser.newPage();
@@ -18,18 +19,14 @@ test.describe.parallel("Components - SideNav", () => {
 	});
 
 	test("Validate that the selected active link is the same as the one highlighted.", async () => {
-		const expectBorderColor = theme.newColors.simplyGold["100"];
-		const titleSectionSelected = await sideNavPage.title.textContent();
-		const selectedLocator = await sideNavPage.getLocatorOfSelectedSection(titleSectionSelected);
-		expect(await sideNavPage.getSpecificBorderFromElement(selectedLocator, "left")).toContain(expectBorderColor);
+		const selectedLocator = sideNavPage.sections.locator("a").first();
+		expect(await sideNavPage.getSpecificBorderFromElement(selectedLocator, "left")).toContain(expectsimplyGoldBorderColor);
 	});
 
 	test("Validate that when selecting a section, the section is highlighted.", async () => {
-		const sectionToSelect = "Accounts";
-		const expectBorderColor = theme.newColors.simplyGold["100"];
-		await sideNavPage.selectSpecificSection(sectionToSelect);
-		const selectedLocator = await sideNavPage.getLocatorOfSelectedSection(sectionToSelect);
-		expect(await sideNavPage.getSpecificBorderFromElement(selectedLocator, "left")).toContain(expectBorderColor);
+		const selectedLocator = sideNavPage.sections.locator("a").last();
+		await selectedLocator.click();
+		expect(await sideNavPage.getSpecificBorderFromElement(selectedLocator, "left")).toContain(expectsimplyGoldBorderColor);
 	});
 
 	test("Validate Side Nav first section has almostBlack color.", async () => {
@@ -43,8 +40,9 @@ test.describe.parallel("Components - SideNav", () => {
 
 	test("Validate selected section has grey2 as background color.", async () => {
 		const expectedColor = theme.newColors.grey2["100"];
-		await sideNavPage.sections.locator("div").first().click();
-		expect(await sideNavPage.getBackgroundColorFromElement(sideNavPage.sections.locator("div").first())).toBe(expectedColor);
+		const selectedLocator = sideNavPage.sections.locator("a").first();
+		await selectedLocator.click();
+		expect(await sideNavPage.getBackgroundColorFromElement(selectedLocator)).toBe(expectedColor);
 	});
 
 

--- a/automation_testing/tests/Components/SideNav/sideNav.spec.ts
+++ b/automation_testing/tests/Components/SideNav/sideNav.spec.ts
@@ -47,12 +47,12 @@ test.describe.parallel("Components - SideNav", () => {
 
 
 	test("Validate that the nav height can be modified", async () => {
-		const firstExpectHeight = "800";
-		const secondEexpectHeight = "1000";
-		await sideNavPage.visit(sideNavPage.page_path, [knob.knobParentHeight + firstExpectHeight]);
-		expect(await sideNavPage.getHeightFromElement(sideNavPage.navLocator)).toBe(firstExpectHeight + "px");
-		await sideNavPage.visit(sideNavPage.page_path, [knob.knobParentHeight + secondEexpectHeight]);
-		expect(await sideNavPage.getHeightFromElement(sideNavPage.navLocator)).toBe(secondEexpectHeight + "px");
+		const firstExpectedHeight = "800";
+		const secondExpectedHeight = "1000";
+		await sideNavPage.visit(sideNavPage.page_path, [knob.knobParentHeight + firstExpectedHeight]);
+		expect(await sideNavPage.getHeightFromElement(sideNavPage.navLocator)).toBe(firstExpectedHeight + "px");
+		await sideNavPage.visit(sideNavPage.page_path, [knob.knobParentHeight + secondExpectedHeight]);
+		expect(await sideNavPage.getHeightFromElement(sideNavPage.navLocator)).toBe(secondExpectedHeight + "px");
 	});
 
 	test("Validate that the selected section is bold", async () => {

--- a/automation_testing/tests/Components/SideNav/sideNav.spec.ts
+++ b/automation_testing/tests/Components/SideNav/sideNav.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, Page } from "@playwright/test";
 import { SideNavPage } from "../../../pages/Components/SideNav/SideNavPage";
 import theme from "../../../../src/theme";
+import { commonKnobs as knob } from "../../../utils/data/knobs";
 
 test.describe.parallel("Components - SideNav", () => {
 	let page: Page;
@@ -44,5 +45,20 @@ test.describe.parallel("Components - SideNav", () => {
 		const expectedColor = theme.newColors.grey2["100"];
 		await sideNavPage.sections.locator("div").first().click();
 		expect(await sideNavPage.getBackgroundColorFromElement(sideNavPage.sections.locator("div").first())).toBe(expectedColor);
+	});
+
+
+	test("Validate that the nav height can be modified", async () => {
+		const firstExpectHeight = "800";
+		const secondEexpectHeight = "1000";
+		await sideNavPage.visit(sideNavPage.page_path, [knob.knobParentHeight + firstExpectHeight]);
+		expect(await sideNavPage.getHeightFromElement(sideNavPage.navLocator)).toBe(firstExpectHeight + "px");
+		await sideNavPage.visit(sideNavPage.page_path, [knob.knobParentHeight + secondEexpectHeight]);
+		expect(await sideNavPage.getHeightFromElement(sideNavPage.navLocator)).toBe(secondEexpectHeight + "px");
+	});
+
+	test("Validate that the selected section is bold", async () => {
+		await sideNavPage.sections.locator("span").last().click();
+		expect(await sideNavPage.getFontWeightFromElement(sideNavPage.sections.locator("span").last())).toBe((theme.fontWeight.semiBold).toString());
 	});
 });

--- a/automation_testing/utils/data/knobs.ts
+++ b/automation_testing/utils/data/knobs.ts
@@ -3,7 +3,8 @@ export const commonKnobs = {
 	knobRequired: "knob-Required=",
 	knobDisabled: "knob-Disabled=",
 	knobShowOptions:"knob-Show%20options=",
-	knobOnBack: "knob-onBack="
+	knobOnBack: "knob-onBack=",
+	knobParentHeight: "knob-Parent%20height%20(px)="
 }
 
 export const cardKnobs = {

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -6,7 +6,6 @@ import { formActions } from "./formActions";
 import FormLayout from "./FormLayout";
 import TopComponent, { ViewType } from "@root/forms/TopComponent";
 import { FormContent, Row } from "@root/forms/TopComponent/TopComponent.styled";
-import FormNav from "@root/forms/FormNav";
 import { useViewResizer, ViewProvider } from "@root/utils/formViewUtils";
 import { MosaicObject } from "@root/types";
 import { filterAction } from "@root/components/DataView/utils/bulkActionsUtils";
@@ -14,6 +13,7 @@ import Dialog from "@root/components/Dialog";
 import { ButtonProps } from "../Button";
 import { Views } from "@root/theme/theme";
 import { useRefsDispatch } from "../../forms/shared/refsContext/RefsContext";
+import SideNav, { Item, SideNavArgs } from "../SideNav";
 
 const Form = (props: FormProps) => {
 	const {
@@ -38,6 +38,7 @@ const Form = (props: FormProps) => {
 	const formContainerRef = useRef<HTMLDivElement>();
 	const topComponentRef = useRef<HTMLDivElement>();
 	const formContentRef = useRef<HTMLDivElement>();
+	const [activeSection, setActiveSection] = useState("0");
 
 	const dispatchRef = useRefsDispatch();
 
@@ -149,6 +150,67 @@ const Form = (props: FormProps) => {
 		},
 	];
 
+	const isBigDesktopWithSections =
+		view === Views.bigDesktop &&
+		sections &&
+		sections?.length > 1;
+
+	/**
+	 * If the Form view is for a big desktop it will create an
+	 * IntersectionObserver the user has scrolled into a section
+	 * and highlighting it.
+	 */
+	useEffect(() => {
+		if (!isBigDesktopWithSections) {
+			return;
+		}
+
+		const observer = new IntersectionObserver((entries) => {
+			entries.forEach(entry => {
+				const sectionId = entry?.target.getAttribute("id");
+
+				if (entry.isIntersecting) {
+					setActiveSection(sectionId);
+				}
+			})
+		}, { threshold: 0.5, rootMargin: "-20px 0px -20%", root: formContentRef?.current });
+
+		sectionsRefs?.forEach(section => {
+			observer.observe(section);
+		})
+
+		return () => observer.disconnect();
+	}, [sectionsRefs, sections, view]);
+
+	/**
+	 * In order to use the SideNav on a big desktop we need to transform
+	 * the sections array into an array of Items objects. The name will
+	 * be the index of the section since this index corresponds to the
+	 * section id.
+	 */
+	const items: Item[] = useMemo(() => {
+		if (!isBigDesktopWithSections) return;
+
+		return sections?.map((section, idx) => ({
+			label: section.title,
+			name: idx.toString(),
+		}));
+	}, [sections]);
+
+	/**
+	 * Highlights and scrolls to the sections which link
+	 * was clicked.
+	 * @param args
+	 */
+	const onNav = (args: SideNavArgs) => {
+		setActiveSection(args.item.name);
+		const sectionIndex = Number(args.item.name);
+		sectionsRefs[sectionIndex].scrollIntoView({
+			behavior: "smooth",
+			block: "start"
+		});
+	};
+
 	return (
 		<>
 			<ViewProvider value={view}>
@@ -181,13 +243,13 @@ const Form = (props: FormProps) => {
 							showActive={showActive}
 						/>
 						}
-						{view === Views.bigDesktop && sections ? (
+						{isBigDesktopWithSections ? (
 							<Row className={view}>
 								{sections &&
-								<FormNav
-									sectionsRefs={sectionsRefs}
-									sections={sections}
-									formContentRef={formContentRef}
+								<SideNav
+									items={[items]}
+									active={activeSection}
+									onNav={onNav}
 								/>
 								}
 								<FormContent view={view} sections={sections} ref={formContentRef}>

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -203,7 +203,6 @@ const Form = (props: FormProps) => {
 	 * @param args
 	 */
 	const onNav = (args: SideNavArgs) => {
-		setActiveSection(args.item.name);
 		const sectionIndex = Number(args.item.name);
 		sectionsRefs[sectionIndex].scrollIntoView({
 			behavior: "smooth",

--- a/src/components/SideNav/SideNav.stories.mdx
+++ b/src/components/SideNav/SideNav.stories.mdx
@@ -11,6 +11,25 @@ A `SideNav` section tab helps users navigate through different sections under th
 
 https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/components/SideNav/SideNavTypes.ts
 
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| **`active`** | `boolean` | Optional - Defines which is the active link and highlights it. |
+| **`items`** | `Item[][]` | Required - List of sections of links that contains a list of links items.|
+| **`onNav`** | `(args: item: Item, event: MouseEvent): void` | Optional - When a nav item does not have its own onNav function defined, this function will be executed.|
+
+### Item
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| **`action`** | `{ icon: SvgIconComponent; onClick: () => void }` | Optional - Each link could have an optional action which consists of an icon that will be displayed when hovering over the link and an onClick callback. |
+| **`attrs`** | `AnchorHTMLAttributes<HTMLAnchorElement>` | Optional - Anchor element attributes.|
+| **`badge`** | `string` | Optional - Descriptive mark of the link. |
+| **`icon`** | `SvgIconComponent` | Optional - Icon that will be rendered to the left of the link.|
+| **`label`** | `string` | Required - Label that names the link. |
+| **`name`** | `string` | Required - Name of the item. It is used to set it as active when is clicked.. |
+| **`onNav`** | `(args: item: Item, event: MouseEvent): void` | Optional - Callback that each link will execute on an onClick event.. |
+
+
 ## SideNav
 
 <Preview withSource='none'>

--- a/src/components/SideNav/SideNav.stories.tsx
+++ b/src/components/SideNav/SideNav.stories.tsx
@@ -60,6 +60,17 @@ export const Example = (): ReactElement => {
 					setContent(<h1>Sitemap</h1>);
 				},
 			},
+			{
+				label: "Simple View link",
+				name: "sv_link",
+				attrs: {
+					href: "https://www.simpleviewinc.com/"
+				},
+				onNav: (args) => {
+					setActive(args.item.name);
+					setContent(<h1>Redirecting...</h1>)
+				}
+			}
 		],
 		[
 			{

--- a/src/components/SideNav/SideNav.styled.tsx
+++ b/src/components/SideNav/SideNav.styled.tsx
@@ -3,7 +3,7 @@ import theme from "../../theme";
 
 export const SideNavStyle = styled.nav`
 	background: white;
-	border: 2px solid ${theme.newColors.grey2["100"]};
+	border-right: 2px solid ${theme.newColors.grey2["100"]};
 	display: flex;
 	flex-direction: column;
 	width: 196px;
@@ -12,15 +12,16 @@ export const SideNavStyle = styled.nav`
 	overflow-y: auto;
 `;
 
-export const LinkWrapper = styled.div`
-  	align-items: center;
-  	display: flex;
-  	gap: 8px;
+export const LinkWrapper = styled.a`
+	align-items: center;
+	display: flex;
+	gap: 8px;
 	background-color: ${(pr) =>
 		pr.idx === pr.selectedLink ? theme.newColors.grey2["100"] : ""};
 		border-left: ${(pr) =>
 		pr.idx === pr.selectedLink ? `4px solid ${theme.newColors.simplyGold["100"]}` : "4px solid transparent"};
 	padding: 12px 20px;
+	text-decoration: none;
 
 	span {
 		font-weight: ${(pr) =>

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -26,7 +26,7 @@ const SideNav = (props: SideNavProps): ReactElement => {
 			// if the nav item has it's own onNav function
 			item.onNav({ item, event });
 		} else {
-			// else if onNav exists, we all onNav for the main app to navigate
+			// else if onNav exists, we use the main onNav to navigate
 			onNav && onNav({ item, event });
 		}
 	};
@@ -40,8 +40,10 @@ const SideNav = (props: SideNavProps): ReactElement => {
 							{items[key].map((item, idx) => {
 								const LinkIcon = item.icon;
 								const ActionIcon = item?.action?.icon;
+
 								return (
 									<LinkWrapper
+										{...item.attrs}
 										idx={item.name}
 										selectedLink={active}
 										onClick={(event) => onLinkClicked({ item, event })}

--- a/src/components/SideNav/SideNavTypes.ts
+++ b/src/components/SideNav/SideNavTypes.ts
@@ -1,5 +1,5 @@
 import { SvgIconComponent } from "@root/types";
-import { MouseEvent } from "react";
+import { AnchorHTMLAttributes, MouseEvent } from "react";
 
 export interface SideNavArgs {
 	item: Item,
@@ -27,29 +27,33 @@ export interface SideNavProps {
 
 export type Item = {
 	/**
-	 * Name of the item. It is used to set it as active when is clicked.
-	 */
-	name: string;
-	/**
-	 * Optional descriptive mark of the link.
-	 */
-	badge?: string;
-	/**
-	 * Label that names the link.
-	 */
-	label: string;
-	/**
-	 * Optional link left icon.
-	 */
-	icon?: SvgIconComponent;
-	/**
-	 * Callback that each link will execute on an onClick event.
-	 */
-	onNav?: SideNavOnNav;
-	/**
 	 * Each link could have an optional action which consists of an
 	 * icon that will be displayed when hovering over the link and
 	 * an onClick callback
 	 */
 	action?: { icon: SvgIconComponent; onClick: () => void };
+	/**
+	 * Anchor element attributes.
+	 */
+	attrs?: AnchorHTMLAttributes<HTMLAnchorElement>;
+	/**
+	 * Optional descriptive mark of the link.
+	 */
+	badge?: string;
+	/**
+	 * Optional link left icon.
+	 */
+	icon?: SvgIconComponent;
+	/**
+	 * Label that names the link.
+	 */
+	label: string;
+	/**
+	 * Name of the item. It is used to set it as active when is clicked.
+	*/
+	name: string;
+	/**
+	 * Callback that each link will execute on an onClick event.
+	 */
+	onNav?: SideNavOnNav;
 };

--- a/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
+++ b/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
@@ -27,7 +27,7 @@ const FormFieldPhoneSelectionDropdown = (
 	const [dialCode, setDialCode] = useState("");
 
 	const onPhoneChange = (phoneValue: string, data: CountryData) => {
-		if(phoneValue === data.dialCode) {
+		if (phoneValue === data.dialCode) {
 			onChange(undefined);
 			setDialCode(data.dialCode);
 		} else {


### PR DESCRIPTION
## What's included?

- Replaces FormNav with SideNav in the Form on a big desktop view.
- Adds attrs prop to the SideNav to be able to configure the anchor element.
- Adds table of SideNav props as documentation.
- Updates SideNav's styles.