### PR TITLE
MOS-1046: Form field definitions exported to be cosumed

### DIFF
--- a/src/components/Form/FormTypes.tsx
+++ b/src/components/Form/FormTypes.tsx
@@ -26,3 +26,5 @@ export interface FormProps {
 	tooltipInfo?: string;
 	showActive?: boolean;
 }
+
+export { FieldDef };


### PR DESCRIPTION
## What's included?

Form field type definition exported to be consumed anywhere the mosaic package is used.