### PR TITLE
MOS-1044 DataView activeFilters displaying in the wrong order

### DIFF
--- a/automation_testing/pages/Components/DataView/DataViewPage.ts
+++ b/automation_testing/pages/Components/DataView/DataViewPage.ts
@@ -250,4 +250,13 @@ export class DataviewPage extends BasePage {
 		}
 		return titleLocators;
 	}
+
+	async getAllFiltersSelected(): Promise<string[]> {
+		const filters = [];
+		for (let i = 1; i < await this.filterRowBtn.count() - 1; i++) {
+			this.filterRowBtn.nth(i).textContent();
+			filters.push(await this.getOnlyStringWithLetters(await this.filterRowBtn.nth(i).textContent()));
+		}
+		return filters;
+	}
 }

--- a/automation_testing/tests/Components/dataview/DataView.spec.ts
+++ b/automation_testing/tests/Components/dataview/DataView.spec.ts
@@ -180,4 +180,14 @@ test.describe.parallel("Components - Data View - Playground", () => {
 			expect(await dataviewPage.getColorFromElement(titles[i])).toBe(theme.newColors.almostBlack["100"]);
 		}
 	});
+
+	test("Validate that the Preload Active Filters knob shows preload filters.", async () => {
+		await dataviewPage.visit(dataviewPage.page_path, [knob.knobPreloadActiveFilters + true]);
+		await dataviewPage.waitForDataviewIsVisible();
+		const expectedFiltersOrder = [ "Updated", "Title", "Keyword" ]
+		const actualFilters = await dataviewPage.getAllFiltersSelected();
+		for (let i = 0; i < actualFilters.length; i++) {
+			expect(actualFilters[i]).toBe(expectedFiltersOrder[i])
+		}
+	});
 });

