### PR TITLE
Mos 1051 - FormFieldDate inconsistency when value has time

### DIFF
--- a/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
@@ -32,6 +32,11 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		}
 	}, [value, dateInput, timeInput]);
 
+	useEffect(() => {
+		if (!fieldDef.inputSettings?.showTime) {
+			setTimeInput(null);
+		}
+	}, [fieldDef.inputSettings?.showTime]);
 
 	const formatDate = (dateValue: Date) => {
 		const stringDate = dateValue.toISOString();
@@ -51,10 +56,13 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		let minutes = 0;
 		let seconds = 0;
 
-		//THIS LOGIC SHOULD ALSO BE UPDATED, I'M GUESSING IT COULD GO AFTER NEWVALUE
-		//ALSO IT DOESN'T MAKE MUCH SENSE TO UPDATE THE STATE HERE AND THEN WANTING TO USE IT BELOW,
-		//THIS MIGHT LEAD TO RACE CONDITIONS.
-		position === 0 ? setDateInput(date) : setTimeInput(date);
+		let newTimeInput = date;
+
+		if (!fieldDef.inputSettings?.showTime) {
+			newTimeInput = null;
+		}
+
+		position === 0 ? setDateInput(date) : setTimeInput(newTimeInput);
 
 		if (!isNaN(date?.valueOf())) {
 
@@ -62,9 +70,9 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 				year = date.getFullYear();
 				month = date.getMonth();
 				day = date.getDate();
-				hours = fieldDef?.inputSettings?.showTime ? timeInput?.getHours() : 0; //THIS ONLY SOLVES THE ONCHANGE, BUT THE VALUE STILL APPEARS ON THE FIELD
-				minutes = fieldDef?.inputSettings?.showTime ? timeInput?.getMinutes() : 0;
-				seconds = fieldDef?.inputSettings?.showTime ? timeInput?.getSeconds() : 0;
+				hours = fieldDef?.inputSettings?.showTime && timeInput?.getHours() ? timeInput?.getHours() : 0;
+				minutes = fieldDef?.inputSettings?.showTime && timeInput?.getMinutes() ? timeInput?.getMinutes() : 0;
+				seconds = fieldDef?.inputSettings?.showTime && timeInput?.getSeconds() ? timeInput?.getSeconds() : 0;
 			} else {
 				year = dateInput?.getFullYear() || new Date().getFullYear();
 				month = dateInput?.getMonth() || new Date().getMonth();

--- a/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
@@ -51,6 +51,9 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		let minutes = 0;
 		let seconds = 0;
 
+		//THIS LOGIC SHOULD ALSO BE UPDATED, I'M GUESSING IT COULD GO AFTER NEWVALUE
+		//ALSO IT DOESN'T MAKE MUCH SENSE TO UPDATE THE STATE HERE AND THEN WANTING TO USE IT BELOW,
+		//THIS MIGHT LEAD TO RACE CONDITIONS.
 		position === 0 ? setDateInput(date) : setTimeInput(date);
 
 		if (!isNaN(date?.valueOf())) {
@@ -59,9 +62,9 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 				year = date.getFullYear();
 				month = date.getMonth();
 				day = date.getDate();
-				hours = timeInput?.getHours() || 0;
-				minutes = timeInput?.getMinutes() || 0;
-				seconds = timeInput?.getSeconds() || 0;
+				hours = fieldDef?.inputSettings?.showTime ? timeInput?.getHours() : 0; //THIS ONLY SOLVES THE ONCHANGE, BUT THE VALUE STILL APPEARS ON THE FIELD
+				minutes = fieldDef?.inputSettings?.showTime ? timeInput?.getMinutes() : 0;
+				seconds = fieldDef?.inputSettings?.showTime ? timeInput?.getSeconds() : 0;
 			} else {
 				year = dateInput?.getFullYear() || new Date().getFullYear();
 				month = dateInput?.getMonth() || new Date().getMonth();


### PR DESCRIPTION
# What's included?
- Updated logic in FormFieldDateField to reset time to 00:00:00 when showTime is not provided / is false. This ensures no matter what time the back end passes to the field, if it's not active we will not return it, preventing time-zone changes.