### PR TITLE
Mos 1009 Overall disabled mechanic changes

### DIFF
--- a/automation_testing/tests/Components/form/playground.spec.ts
+++ b/automation_testing/tests/Components/form/playground.spec.ts
@@ -137,7 +137,7 @@ test.describe.parallel("Components - Form - Playground", () => {
 		}
 	});
 
-	test("Validate that when the disabled knob is active, the label of the field have the correct style.", async () => {
+	test("Validate that no error message are displayed when the knob disabled is active.", async () => {
 		await playgroundPage.visit(playgroundPage.page_path, [commonKnobs.knobDisabled + "true", commonKnobs.knobRequired + "true"]);
 		await playgroundPage.saveBtn.click();
 		await expect(playgroundPage.errorIcon).not.toBeVisible();

--- a/automation_testing/tests/Components/form/playground.spec.ts
+++ b/automation_testing/tests/Components/form/playground.spec.ts
@@ -141,5 +141,6 @@ test.describe.parallel("Components - Form - Playground", () => {
 		await playgroundPage.visit(playgroundPage.page_path, [commonKnobs.knobDisabled + "true", commonKnobs.knobRequired + "true"]);
 		await playgroundPage.saveBtn.click();
 		await expect(playgroundPage.errorIcon).not.toBeVisible();
+		await expect(playgroundPage.errorMessage).not.toBeVisible();
 	});
 });

--- a/src/components/Checkbox/Checkbox.styled.ts
+++ b/src/components/Checkbox/Checkbox.styled.ts
@@ -8,7 +8,7 @@ export const StyledFormControlLabel = styled(MUIFormControlLabel)`
     margin-left: 0px;
     margin-right: 0px;
     align-items: flex-start;
-    color: ${(pr) => pr.disabled ? theme.colors.labelDisabled : theme.newColors.grey4["100"]};
+    color: ${theme.newColors.grey4["100"]};
   }
 
   & > span.checked,

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -98,7 +98,6 @@ const Field = ({
 						|| (fieldDef?.instructionText && renderAsTooltip))
 					&&
 					<Label
-						disabled={fieldDef?.disabled}
 						required={fieldDef?.required}
 						htmlFor={fieldDef?.name}
 						maxCharacters={fieldDef?.inputSettings?.maxCharacters}

--- a/src/components/Field/Label.tsx
+++ b/src/components/Field/Label.tsx
@@ -19,8 +19,7 @@ const LabelWrapper = styled.div`
   .MuiInputLabel-root {
     font-family: inherit;
     font-size: 16px;
-    color:  ${pr =>
-		pr.disabled ? theme.colors.labelDisabled : theme.newColors.almostBlack["100"]};
+    color:  ${theme.newColors.almostBlack["100"]};
     word-wrap: break-word;
 
   :after {
@@ -58,7 +57,6 @@ const StyledInputLabel = styled(InputLabel)`
 
 interface LabelProps {
   className?: string;
-  disabled?: boolean;
   required?: boolean;
   htmlFor?: string;
   children?: ReactNode;
@@ -72,7 +70,6 @@ const Label = (props: LabelProps): ReactElement => {
 	const {
 		children,
 		className,
-		disabled,
 		required,
 		htmlFor,
 		value,
@@ -82,7 +79,7 @@ const Label = (props: LabelProps): ReactElement => {
 	} = props;
 
 	return (
-		<LabelWrapper className={className} disabled={disabled} required={required}>
+		<LabelWrapper className={className} required={required}>
 			<StyledInputTooltipWrapper>
 				<StyledInputLabel htmlFor={htmlFor}>{children}</StyledInputLabel>
 				{tooltip &&

--- a/src/components/Form/Col.tsx
+++ b/src/components/Form/Col.tsx
@@ -155,7 +155,7 @@ const Col = (props: ColPropsTypes) => {
 				const name = fieldProps.name;
 				const ref = fieldProps.ref;
 				const value = state?.data[fieldProps.name];
-				const error = (state?.errors[fieldProps.name] && !currentField.disabled) || "";
+				const error = (state?.errors[fieldProps.name] && !currentField.disabled) ? state.errors[fieldProps.name] : "";
 
 				let maxSize: Sizes | string;
 				const SizeSelected = Sizes[currentField?.size] ? Sizes[currentField?.size] : currentField?.size;

--- a/src/components/Form/Col.tsx
+++ b/src/components/Form/Col.tsx
@@ -155,7 +155,7 @@ const Col = (props: ColPropsTypes) => {
 				const name = fieldProps.name;
 				const ref = fieldProps.ref;
 				const value = state?.data[fieldProps.name];
-				const error = state?.errors[fieldProps.name] || "";
+				const error = (state?.errors[fieldProps.name] && !currentField.disabled) || "";
 
 				let maxSize: Sizes | string;
 				const SizeSelected = Sizes[currentField?.size] ? Sizes[currentField?.size] : currentField?.size;

--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -74,6 +74,20 @@ export const formActions = {
 	},
 	validateField({ name }: { name: string }) {
 		return async function (dispatch, getState, extraArgs): Promise<void> {
+			/**
+			 * We dispatch an undefined so that way, if by any reason
+			 * the field had an error message and then became disabled,
+			 * the error would get removed from the state.
+			 */
+			if (extraArgs?.fieldMap[name].disabled) {
+				await dispatch({
+					type: "FIELD_VALIDATE",
+					name,
+					value: undefined
+				});
+
+				return;
+			}
 			const requiredFlag = extraArgs?.fieldMap[name]?.required;
 			const validators = extraArgs?.fieldMap[name]?.validators ? extraArgs?.fieldMap[name]?.validators : [];
 

--- a/src/forms/FormFieldCheckbox/FormFieldCheckbox.styled.ts
+++ b/src/forms/FormFieldCheckbox/FormFieldCheckbox.styled.ts
@@ -14,19 +14,6 @@ export const StyledWrapper = styled.div`
   display: flex;
 `;
 
-export const LabelWrapper = styled.div`
-  .MuiInputLabel-root {
-    font-family: inherit;
-    font-size: 16px;
-    color: ${(pr) =>
-		pr.disabled ? theme.colors.labelDisabled : theme.newColors.almostBlack["100"]};
-  }
-
-  .MuiFormLabel-asterisk {
-    color: ${theme.newColors.darkRed["100"]};
-  }
-`;
-
 export const FieldWrapper = styled.div`
   font-family: ${theme.fontFamily};
   padding: 20px;
@@ -38,11 +25,6 @@ export const StyledCheckboxList = styled(CheckboxList)`
   &.MuiFormGroup-root {
     margin-left: -12px;
 		height: fit-content !important;
-  }
-
-  .MuiFormControlLabel-label {
-    color: ${theme.newColors.grey4["100"]};
-
   }
 `;
 

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -86,7 +86,6 @@ const colors = {
 	blueTeal : "#008DA8",
 	tealHover : "#005769",
 	tealOpacity : "rgb(0, 141, 168, 0.2)",
-	labelDisabled : "#838791",
 	lightBlue: "#edf5fe",
 	lightRed : "#B100000D",
 	red : "#b10000",


### PR DESCRIPTION
# What's included?
- Removed "disabled" from Label component so it always renders almostBlack
- Updated "validateField" action to return if the field is disabled
- Updated error in Col.tsx to not get passed to Fields when disabled
- Removed "labelDisabled" color from theme file