--- a/automation_testing/utils/data/knobs.ts
+++ b/automation_testing/utils/data/knobs.ts
@@ -35,7 +35,8 @@ export const dataviewKnobs = {
 	knobBulkActions: "knob-bulkActions=",
 	knobPrimaryActions: "knob-primaryActions=",
 	knobAdditionalActions: "knob-additionalActions=",
-	knobComparison: "knob-Comparison="
+	knobComparison: "knob-Comparison=",
+	knobPreloadActiveFilters: "knob-Preload%20active%20filters="
 }
 
 export const buttonKnobs = {

--- a/src/components/DataView/DataView.stories.tsx
+++ b/src/components/DataView/DataView.stories.tsx
@@ -435,7 +435,8 @@ export const Playground = (): ReactElement => {
 		skip: 0,
 		loading: false,
 		savedView: defaultView,
-		...defaultView.state
+		...defaultView.state,
+		activeFilters: preloadedActiveFilters ? ["updated", "title", "keyword"] : []
 	});
 
 	useEffect(() => {

--- a/src/components/DataView/DataView.stories.tsx
+++ b/src/components/DataView/DataView.stories.tsx
@@ -419,6 +419,7 @@ export const Playground = (): ReactElement => {
 	const displayGrid = boolean("displayGrid", true);
 	const draggableRows = boolean("draggableRows", true);
 	const showCheckboxes = boolean("Show Checkboxes", true);
+	const preloadedActiveFilters = boolean("Preload active filters", false);
 	const defaultView: DataViewProps["savedView"] = {
 		...rootDefaultView,
 		state: {
@@ -436,6 +437,11 @@ export const Playground = (): ReactElement => {
 		savedView: defaultView,
 		...defaultView.state
 	});
+
+	useEffect(() => {
+		if (preloadedActiveFilters && state.activeFilters.length === 0)
+			setState(prev => ({...prev, activeFilters: ["updated", "title", "keyword"]}));
+	}, [preloadedActiveFilters, state.activeFilters]);
 
 	const [checkedState, setCheckedState] = useState({
 		checked: [],

--- a/src/components/DataView/DataViewFilters/DataViewFilters.test.tsx
+++ b/src/components/DataView/DataViewFilters/DataViewFilters.test.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import DataViewFilters from "./DataViewFilters";
+import DataViewFilterText from "@root/components/DataViewFilterText";
+import DataViewFilterMultiselect from "@root/components/DataViewFilterMultiselect";
+import DataViewFilterDate from "@root/components/DataViewFilterDate";
+import DataViewFilterSingleSelect from "@root/components/DataViewFilterSingleSelect";
+
+afterEach(cleanup);
+
+const filters = [
+	{
+		name: "keyword",
+		label: "Keyword",
+		component: DataViewFilterText,
+		column: "title",
+		onChange: () => undefined,
+	},
+	{
+		name: "categories",
+		label: "Categories",
+		component: DataViewFilterMultiselect,
+		args: {},
+		column: "categories_ids",
+		onChange: () => undefined,
+	},
+	{
+		name: "single_select_category",
+		label: "Single Select Category",
+		component: DataViewFilterSingleSelect,
+		args: {},
+		column: "categories_ids",
+		onChange: () => undefined,
+	},
+	{
+		name: "categories_with_comparisons",
+		label: "Categories with Comparisons",
+		component: DataViewFilterMultiselect,
+		args: {
+			comparisons: ["in", "not_in", "all", "exists", "not_exists"]
+		},
+		column: "categories_ids",
+		onChange: () => undefined,
+	},
+	{
+		name: "title",
+		label: "Title",
+		component: DataViewFilterText,
+		onChange: () => undefined,
+	},
+	{
+		name: "created",
+		label: "Created",
+		component: DataViewFilterDate,
+		onChange: () => undefined,
+	},
+	{
+		name: "updated",
+		label: "Updated",
+		component: DataViewFilterDate,
+		onChange: () => undefined,
+	},
+	{
+		name: "title_with_comparisons",
+		label: "Title with Comparisons",
+		component: DataViewFilterText,
+		column: "title",
+		args: {
+			comparisons: ["equals", "not_equals", "contains", "not_contains", "exists", "not_exists"]
+		},
+		onChange: () => undefined,
+	}
+];
+
+const activeFilters = ["updated", "title", "keyword"];
+
+describe("DataViewFilters", () => {
+	it("Should display the active filters in the order passed by the developer", async () => {
+		render(
+			<DataViewFilters
+				activeFilters={activeFilters}
+				filters={filters}
+				filter={{}}
+				onActiveFiltersChange={jest.fn}
+			/>
+		);
+
+		const buttons = await screen.findAllByRole("button");
+		const updatedIndex = buttons.findIndex(button => button.textContent === "Updated");
+		const titleIndex = buttons.findIndex(button => button.textContent === "Title");
+		const keywordIndex = buttons.findIndex(button => button.textContent === "Keyword");
+
+		const realOrder = [];
+		for (let i = 0; i < buttons.length; i++) {
+			if (i === updatedIndex)
+				realOrder.push(buttons[updatedIndex].textContent.toLowerCase());
+			if (i === titleIndex)
+				realOrder.push(buttons[titleIndex].textContent.toLowerCase());
+			if (i === keywordIndex)
+				realOrder.push(buttons[keywordIndex].textContent.toLowerCase());
+		}
+
+		expect(JSON.stringify(realOrder)).toEqual(JSON.stringify(activeFilters));
+	});
+});

--- a/src/components/DataView/DataViewFilters/DataViewFilters.test.tsx
+++ b/src/components/DataView/DataViewFilters/DataViewFilters.test.tsx
@@ -100,6 +100,6 @@ describe("DataViewFilters", () => {
 				realOrder.push(buttons[keywordIndex].textContent.toLowerCase());
 		}
 
-		expect(JSON.stringify(realOrder)).toEqual(JSON.stringify(activeFilters));
+		expect(realOrder).toEqual(activeFilters);
 	});
 });

--- a/src/components/DataView/DataViewFilters/DataViewFilters.tsx
+++ b/src/components/DataView/DataViewFilters/DataViewFilters.tsx
@@ -28,7 +28,7 @@ function DataViewFilters(props: DataViewFiltersProps) {
 
 	const activeFilters = props.activeFilters || [];
 
-	const active = props.filters.filter(val => activeFilters.includes(val.name));
+	const active = activeFilters.map(activeFilter => props.filters.find(filter => filter.name === activeFilter));
 	const options = props.filters
 		.map((val) => ({ label: val.label, value: val.name }))
 		.sort((a, b) => a.label.localeCompare(b.label));


### PR DESCRIPTION
# What's included?
- Updated logic for rendering activeFilters in DataViewFilters.tsx
- Added knob for showing active filters loaded on a different order than the regular filters array.