### PR TITLE
MOS-1021: AdvancedSelection getOptions is not properly typed

### DIFF
--- a/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectTypes.ts
+++ b/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectTypes.ts
@@ -1,5 +1,6 @@
 import { AdvancedSelectionInputSettings } from "@root/forms/FormFieldAdvancedSelection";
 import { DataViewFilterProps } from "../DataView/DataViewTypes";
+import { MosaicLabelValue } from "@root/types";
 
 export type MultiSelectComparison = "in" | "not_in" | "all" | "exists" | "not_exists";
 
@@ -7,11 +8,23 @@ interface DataViewFilterMultiselectData {
 	value?: any;
 	comparison?: MultiSelectComparison | "";
 }
+export interface GetOptionsArgs {
+	limit?: number
+	skip?: number
+	keyword?: string
+}
+
+export interface GetOptionsReturn {
+	docs: MosaicLabelValue[]
+	hasMore?: boolean
+}
+
+export type GetOptions = (val: GetOptionsArgs) => Promise<GetOptionsReturn> | GetOptionsReturn;
 
 export interface DataViewFilterMultiselectProps extends DataViewFilterProps {
 	data: DataViewFilterMultiselectData;
 	args: {
-		getOptions(val: any): Promise<any> | any;
+		getOptions: GetOptions
 		getSelected(val: any): Promise<any> | any;
 		comparisons?:  MultiSelectComparison[];
 		placeholder?: string;

--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -374,7 +374,7 @@ export const Playground = (): ReactElement => {
 					required,
 					inputSettings: {
 						options: additionalOptions,
-						createNewOption
+						createNewOption,
 					},
 					defaultValue: !showDefaultValues ? undefined : [
 						{

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
@@ -184,7 +184,6 @@ export const KitchenSink = (): ReactElement => {
 						createNewOption
 					}
 				},
-
 				{
 					name: "selectLimitOfOptions",
 					label: "Advanced selection with selectLimit prop (Max 2 options)",

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ReactElement, useMemo } from "react";
-import { boolean, text, withKnobs, select } from "@storybook/addon-knobs";
+import { boolean, text, withKnobs, select, number } from "@storybook/addon-knobs";
 import { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
 import { renderButtons } from "@root/utils/storyUtils";
@@ -29,7 +29,7 @@ export const Playground = (): ReactElement => {
 		["Local", "DB"],
 		"Local"
 	);
-	const getOptionsLimit = text("Get options limit", "5");
+	const getOptionsLimit = number("Get options limit", 5);
 	const createNewOptionsKnob = boolean("Create new option", true);
 	const selectLimit = text("Select limit", "");
 

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelectionDrawer.tsx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelectionDrawer.tsx
@@ -83,7 +83,7 @@ const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactE
 		let newOptions: MosaicLabelValue[] = localOptions?.options || [];
 		const regSearchKeyword = new RegExp(keyword, "i");
 		if (keyword !== undefined && localOptions.options !== undefined) {
-			newOptions = localOptions.options.filter(option => {
+			newOptions = localOptions?.options.filter(option => {
 				return regSearchKeyword.exec(option.label)
 			})
 		}
@@ -104,11 +104,11 @@ const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactE
 				value={value && value.map(v => v.value)}
 				comparison={""}
 				selected={value}
-				getOptions={externalOptions.getOptions ? externalOptions.getOptions : getSyncOptions}
+				getOptions={externalOptions?.getOptions !== undefined ? externalOptions.getOptions : getSyncOptions}
 				isOpen={true}
 				onApply={onSubmit}
 				placeholder={"Search..."}
-				limit={externalOptions.getOptionsLimit}
+				limit={externalOptions?.getOptionsLimit}
 				selectLimit={fieldDef.inputSettings.selectLimit}
 				onChange={(value) => setSelectedOptions(value)}
 				hideButtons={true}

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelectionDrawer.tsx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelectionDrawer.tsx
@@ -7,11 +7,12 @@ import {
 	useEffect,
 	useState
 } from "react";
-import { AdvanceSelectionDrawerPropTypes } from ".";
+import { AdvancedSelectionExternalOptions, AdvancedSelectionLocalOptions, AdvanceSelectionDrawerPropTypes } from ".";
 import { FormDrawerWrapper } from "../shared/styledComponents";
-import { DataViewFilterMultiselectDropdownContent } from "@root/components/DataViewFilterMultiselect";
+import { DataViewFilterMultiselectDropdownContent, GetOptions } from "@root/components/DataViewFilterMultiselect";
 import PageHeader from "@root/components/PageHeader";
 import Dialog from "@root/components/Dialog";
+import { MosaicLabelValue } from "@root/types";
 
 const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactElement => {
 	const {
@@ -24,7 +25,16 @@ const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactE
 		handleDialogClose,
 	} = props;
 
-	const { options, getOptions, createNewOption } = fieldDef?.inputSettings || {};
+	let externalOptions: AdvancedSelectionExternalOptions | undefined;
+	let localOptions: AdvancedSelectionLocalOptions | undefined;
+
+	if ("getOptions" in fieldDef.inputSettings) {
+		externalOptions = fieldDef.inputSettings;
+	}
+
+	if ("options" in fieldDef.inputSettings) {
+		localOptions = fieldDef.inputSettings;
+	}
 
 	const [selectedOptions, setSelectedOptions] = useState(value?.length > 0 ? value : []);
 
@@ -69,11 +79,11 @@ const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactE
 		}
 	];
 
-	const getSyncOptions = ({keyword}) => {
-		let newOptions = options || [];
+	const getSyncOptions: GetOptions = ({ keyword }) => {
+		let newOptions: MosaicLabelValue[] = localOptions?.options || [];
 		const regSearchKeyword = new RegExp(keyword, "i");
-		if (keyword !== undefined && options !== undefined) {
-			newOptions = options.filter(option => {
+		if (keyword !== undefined && localOptions.options !== undefined) {
+			newOptions = localOptions.options.filter(option => {
 				return regSearchKeyword.exec(option.label)
 			})
 		}
@@ -94,15 +104,15 @@ const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactE
 				value={value && value.map(v => v.value)}
 				comparison={""}
 				selected={value}
-				getOptions={getOptions ? getOptions : getSyncOptions}
+				getOptions={externalOptions.getOptions ? externalOptions.getOptions : getSyncOptions}
 				isOpen={true}
 				onApply={onSubmit}
 				placeholder={"Search..."}
-				limit={fieldDef?.inputSettings?.getOptionsLimit}
-				selectLimit={fieldDef?.inputSettings?.selectLimit}
+				limit={externalOptions.getOptionsLimit}
+				selectLimit={fieldDef.inputSettings.selectLimit}
 				onChange={(value) => setSelectedOptions(value)}
 				hideButtons={true}
-				createNewOption={createNewOption}
+				createNewOption={fieldDef.inputSettings.createNewOption}
 			/>
 			<Dialog
 				buttons={dialogButtons}

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelectionTypes.tsx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelectionTypes.tsx
@@ -1,3 +1,4 @@
+import { GetOptions } from "@root/components/DataViewFilterMultiselect";
 import { FieldDefBase } from "@root/components/Field";
 import { MosaicLabelValue } from "@root/types";
 
@@ -10,27 +11,19 @@ type AdvancedSelectionBasic = {
 	selectLimit?: number;
 }
 
-type AdvancedSelectionLocalOptions = {
+export type AdvancedSelectionLocalOptions = {
 	/**
 	* Options to be display within the Modal.
 	*/
 	options: MosaicLabelValue[];
 } & AdvancedSelectionBasic;
 
-type AdvancedSelectionExternalOptions = {
+export type AdvancedSelectionExternalOptions = {
 	/**
 	 * Used to get the selected options on the parent component.
 	 */
-	getOptions: ({
-		filter,
-		limit,
-		offset,
-	}: {
-		filter?: string;
-		limit?: number;
-		offset?: number;
-	}) => Promise<MosaicLabelValue[]>;
-	getOptionsLimit?: number | string;
+	getOptions: GetOptions
+	getOptionsLimit?: number;
 } & AdvancedSelectionBasic;
 
 export type AdvancedSelectionInputSettings = AdvancedSelectionLocalOptions | AdvancedSelectionExternalOptions;
@@ -49,7 +42,7 @@ export interface ChipListPropsTypes {
 
 export interface AdvanceSelectionDrawerPropTypes {
 	value: MosaicLabelValue[];
-	fieldDef: any;
+	fieldDef: FieldDefBase<"advancedSelection", AdvancedSelectionInputSettings, AdvancedSelectionData>;
 	onChange: (e: MosaicLabelValue[]) => Promise<void>;
 	isModalOpen: boolean;
 	isMobileView: boolean;


### PR DESCRIPTION
## What's included?

- Exports GetOptions type that is used by the AdvancedSelection and the DataViewFilterMultiSelect
- Adds type guards to AdvancedSelection to differentiate between local and external options.