### PR TITLE
MOS-1015: Make the number table summing row and column optional

### DIFF
--- a/automation_testing/tests/FormFields/formFieldNumberTable.spec.ts
+++ b/automation_testing/tests/FormFields/formFieldNumberTable.spec.ts
@@ -66,9 +66,7 @@ test.describe.parallel("FormFields - FormFieldNumberTable - Playground", () => {
 
 	test("Validate that the column and row sums are not displayed.", async () => {
 		await ffNumberTablePage.visit(ffNumberTablePage.page_path, [knob.knobDisplayColumnsSum + "false", knob.knobDisplayRowSum + "false"]);
-
 		expect(await ffNumberTablePage.numberTableLocator.locator("tr").last().locator("td").first().textContent()).not.toBe("TOTAL");
 		expect(await ffNumberTablePage.numberTableLocator.locator("thead").locator("th").last().textContent()).not.toBe("No. Rooms");
-
 	});
 });

--- a/automation_testing/tests/FormFields/formFieldNumberTable.spec.ts
+++ b/automation_testing/tests/FormFields/formFieldNumberTable.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, Page } from "@playwright/test";
 import theme from "../../../src/theme";
 import { FormFieldNumberTablePage } from "../../pages/FormFields/FormFieldNumberTablePage";
-import { commonKnobs } from "../../utils/data/knobs";
+import { commonKnobs, formFieldNumberTableKnobs as knob } from "../../utils/data/knobs";
 
 test.describe.parallel("FormFields - FormFieldNumberTable - Playground", () => {
 	let page: Page;
@@ -62,5 +62,13 @@ test.describe.parallel("FormFields - FormFieldNumberTable - Playground", () => {
 			expect.soft(await ffNumberTablePage.getFontWeightFromElement(columnLocator), "Validating Font Weight the Total of each column.").toBe((theme.fontWeight.normal).toString());
 			expect.soft(await ffNumberTablePage.getFontSizeFromElement(columnLocator), "Validating Font Size the Total of each column.").toBe("14px");
 		}
+	});
+
+	test("Validate that the column and row sums are not displayed.", async () => {
+		await ffNumberTablePage.visit(ffNumberTablePage.page_path, [knob.knobDisplayColumnsSum + "false", knob.knobDisplayRowSum + "false"]);
+
+		expect(await ffNumberTablePage.numberTableLocator.locator("tr").last().locator("td").first().textContent()).not.toBe("TOTAL");
+		expect(await ffNumberTablePage.numberTableLocator.locator("thead").locator("th").last().textContent()).not.toBe("No. Rooms");
+
 	});
 });

--- a/automation_testing/utils/data/knobs.ts
+++ b/automation_testing/utils/data/knobs.ts
@@ -47,3 +47,8 @@ export const buttonKnobs = {
 	knobShow: "knob-Show=",
 	knobTypeOfLabel: "knob-Type%20of%20label="
 }
