### PR TITLE
MOS-1001: Form columns not constraining correctly

### DIFF
--- a/src/components/Field/Field.styled.ts
+++ b/src/components/Field/Field.styled.ts
@@ -2,12 +2,13 @@ import styled from "styled-components";
 import theme from "@root/theme";
 
 export const StyledFieldWrapper = styled.div`
-  font-family: ${theme.fontFamily};
-  padding: ${theme.fieldSpecs.inputSpacing.fieldPadding};
-  background-color: ${(pr) =>
+	font-family: ${theme.fontFamily};
+	padding: ${theme.fieldSpecs.inputSpacing.fieldPadding};
+	background-color: ${(pr) =>
 		pr.error ? theme.newColors.darkRed["5"] : "transparent"};
-  width: fit-content;
-  position: relative;
+	width: 100%;
+	max-width: fit-content;
+	position: relative;
 `;
 
 export const StyledFieldContainer = styled.div`

--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -227,7 +227,8 @@ export const Playground = (): ReactElement => {
 								value: "label_2"
 							},
 							{
-								label: "Label 3",
+								label:
+									"Very long label that should fit: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat",
 								value: "label_3"
 							}
 						],

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -188,7 +188,7 @@ const Form = (props: FormProps) => {
 			label: section.title,
 			name: idx.toString(),
 		}));
-	}, [sections]);
+	}, [sections, view]);
 
 	/**
 	 * Highlights and scrolls to the sections which link

--- a/src/components/Form/Section.tsx
+++ b/src/components/Form/Section.tsx
@@ -33,7 +33,6 @@ const StyledDescription = styled.p`
 `
 
 const StyledRows = styled.div`
-	display: grid;
 	margin: 0px;
 	padding: ${pr => pr.view === Views.mobile ? "0px 30px" : `${!pr.hasTitle ? "" : "16px 24px"}`};
 `;

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -34,10 +34,10 @@ const SideNav = (props: SideNavProps): ReactElement => {
 	return (
 		<SideNavStyle>
 			<SidebarWrap>
-				{Object.keys(items).map((key) => {
+				{Object.keys(items)?.map((key) => {
 					return (
 						<SectionWrapper data-testid="section-wrapper" key={key}>
-							{items[key].map((item, idx) => {
+							{items[key]?.map((item, idx) => {
 								const LinkIcon = item.icon;
 								const ActionIcon = item?.action?.icon;
 

--- a/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.test.tsx
+++ b/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.test.tsx
@@ -67,7 +67,7 @@ describe("FormFieldPhoneSelectionDropdown disabled state", () => {
 			/>
 		);
 
-		expect(getByText("Phone field disabled")).toBeDefined();
+		expect(getByText("Disabled field")).toBeDefined();
 	});
 
 	it('should display "Phone value:" text plus the value', () => {
@@ -83,7 +83,7 @@ describe("FormFieldPhoneSelectionDropdown disabled state", () => {
 			/>
 		);
 
-		expect(getByText("Phone value: 345")).toBeDefined();
+		expect(getByText("345")).toBeDefined();
 	});
 });
 


### PR DESCRIPTION
## What's included?

- Fixes Field wrapper to take the 100% width to not overlap fields located in the adjacent column
- Fixes PhoneDropdownSelection unit tests

## How to test it?

- Go to the Form Playground story and set at least 1 section using the respective knob
- A long string is being used on a chip to show that the Filed width is being respected

## Screenshot

![image](https://user-images.githubusercontent.com/87880265/229843016-3a7817b6-6ffc-4f39-bf66-9706fed39faf.png)
