### PR TITLE
MOS-1024: Add show capability to content buttons

### DIFF
--- a/src/components/Content/Content.stories.tsx
+++ b/src/components/Content/Content.stories.tsx
@@ -104,7 +104,8 @@ export const Playground = (): ReactElement => {
 	const singleColumn = boolean("Single column", false);
 	const showChips = boolean("Show chips", true);
 	const useSections = boolean("Use sections", true);
-	const useButtons = boolean("Use buttons", true);
+	const showEditBtn = boolean("Show edit button", true);
+	const showDetailsBtn = boolean("Show details button", true);
 	const amountContent = select(
 		"Amount of contents",
 		[1, 2],
@@ -126,6 +127,7 @@ export const Playground = (): ReactElement => {
 			mIcon: EditIcon,
 			color: "gray",
 			variant: "icon",
+			show: showEditBtn,
 			onClick: function () {
 				alert("Edit button clicked");
 			}
@@ -136,6 +138,7 @@ export const Playground = (): ReactElement => {
 			variant: "text",
 			label: showMore ? "Less Details" : "More Details",
 			onClick: showDetails,
+			show: [showDetailsBtn],
 		},
 	]
 
@@ -197,7 +200,7 @@ export const Playground = (): ReactElement => {
 				data={data}
 				fields={fields}
 				sections={sectionsToDisplay}
-				buttons={useButtons && buttonsToDisplay}
+				buttons={buttonsToDisplay}
 				variant={variant}
 			/>
 			{amountContent === 2 &&
@@ -206,7 +209,7 @@ export const Playground = (): ReactElement => {
 					data={data}
 					fields={fields}
 					sections={singleColumn ? oneColumnSecondContent : multipleColumnSecondContent}
-					buttons={useButtons && buttons.slice(0, 1)}
+					buttons={buttons.slice(0, 1)}
 					variant={variant}
 				/>
 			}

--- a/src/components/Content/Content.test.tsx
+++ b/src/components/Content/Content.test.tsx
@@ -5,7 +5,7 @@ import {
 	fireEvent,
 } from "@testing-library/react";
 import * as React from "react";
-import Content from "./Content";
+import Content, { showContent } from "./Content";
 import { ContentField } from "./ContentTypes";
 import {
 	transform_boolean,
@@ -110,6 +110,14 @@ const buttons: ButtonProps[] = [
 		variant: "icon",
 		onClick: onClickAdd
 	},
+	{
+		name: "hidden",
+		label: "Hidden button",
+		color: "teal",
+		variant: "text",
+		onClick: onClickAdd,
+		show: false
+	},
 ]
 
 describe("Content component", () => {
@@ -153,6 +161,12 @@ describe("Content component", () => {
 		expect(onClickEdit).toHaveBeenCalled();
 		expect(onClickAdd).toHaveBeenCalled();
 	});
+
+	it("should not show the buttons that its prop show is set as false", () => {
+		const hiddenButton = screen.queryByText("Hidden button");
+
+		expect(hiddenButton).not.toBeInTheDocument();
+	});
 });
 
 describe("Content componenent with no sections", () => {
@@ -177,5 +191,23 @@ describe("Content componenent with no sections", () => {
 		expect(date).toBeInTheDocument();
 		expect(colorPicker).toBeInTheDocument();
 		expect(header).toBeInTheDocument();
+	});
+});
+
+describe("showContent helper function", () => {
+	it("should return the value of the show paramenter when is defined as a boolean", () => {
+		expect(showContent(false)).toBe(false);
+	});
+
+	it("should return true since all its show values are truthy", () => {
+		const show = [true, () => true];
+
+		expect(showContent(show)).toBe(true);
+	});
+
+	it("should return false since one of the show values is false", () => {
+		const show = [true, () => true, () => false];
+
+		expect(showContent(show)).toBe(false);
 	});
 });

--- a/src/components/Content/Content.tsx
+++ b/src/components/Content/Content.tsx
@@ -25,7 +25,7 @@ import { ActionAdditional } from "../DataView";
  * @param show is used to evaluate whether a field should be displayed
  * @returns boolean flag comming from the  validation of the show paramater.
  */
-const showContent = (show: ActionAdditional["show"]) => {
+export const showContent = (show: ActionAdditional["show"]) => {
 	const conditions = isArray(show) ? show : [show];
 
 	const isValid = conditions.every((show) => {
@@ -74,7 +74,7 @@ const Content = (props: ContentProps): ReactElement => {
 			);
 		}
 
-		if (currentField?.show && !showContent(currentField?.show)) {
+		if (currentField?.show !== undefined && !showContent(currentField?.show)) {
 			return;
 		}
 
@@ -144,12 +144,17 @@ const Content = (props: ContentProps): ReactElement => {
 		<MainWrapper className={cardVariant ? "card-wrapper" : "content-wrapper"}>
 			<TitleWrapper className={cardVariant ? "title-bar" : ""}>
 				<Title>{title}</Title>
-				{buttons &&
-					<ButtonsWrapper className={cardVariant ? "card-buttons" : "standard-buttons"}>
-						{buttons?.map((button, idx) => (
-							<Button key={`${button.label}-${idx}`} {...button} />
-						))}
-					</ButtonsWrapper>}
+				{buttons && (
+					<ButtonsWrapper
+						className={cardVariant ? "card-buttons" : "standard-buttons"}
+					>
+						{buttons?.map((button, idx) =>
+							button.show !== undefined ? (
+								showContent(button.show) && <Button key={`${button.label}-${idx}`} {...button} />
+							) : <Button key={`${button.label}-${idx}`} {...button} />
+						)}
+					</ButtonsWrapper>
+				)}
 			</TitleWrapper>
 			<div className={cardVariant ? "card-content" : ""}>
 				{data && sectionsToRender.map((section, idx) => (


### PR DESCRIPTION
## What's included?

- Adds show capability to the buttons passed to the Content component
- Adds unit test for the `showContent` function
- Fixes issue with the `showContent` that was not being applied when a single `false` value was passed, now is explicitly only checking for `undefined` values