### PR TITLE
MOS-1058 bug scrub

### DIFF
--- a/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectDropdownContent.tsx
+++ b/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectDropdownContent.tsx
@@ -33,20 +33,13 @@ function DataViewFilterMultiselectDropdownContent(props: DataViewFilterMultisele
 
 	const [showCreateOptionButton, setShowCreateOptionButton] = useState(false);
 
-	const [disabled, setDisabled] = useState(false);
-
 	const { t } = useMosaicTranslation();
 
 	const limit = Math.abs(props.limit) || 25;
 
 	// mark the active comparison
 	const activeComparison = props.comparisons ? props.comparisons.find(val => val.value === state.comparison) : undefined;
-
-	useEffect(() => {
-		state.selected.length >= props.selectLimit
-			? setDisabled(true)
-			: setDisabled(false);
-	}, [state.selected, props.selectLimit]);
+	const disabled = state.selected.length >= props.selectLimit;
 
 	useEffect(() => {
 		async function fetchData() {

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -54,6 +54,7 @@ interface DrawerProps extends MUIDrawerProps {
 	exitCB?: () => void;
 	anchorstyle?: "left" | "right";
 	display?: boolean;
+	backdropCloseHandler?: boolean
 }
 
 const Drawer = (props: DrawerProps): ReactElement => {
@@ -65,7 +66,8 @@ const Drawer = (props: DrawerProps): ReactElement => {
 		anchor = "right",
 		display,
 		anchorstyle,
-		exitCB
+		exitCB,
+		backdropCloseHandler = true
 	} = props;
 
 	const prevStyleRef = useRef<typeof anchorstyle>();
@@ -94,6 +96,14 @@ const Drawer = (props: DrawerProps): ReactElement => {
 		if (exitCB) exitCB();
 	}
 
+	const onDrawClose = (e, r) => {
+		if (!backdropCloseHandler && r === "backdropClick") {
+			return;
+		}
+
+		onClose();
+	}
+
 	return (
 		<>
 			<MUIDrawerStyled
@@ -102,7 +112,7 @@ const Drawer = (props: DrawerProps): ReactElement => {
 				anchor={anchor}
 				display={display}
 				open={open}
-				onClose={onClose}
+				onClose={onDrawClose}
 				SlideProps={{
 					onExited,
 				}}

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelectionDrawer.tsx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelectionDrawer.tsx
@@ -4,14 +4,12 @@ import {
 	memo,
 	ReactElement,
 	useCallback,
-	useEffect,
 	useState
 } from "react";
 import { AdvancedSelectionExternalOptions, AdvancedSelectionLocalOptions, AdvanceSelectionDrawerPropTypes } from ".";
 import { FormDrawerWrapper } from "../shared/styledComponents";
 import { DataViewFilterMultiselectDropdownContent, GetOptions } from "@root/components/DataViewFilterMultiselect";
 import PageHeader from "@root/components/PageHeader";
-import Dialog from "@root/components/Dialog";
 import { MosaicLabelValue } from "@root/types";
 
 const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactElement => {
@@ -20,9 +18,6 @@ const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactE
 		fieldDef,
 		onChange,
 		handleClose,
-		handleUnsavedChanges,
-		dialogOpen,
-		handleDialogClose,
 	} = props;
 
 	let externalOptions: AdvancedSelectionExternalOptions | undefined;
@@ -37,27 +32,6 @@ const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactE
 	}
 
 	const [selectedOptions, setSelectedOptions] = useState(value?.length > 0 ? value : []);
-
-	const dialogButtons: ButtonProps[] = [
-		{
-			label: "No, stay",
-			onClick: () => handleDialogClose(false),
-			color: "gray",
-			variant: "outlined",
-		},
-		{
-			label: "Yes, leave",
-			onClick: () => handleDialogClose(true),
-			color: "yellow",
-			variant: "contained",
-		},
-	];
-
-	useEffect(() => {
-		if (selectedOptions.length > 0) {
-			handleUnsavedChanges(true);
-		}
-	}, [selectedOptions]);
 
 	const onSubmit = useCallback(async() => {
 		await onChange(selectedOptions);
@@ -113,13 +87,6 @@ const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactE
 				hideButtons={true}
 				createNewOption={fieldDef.inputSettings.createNewOption}
 			/>
-			<Dialog
-				buttons={dialogButtons}
-				dialogTitle='Are you sure you want to leave?'
-				open={dialogOpen}
-			>
-				You have unsaved changes. If you leave all your changes will be lost.
-			</Dialog>
 		</FormDrawerWrapper>
 
 	);

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelectionTypes.tsx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelectionTypes.tsx
@@ -47,9 +47,6 @@ export interface AdvanceSelectionDrawerPropTypes {
 	isModalOpen: boolean;
 	isMobileView: boolean;
 	handleClose: (save?: boolean) => Promise<void>;
-	handleUnsavedChanges?: (val: boolean) => void;
-	dialogOpen?: boolean;
-	handleDialogClose?: (val: boolean) => void;
 }
 
 export type AdvancedSelectionData = MosaicLabelValue[];

--- a/src/forms/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
+++ b/src/forms/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
@@ -40,9 +40,6 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [isMobileView, setIsMobileView] = useState(false);
 
-	const [hasUnsavedChanges, setUnsavedChanges] = useState(false);
-	const [dialogOpen, setIsDialogOpen] = useState(false);
-
 	useEffect(() => {
 		const setResponsiveness = () => {
 			setIsMobileView(window.innerWidth < BREAKPOINTS.mobile);
@@ -68,24 +65,13 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
    */
 	const handleClose = async (save = false) => {
 		if (typeof save === "boolean" && save) {
-			setUnsavedChanges(false);
 			setIsModalOpen(false);
 			if (onBlur) await onBlur();
-		} else if (hasUnsavedChanges)
-			setIsDialogOpen(true);
-		else {
-			setUnsavedChanges(false);
+		} else {
 			setIsModalOpen(false);
 			if (onBlur) await onBlur();
 		}
 	};
-
-	const handleDialogClose = async (close: boolean) => {
-		if (close) {
-			await handleClose(true);
-		}
-		setIsDialogOpen(false);
-	}
 
 	const initialRefs: MosaicObject = {
 		topComponentDrawerRef: null,
@@ -132,7 +118,10 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 				)
 			)}
 			<RefsProvider initialRefs={initialRefs}>
-				<Drawer open={isModalOpen} onClose={handleClose}>
+				<Drawer
+					open={isModalOpen}
+					onClose={handleClose} backdropCloseHandler={false}
+				>
 					<AdvancedSelectionDrawer
 						value={value ?? []}
 						fieldDef={fieldDef}
@@ -140,9 +129,6 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 						isModalOpen={isModalOpen}
 						isMobileView={isMobileView}
 						handleClose={handleClose}
-						handleUnsavedChanges={(e) => setUnsavedChanges(e)}
-						dialogOpen={dialogOpen}
-						handleDialogClose={handleDialogClose}
 					/>
 				</Drawer>
 			</RefsProvider>


### PR DESCRIPTION
This PR

- Removes the state dependency within the Advanced Selection form field component
- Removes behaviour that prompts user about unsaved changes when closing the draw
- Prevents clicks to the draw backdrop from closing the draw