### PR TITLE
MOS-1020: Click targeting of dropdown input is off

### DIFF
--- a/automation_testing/tests/FormFields/formFieldDropdownSingleSelection.spec.ts
+++ b/automation_testing/tests/FormFields/formFieldDropdownSingleSelection.spec.ts
@@ -75,4 +75,11 @@ test.describe.parallel("FormFields - FormFieldDropdownSingleSelection - Kitchen 
 		expect(await formFieldDropdownSingleSelectionPage.
 			getSpecificBorderFromElement(formFieldDropdownSingleSelectionPage.page.locator("p", {hasText: "placeholder"}))).toContain(expectedColor);
 	});
+
+	test("Validate padding of the input fields.", async () => {
+		const inputCount = await formFieldDropdownSingleSelectionPage.inputLocator.count()
+		for (let i = 0; i < inputCount; i++) {
+			expect(await formFieldDropdownSingleSelectionPage.getSpecificPaddingFromElement(formFieldDropdownSingleSelectionPage.inputLocator.nth(i), "all")).toBe(theme.fieldSpecs.inputText.padding);
+		}
+	});
 });

--- a/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.styled.tsx
+++ b/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.styled.tsx
@@ -9,8 +9,9 @@ import Popper from "@mui/material/Popper";
 export const StyledAutocomplete = styled(MUIAutocomplete)`
   & .MuiFormControl-root .MuiInputBase-root {
     background-color: ${theme.newColors.grey1["100"]};
-	font-family: ${theme.fontFamily};
-	color: ${theme.newColors.almostBlack["100"]};
+    font-family: ${theme.fontFamily};
+    color: ${theme.newColors.almostBlack["100"]};
+
     &:hover {
       background-color: ${theme.newColors.grey2["100"]}
     }
@@ -31,6 +32,14 @@ export const StyledAutocomplete = styled(MUIAutocomplete)`
 
   .MuiAutocomplete-clearIndicator {
     margin-right: 20px;
+  }
+
+  .MuiInputBase-input {
+    padding: ${theme.fieldSpecs.inputText.padding} !important;
+  }
+
+  & .MuiAutocomplete-inputRoot[class*='MuiOutlinedInput-root'] {
+    padding: 0 !important;
   }
 
   &.MuiAutocomplete-hasPopupIcon.MuiAutocomplete-hasClearIcon .MuiAutocomplete-inputRoot[class*="MuiOutlinedInput-root"] {


### PR DESCRIPTION
## What's included?

Moves misplaced padding to fix the dropdown's click target to be the input element. 