### PR TITLE
MOS-1061 MOSAIC BUG for version 22 - Undefined buttons in Content component causes TypeError

### DIFF
--- a/automation_testing/tests/Components/Content/Content.spec.ts
+++ b/automation_testing/tests/Components/Content/Content.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, Page } from "@playwright/test";
 import { ContentPage } from "../../../pages/Components/Content/ContentPage";
 import theme from "../../../../src/theme";
-import { buttonKnobs as knob, contentKnobs } from "../../../utils/data/knobs";
+import { buttonKnobs as knob, contentKnobs, pageHeaderKnobs } from "../../../utils/data/knobs";
 
 test.describe.parallel("Components - Content - Playground", () => {
 	let page: Page;
@@ -65,6 +65,12 @@ test.describe.parallel("Components - Content - Playground", () => {
 		await expect(contentPage.editButton).not.toBeVisible();
 
 		await contentPage.visit(contentPage.page_path, [contentKnobs.knobShowDetailsButton + "false"]);
+		await expect(contentPage.detailsButton).not.toBeVisible();
+	});
+
+	test("Validate that when the buttons knob is undefined, the additional buttons are not displayed.", async () => {
+		await contentPage.visit(contentPage.page_path, [pageHeaderKnobs.knobButtons + "undefined"]);
+		await expect(contentPage.editButton).not.toBeVisible();
 		await expect(contentPage.detailsButton).not.toBeVisible();
 	});
 });

--- a/automation_testing/tests/Components/Content/Content.spec.ts
+++ b/automation_testing/tests/Components/Content/Content.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, Page } from "@playwright/test";
 import { ContentPage } from "../../../pages/Components/Content/ContentPage";
 import theme from "../../../../src/theme";
-import { buttonKnobs as knob, contentKnobs, pageHeaderKnobs } from "../../../utils/data/knobs";
+import { buttonKnobs as knob, pageHeaderKnobs } from "../../../utils/data/knobs";
 
 test.describe.parallel("Components - Content - Playground", () => {
 	let page: Page;
@@ -61,10 +61,8 @@ test.describe.parallel("Components - Content - Playground", () => {
 	});
 
 	test("Validate the show capability to content buttons.", async () => {
-		await contentPage.visit(contentPage.page_path, [contentKnobs.knobShowEditButton + "false"]);
+		await contentPage.visit(contentPage.page_path, [pageHeaderKnobs.knobButtons + 0]);
 		await expect(contentPage.editButton).not.toBeVisible();
-
-		await contentPage.visit(contentPage.page_path, [contentKnobs.knobShowDetailsButton + "false"]);
 		await expect(contentPage.detailsButton).not.toBeVisible();
 	});
 

--- a/automation_testing/utils/data/knobs.ts
+++ b/automation_testing/utils/data/knobs.ts
@@ -67,8 +67,3 @@ export const formFieldNumberTableKnobs = {
 	knobDisplayColumnsSum: "knob-Display%20columns%20sums=",
 	knobNumberFormatOptions: "knob-Number%20format%20options="
 }
-
-export const contentKnobs = {
-	knobShowEditButton: "knob-Show%20edit%20button=",
-	knobShowDetailsButton: "knob-Show%20details%20button="
-}

--- a/src/components/Content/Content.stories.tsx
+++ b/src/components/Content/Content.stories.tsx
@@ -103,9 +103,8 @@ export const Playground = (): ReactElement => {
 	const variant = select("Variant", ["standard", "card"], "standard")
 	const singleColumn = boolean("Single column", false);
 	const showChips = boolean("Show chips", true);
+	const showButtons = select("Buttons", ["1", "2", "0", "undefined"], "2");
 	const useSections = boolean("Use sections", true);
-	const showEditBtn = boolean("Show edit button", true);
-	const showDetailsBtn = boolean("Show details button", true);
 	const amountContent = select(
 		"Amount of contents",
 		[1, 2],
@@ -127,7 +126,7 @@ export const Playground = (): ReactElement => {
 			mIcon: EditIcon,
 			color: "gray",
 			variant: "icon",
-			show: showEditBtn,
+			show: showButtons !== "undefined" && Number(showButtons) >= 1,
 			onClick: function () {
 				alert("Edit button clicked");
 			}
@@ -138,7 +137,7 @@ export const Playground = (): ReactElement => {
 			variant: "text",
 			label: showMore ? "Less Details" : "More Details",
 			onClick: showDetails,
-			show: [showDetailsBtn],
+			show: [showButtons !== "undefined" && Number(showButtons) >= 2],
 		},
 	]
 
@@ -200,7 +199,7 @@ export const Playground = (): ReactElement => {
 				data={data}
 				fields={fields}
 				sections={sectionsToDisplay}
-				buttons={buttonsToDisplay}
+				buttons={showButtons === "undefined" ? undefined : buttonsToDisplay}
 				variant={variant}
 			/>
 			{amountContent === 2 &&

--- a/src/components/Content/Content.test.tsx
+++ b/src/components/Content/Content.test.tsx
@@ -194,6 +194,31 @@ describe("Content componenent with no sections", () => {
 	});
 });
 
+describe("Content componenent with no buttons", () => {
+	it("should display the content when buttons are not defined", async () => {
+		render(
+			<Content
+				title="Main Section"
+				data={data}
+				fields={fields}
+				buttons={undefined}
+			/>
+		);
+
+		const chips = screen.getAllByTestId("chip-testid");
+		const thumbnail = screen.getByRole("img");
+		const date = screen.getByText("12/17/1995");
+		const colorPicker = screen.getByText("#a8001791");
+		const header = screen.getByText("H1 Header");
+
+		expect(thumbnail).toBeInTheDocument();
+		expect(chips).toHaveLength(4);
+		expect(date).toBeInTheDocument();
+		expect(colorPicker).toBeInTheDocument();
+		expect(header).toBeInTheDocument();
+	});
+});
+
 describe("showContent helper function", () => {
 	it("should return the value of the show paramenter when is defined as a boolean", () => {
 		expect(showContent(false)).toBe(false);

--- a/src/components/Content/Content.tsx
+++ b/src/components/Content/Content.tsx
@@ -152,7 +152,7 @@ const Content = (props: ContentProps): ReactElement => {
 		<MainWrapper className={cardVariant ? "card-wrapper" : "content-wrapper"}>
 			<TitleWrapper className={cardVariant ? "title-bar" : ""}>
 				<Title>{title}</Title>
-				{buttonToRender.length > 0 && (
+				{buttonToRender && (buttonToRender.length > 0) && (
 					<ButtonsWrapper
 						className={cardVariant ? "card-buttons" : "standard-buttons"}
 					>


### PR DESCRIPTION
# What's included?
- Updated Content's playground story to include "undefined" as a value for buttons.
- Updated unit tests to account for undefined scenario.
- Fixed conditional that throwed an error when no buttons get passed.