### PR TITLE
MOS-1039: Title in PageHeader should have tooltip

### DIFF
--- a/automation_testing/tests/Components/SummaryPageTopComponent/summaryPageTopComponent.spec.ts
+++ b/automation_testing/tests/Components/SummaryPageTopComponent/summaryPageTopComponent.spec.ts
@@ -43,4 +43,10 @@ test.describe.parallel("Components - SummaryPageTopComponent - Kitchen Sink", ()
 	test("Validate the Summary Page Top Component title style.", async () => {
 		await summaryPage.validateTitleStylingOfLocator(summaryPage.title.last());
 	});
+
+	test("Validate that the title attribute is equal to the actual title.", async () => {
+		const title = await summaryPage.title.last().textContent();
+		const attribute = await summaryPage.title.last().getAttribute("title");
+		expect(attribute).toBe(title)
+	});
 });

--- a/src/forms/TopComponent/Utils/TitleWrapper.tsx
+++ b/src/forms/TopComponent/Utils/TitleWrapper.tsx
@@ -50,7 +50,7 @@ const TitleWrapper = (props: TitleWrapperProps): ReactElement => {
 					props.onBack &&
 						<Button className="back-button" color="black" variant="icon" mIcon={ChevronLeftIcon} onClick={props.onBack}/>
 				}
-				<H1>{title}</H1>
+				<H1 attrs={{ title }} >{title}</H1>
 			</StyledWrapper>
 			{description && <Description>{description}</Description>}
 		</>


### PR DESCRIPTION
## What's included?

- Adds the title HTML property to the TitleWrapper that is used as page, DV and Form header/title