+
+export const formFieldNumberTableKnobs = {
+	knobDisplayRowSum: "knob-Display%20rows%20sums=",
+	knobDisplayColumnsSum: "knob-Display%20columns%20sums="
+}

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -1575,7 +1575,9 @@ This field implements the [**FieldDef**](#generic-field-props-fielddef) interfac
 | Name | Type | Default | Description |
 | ---- | ---- | --------| ----------- |
 | **`columns`** | `{ name: string; title: string }[]` | | Columns definition. |
-| **`columnTotalLabel`** | `string` | "Total" | optional - Default: "Total". Label shown on the column that displays the totals. |
+| **`columnTotalLabel`** | `string` | `true` | optional - Default: "Total". Label shown on the column that displays the totals. |
+| **`displaySumColumn`** | `boolean` | `true` | optional - Default: "Total". Label shown on the column that displays the totals. |
+| **`displaySumRow`** | `boolean` | "Total" | optional - Default: "Total". Label shown on the column that displays the totals. |
 | **`rows`** | `{ name: string; title: string, subtitle?: string }[]` | | Rows definition. |
 | **`rowTotalLabel`** | `string` | "Total" | optional - Label shown on the total row. |
 | **`topLeftLabel`** | `string` | |  optional - Label placed on the top left table corner i.e the first column. |

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -1575,9 +1575,9 @@ This field implements the [**FieldDef**](#generic-field-props-fielddef) interfac
 | Name | Type | Default | Description |
 | ---- | ---- | --------| ----------- |
 | **`columns`** | `{ name: string; title: string }[]` | | Columns definition. |
-| **`columnTotalLabel`** | `string` | `true` | optional - Default: "Total". Label shown on the column that displays the totals. |
-| **`displaySumColumn`** | `boolean` | `true` | optional - Default: "Total". Label shown on the column that displays the totals. |
-| **`displaySumRow`** | `boolean` | "Total" | optional - Default: "Total". Label shown on the column that displays the totals. |
+| **`columnTotalLabel`** | `string` | "Total" | optional - Default: "Total". Label shown on the column that displays the totals. |
+| **`displaySumColumn`** | `boolean` | `true` | optional - Shows or hides the total sums of each column. |
+| **`displaySumRow`** | `boolean` | `true` | optional - Shows or hides the total sums of each row. |
 | **`rows`** | `{ name: string; title: string, subtitle?: string }[]` | | Rows definition. |
 | **`rowTotalLabel`** | `string` | "Total" | optional - Label shown on the total row. |
 | **`topLeftLabel`** | `string` | |  optional - Label placed on the top left table corner i.e the first column. |

--- a/src/forms/FormFieldNumberTable/FormFieldNumberTable.stories.tsx
+++ b/src/forms/FormFieldNumberTable/FormFieldNumberTable.stories.tsx
@@ -24,6 +24,8 @@ export const Playground = (): ReactElement => {
 	const disabled = boolean("Disabled", false);
 	const instructionText = text("Instruction text", "");
 	const helperText = text("Helper text", "");
+	const displayColumnsSums = boolean("Display columns sums", true);
+	const displayRowsSums = boolean("Display rows sums", true);
 
 	const fields = useMemo(
 		(): FieldDef[] => [
@@ -35,6 +37,8 @@ export const Playground = (): ReactElement => {
 				disabled,
 				defaultValue: numberTableDefaultValue,
 				inputSettings: {
+					displaySumColumn: displayColumnsSums,
+					displaySumRow: displayRowsSums,
 					rowTotalLabel: rowTotalLabel,
 					columnTotalLabel: columnTotalLabel,
 					topLeftLabel: topLeftLabel,
@@ -47,6 +51,8 @@ export const Playground = (): ReactElement => {
 		],
 		[
 			label,
+			displayColumnsSums,
+			displayRowsSums,
 			required,
 			disabled,
 			instructionText,

--- a/src/forms/FormFieldNumberTable/FormFieldNumberTable.styled.tsx
+++ b/src/forms/FormFieldNumberTable/FormFieldNumberTable.styled.tsx
@@ -81,7 +81,7 @@ export const TBody = styled.tbody`
 export const TrTotals = styled.tr`
   background-color: ${theme.newColors.grey1["100"]};
 
-  td:last-child {
+  .totals-row {
     font-weight: ${theme.fontWeight.medium};
   }
 `;

--- a/src/forms/FormFieldNumberTable/FormFieldNumberTable.test.tsx
+++ b/src/forms/FormFieldNumberTable/FormFieldNumberTable.test.tsx
@@ -18,7 +18,13 @@ import {
 	rows,
 } from "./numberTableUtils";
 
-const NumberTableExample = (): ReactElement => {
+const NumberTableExample = ({
+	displaySumColumn = true,
+	displaySumRow = true,
+}: {
+  displaySumColumn?: boolean;
+  displaySumRow?: boolean;
+}): ReactElement => {
 	const { state, dispatch } = useForm();
 
 	const onSubmit = async () => {
@@ -39,6 +45,8 @@ const NumberTableExample = (): ReactElement => {
 				type: "numberTable",
 				defaultValue: numberTableDefaultValue,
 				inputSettings: {
+					displaySumColumn: displaySumColumn,
+					displaySumRow: displaySumRow,
 					rowTotalLabel: "TOTAL",
 					columnTotalLabel: "No. Rooms",
 					topLeftLabel: "Day",
@@ -142,5 +150,18 @@ describe("FormFieldNumberTable component", () => {
 		expect(isValidRowCol("invalidColumn", columns)).toBe(false);
 		expect(isValidRowCol("2023_02_10", rows)).toBe(true);
 		expect(isValidRowCol("single", columns)).toBe(true);
+	});
+});
+
+describe("FormFieldNumberTable with displaySumRow and displaySumColumn disabled", () => {
+	beforeEach(async () => {
+		await act(() => {
+			render(<NumberTableExample displaySumColumn={false} displaySumRow={false}/>);
+		});
+	});
+
+	it("should not display the totals for each row and column", () => {
+		expect(screen.queryByText(labels.rowTotal)).not.toBeInTheDocument();
+		expect(screen.queryByText(labels.columnTotal)).not.toBeInTheDocument();
 	});
 });

--- a/src/forms/FormFieldNumberTable/FormFieldNumberTable.tsx
+++ b/src/forms/FormFieldNumberTable/FormFieldNumberTable.tsx
@@ -32,6 +32,7 @@ const FormFieldNumberTable = (
 	const { fieldDef, onChange, value } = props;
 
 	const { inputSettings } = fieldDef;
+	const { displaySumColumn = true, displaySumRow = true } = inputSettings;
 	const rowTotals = {};
 	const [columnsTotals, setColumnsTotals] = useState({});
 
@@ -59,11 +60,12 @@ const FormFieldNumberTable = (
 			});
 		}
 
-		totals["mos_col_totals"] = Object.values(totals).reduce(
-			(acc: number, current: number) => acc + current
-		);
-
-		setColumnsTotals(totals);
+		if (displaySumColumn) {
+			totals["mos_col_totals"] = Object.values(totals).reduce(
+				(acc: number, current: number) => acc + current
+			);
+			setColumnsTotals(totals);
+		}
 	}, [value]);
 
 	/**
@@ -117,7 +119,9 @@ const FormFieldNumberTable = (
 					{inputSettings.columns.map((column, index) => (
 						<Th key={`${column.name}-${index}`}>{column.title}</Th>
 					))}
-					<Th>{inputSettings.columnTotalLabel || "Total"}</Th>
+					{displaySumRow && (
+						<Th>{inputSettings.columnTotalLabel || "Total"}</Th>
+					)}
 				</TrHead>
 			</thead>
 			<TBody>
@@ -129,8 +133,11 @@ const FormFieldNumberTable = (
 						</Td>
 						{inputSettings.columns.map((column) => {
 							const strValue = value?.[row.name]?.[column.name] ?? "";
-							const numberValue = isNaN(Number(strValue)) ? 0 : Number(strValue);
-							rowTotals[row.name] = (rowTotals[row.name] || 0) + numberValue;
+
+							if (displaySumRow) {
+								const numberValue = isNaN(Number(strValue)) ? 0 : Number(strValue);
+								rowTotals[row.name] = (rowTotals[row.name] || 0) + numberValue;
+							}
 
 							return (
 								<Td key={`${row.name}-${column.name}`}>
@@ -144,22 +151,26 @@ const FormFieldNumberTable = (
 								</Td>
 							);
 						})}
-						<TdTitle key={`totals-${row.name}`}>
-							{rowTotals[row.name]}
-						</TdTitle>
+						{displaySumRow && (
+							<TdTitle key={`totals-${row.name}`}>
+								{rowTotals[row.name]}
+							</TdTitle>
+						)}
 					</tr>
 				))}
-				<TrTotals>
-					<TdTitle>{inputSettings.rowTotalLabel || "Total"}</TdTitle>
-					{inputSettings.columns.map((column) => (
-						<TdTotals key={`column-${column.name}`}>
-							{columnsTotals[column.name] || 0}
-						</TdTotals>
-					))}
-					<TdTotals>
-						{columnsTotals["mos_col_totals"] || 0}
-					</TdTotals>
-				</TrTotals>
+				{displaySumColumn && (
+					<TrTotals>
+						<TdTitle>{inputSettings.rowTotalLabel || "Total"}</TdTitle>
+						{inputSettings.columns.map((column) => (
+							<TdTotals key={`column-${column.name}`}>
+								{columnsTotals[column.name] || 0}
+							</TdTotals>
+						))}
+						{displaySumRow && (
+							<TdTotals className="totals-row">{columnsTotals["mos_col_totals"] || 0}</TdTotals>
+						)}
+					</TrTotals>
+				)}
 			</TBody>
 		</StyledTable>
 	);

--- a/src/forms/FormFieldNumberTable/FormFieldNumberTableTypes.ts
+++ b/src/forms/FormFieldNumberTable/FormFieldNumberTableTypes.ts
@@ -9,7 +9,14 @@ export type NumberTableInputSettings = {
    * Label shown on the column that displays the totals.
    */
   columnTotalLabel?: string;
-
+  /**
+   * Shows or hides the column that cointains the totals sums.
+   */
+  displaySumColumn?: boolean;
+  /**
+   * Shows or hides the total sums for each row.
+   */
+  displaySumRow?: boolean;
   /**
    * Rows definition.
    */


### PR DESCRIPTION
## What's included?

- Adds displaySumColumn and displaySumRow optional props to know whether to render the totals or not
- Adds unit tests for this matter
- Updates related docs