### PR TITLE
MOS-1019: Updates types of the useForm hook

### DIFF
--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -1,21 +1,34 @@
 import { MosaicObject } from "@root/types";
-import { useRef, useCallback, useReducer } from "react";
+import { useRef, useCallback, useReducer, Dispatch } from "react";
 import { SectionDef } from "./FormTypes";
 
 type State = {
-	data: MosaicObject;
-	errors: any;
-	validating: any;
+	data: any;
+	errors: { [key: string]: string };
+	validating: MosaicObject;
 	custom: unknown;
 	validForm: boolean;
 	disabled: boolean;
 	touched: { [key: string]: boolean };
 }
 
+type ActionTypes =
+	| "FIELD_ON_CHANGE"
+	| "FIELD_TOUCHED"
+	| "FIELD_VALIDATE"
+	| "FORM_START_DISABLE"
+	| "FORM_END_DISABLE"
+	| "FORM_VALIDATE"
+	| "FORM_START_DISABLE"
+	| "FORM_END_DISABLE"
+	| "FORM_VALIDATE"
+	| "FORM_RESET"
+	| "PROPERTY_RESET";
+
 type Action = {
-	type: string;
+	type: ActionTypes;
 	value: any;
-	name: string;
+	name?: string;
 }
 
 export function coreReducer(state: State, action: Action): State {
@@ -79,10 +92,11 @@ export function coreReducer(state: State, action: Action): State {
 	}
 }
 
+type CustomDispatch = (action: any) => any | Dispatch<Action>;
 
 type UseFormReturn = {
-	state: any;
-	dispatch: any;
+	state: State;
+	dispatch:  CustomDispatch;
 }
 
 export function useForm(): UseFormReturn {
@@ -198,7 +212,7 @@ export function useThunkReducer(reducer, initialState, extraArgs) {
 	);
 	const [state, dispatch] = useReducer(enhancedReducer, initialState);
 
-	const customDispatch = useCallback(
+	const customDispatch: CustomDispatch = useCallback(
 		(action) => {
 			if (typeof action === "function") {
 				return action(customDispatch, getState, extraArgs);

--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -3,13 +3,13 @@ import { useRef, useCallback, useReducer, Dispatch } from "react";
 import { SectionDef } from "./FormTypes";
 
 type State = {
-	data: any;
-	errors: { [key: string]: string };
+	data: MosaicObject<any>;
+	errors: MosaicObject<string>;
 	validating: MosaicObject;
 	custom: unknown;
 	validForm: boolean;
 	disabled: boolean;
-	touched: { [key: string]: boolean };
+	touched: MosaicObject<boolean>;
 }
 
 type ActionTypes =

--- a/src/forms/FormFieldMapCoordinates/MapCoordinatesDrawer/MapCoordinatesDrawer.tsx
+++ b/src/forms/FormFieldMapCoordinates/MapCoordinatesDrawer/MapCoordinatesDrawer.tsx
@@ -329,7 +329,7 @@ const MapCoordinatesDrawer = (props: MapCoordinatesDrawerProps): ReactElement =>
 			onClick: onSubmit,
 			color: "yellow",
 			variant: "contained",
-			disabled: !state.data.lat || !state.data.lng || state.errors.lng || state.errors.lat
+			disabled: (!state.data.lat || !state.data.lng || state.errors.lng || state.errors.lat) as boolean
 		}
 	];
 

--- a/src/forms/FormFieldTable/TableTypes.ts
+++ b/src/forms/FormFieldTable/TableTypes.ts
@@ -54,7 +54,7 @@ export type TableInputSettings = {
 }
 
 export type TableDataState = {
-  table: TableRow[];
+  [key: string]: TableRow[];
 }
 
 export type UseTableReturnType = {

--- a/src/forms/FormFieldTable/tableUtils.ts
+++ b/src/forms/FormFieldTable/tableUtils.ts
@@ -76,12 +76,11 @@ export const deleteTableRow = (): void => {
  * and the edit action.
  */
 export const useTable = (
-	dataState: TableDataState[],
+	dataState: TableDataState,
 	name: string,
 	dispatch: (action: unknown) => void
 ): UseTableReturnType => {
 	const addTableRow = (): void => {
-
 		const tableDataLength = dataState[name] ? dataState[name].length : 0;
 
 		if (tableDataLength === 0) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,8 +7,8 @@ export interface MosaicLabelValue {
 }
 
 /** Javascript object than can have any keys and any data */
-export interface MosaicObject {
-	[key: string]: unknown
+export interface MosaicObject<T = unknown> {
+	[key: string]: T
 }
 
 export interface MosaicCallback {


### PR DESCRIPTION
## What's included?

Updates types of the `useForm` hook

## Notes

When trying to define `MosaicObject` as a type for `state.data` the following typescript errors happened, among many others.

With a union type of `string | Element`
![image](https://user-images.githubusercontent.com/87880265/232914511-5285804e-e64d-45b8-a061-ac6eeb9012d1.png)

With an array
![image](https://user-images.githubusercontent.com/87880265/232915745-2967cf2f-2413-434f-a85f-2afd05ddaaff.png)

And this is because the `MosaicObject` type definition is `{ [key: string]: unknown }`. The thing is that when using `unknown `, we must perform additional type checks or assertions to ensure that the value has the expected type before using it. That's why the type of `data` remained as `any`.
