### PR TITLE
MOS-1059 Date field fixes

### DIFF
--- a/src/components/DataView/DataViewFilters/DataViewFilters.tsx
+++ b/src/components/DataView/DataViewFilters/DataViewFilters.tsx
@@ -26,7 +26,7 @@ function DataViewFilters(props: DataViewFiltersProps) {
 		dropdownOpen : false
 	});
 
-	const activeFilters = props.activeFilters || [];
+	const activeFilters = useMemo(() => props.activeFilters || [], [props.activeFilters]);
 
 	const active = activeFilters.map(activeFilter => props.filters.find(filter => filter.name === activeFilter));
 	const options = props.filters

--- a/src/components/Field/FieldTypes.tsx
+++ b/src/components/Field/FieldTypes.tsx
@@ -56,6 +56,10 @@ export interface MosaicFieldProps<T = any, U = any, V = any> {
 	 * Number that represents the amount of fields that share the same row.
 	 */
 	colsInRow?: number;
+	/**
+	 * Form action dispatcher
+	 */
+	dispatch?: any
 }
 
 // SHARED FIELD DEFINITION - DEVELOPER GENERIC CONTRACT

--- a/src/components/Form/Col.tsx
+++ b/src/components/Form/Col.tsx
@@ -188,6 +188,7 @@ const Col = (props: ColPropsTypes) => {
 						ref={ref}
 						// onBlur={onBlur}
 						key={`${name}_${i}`}
+						dispatch={dispatch}
 					/>
 				), [value, error, onChange, currentField]);
 

--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -16,6 +16,7 @@ type ActionTypes =
 	| "FIELD_ON_CHANGE"
 	| "FIELD_TOUCHED"
 	| "FIELD_VALIDATE"
+	| "FIELD_UNVALIDATE"
 	| "FORM_START_DISABLE"
 	| "FORM_END_DISABLE"
 	| "FORM_VALIDATE"
@@ -50,13 +51,24 @@ export function coreReducer(state: State, action: Action): State {
 			}
 		};
 	case "FIELD_VALIDATE":
-		return {
+		// TODO this is bad there's no support for multiple errors, but will be refactored in
+		// https://simpleviewtools.atlassian.net/browse/MOS-1131
+		return state.errors[action.name] ? state : {
 			...state,
 			errors: {
 				...state.errors,
 				[action.name]: action.value
 			},
 		};
+	case "FIELD_UNVALIDATE": {
+		return {
+			...state,
+			errors: {
+				...state.errors,
+				[action.name]: undefined
+			},
+		};
+	}
 	case "FORM_START_DISABLE":
 		return {
 			...state,

--- a/src/constants/formats.ts
+++ b/src/constants/formats.ts
@@ -1,0 +1,2 @@
+export const DATE_FORMAT_FULL = "MM/dd/yyyy";
+export const TIME_FORMAT_FULL = "hh:mm bbb";

--- a/src/constants/formats.ts
+++ b/src/constants/formats.ts
@@ -1,2 +1,4 @@
 export const DATE_FORMAT_FULL = "MM/dd/yyyy";
-export const TIME_FORMAT_FULL = "hh:mm bbb";
+export const DATE_FORMAT_FULL_PLACEHOLDER = "MM / DD / YYYY";
+export const TIME_FORMAT_FULL = "hh:mm aaa";
+export const TIME_FORMAT_FULL_PLACEHOLDER = "00:00 AM/PM";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from "./formats"

--- a/src/forms/FormFieldDate/DateField/DateField.stories.tsx
+++ b/src/forms/FormFieldDate/DateField/DateField.stories.tsx
@@ -125,6 +125,7 @@ export const KitchenSink = (): ReactElement => {
 
 	return (
 		<>
+			<pre>{Object.keys(state.data).map((key, index) => <div key={index}>{key}: {state.data[key] && state.data[key].toString()}</div>)}</pre>
 			<pre>{JSON.stringify(state, null, "  ")}</pre>
 			<Form
 				buttons={renderButtons(dispatch)}

--- a/src/forms/FormFieldDate/DateField/DateField.stories.tsx
+++ b/src/forms/FormFieldDate/DateField/DateField.stories.tsx
@@ -121,8 +121,6 @@ export const KitchenSink = (): ReactElement => {
 
 	return (
 		<>
-			<pre>{Object.keys(state.data).map((key, index) => <div key={index}>{key}: {state.data[key] && state.data[key].toString()}</div>)}</pre>
-			<pre>{JSON.stringify(state, null, "  ")}</pre>
 			<Form
 				buttons={renderButtons(dispatch)}
 				title={"Date Field Calendar"}
@@ -132,6 +130,10 @@ export const KitchenSink = (): ReactElement => {
 				dispatch={dispatch}
 				getFormValues={getFormValues}
 			/>
+			<h3>Date.toString()</h3>
+			<pre>{Object.keys(state.data).map((key, index) => <div key={index}>{key}: {state.data[key] && state.data[key].toString()}</div>)}</pre>
+			<h3>State</h3>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
 		</>
 	);
 };

--- a/src/forms/FormFieldDate/DateField/DateField.stories.tsx
+++ b/src/forms/FormFieldDate/DateField/DateField.stories.tsx
@@ -53,6 +53,12 @@ export const Playground = (): ReactElement => {
 	);
 };
 
+const getFormValues = async () => {
+	return {
+		dateTimePrefilled: new Date(1993, 2, 12, 0, 15, 15)
+	};
+};
+
 export const KitchenSink = (): ReactElement => {
 	const {	state, dispatch	} = useForm();
 	const helperText = "Helper text";
@@ -74,18 +80,6 @@ export const KitchenSink = (): ReactElement => {
 					}
 				},
 				{
-					name: "disableSingleDate",
-					type: "date",
-					label: "Disable Single Date Calendar",
-					required: false,
-					disabled: true,
-					helperText,
-					instructionText,
-					inputSettings: {
-						showTime: false
-					}
-				},
-				{
 					name: "dateTime",
 					type: "date",
 					label: "Date Time Input",
@@ -96,18 +90,20 @@ export const KitchenSink = (): ReactElement => {
 					inputSettings: {
 						showTime: true
 					}
-				}, {
-					name: "disableDateTime",
+				},
+				{
+					name: "dateTimePrefilled",
 					type: "date",
-					label: "Disable Date Time Calendar",
+					label: "Date Time with preset values",
 					required: false,
-					disabled: true,
+					disabled: false,
 					helperText,
 					instructionText,
 					inputSettings: {
 						showTime: true
 					}
-				}, {
+				},
+				{
 					name: "requiredDateTime",
 					type: "date",
 					label: "Required Single Date Calendar",
@@ -134,6 +130,7 @@ export const KitchenSink = (): ReactElement => {
 				state={state}
 				fields={fields}
 				dispatch={dispatch}
+				getFormValues={getFormValues}
 			/>
 		</>
 	);

--- a/src/forms/FormFieldDate/DateField/DateField.stories.tsx
+++ b/src/forms/FormFieldDate/DateField/DateField.stories.tsx
@@ -55,7 +55,7 @@ export const Playground = (): ReactElement => {
 
 const getFormValues = async () => {
 	return {
-		dateTimePrefilled: new Date(1993, 2, 12, 0, 15, 15)
+		dateTimePrefilled: new Date("2023-07-31T14:00:00.000Z")
 	};
 };
 

--- a/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
@@ -13,7 +13,7 @@ import { StyledDisabledText } from "@root/forms/shared/styledComponents";
 import { transform_dateFormat } from "@root/transforms";
 import { isEqual } from "date-fns";
 import { matchTime, textIsValidDate } from "@root/utils/date";
-import { DATE_FORMAT_FULL, TIME_FORMAT_FULL } from "@root/constants";
+import { DATE_FORMAT_FULL, DATE_FORMAT_FULL_PLACEHOLDER, TIME_FORMAT_FULL, TIME_FORMAT_FULL_PLACEHOLDER } from "@root/constants";
 
 const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, DateData>): ReactElement => {
 	const {
@@ -29,7 +29,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 
 	// State splitting is necessary because the form value is a
 	// single date object, which provides no way of differentiating
-	// between a valid date / invalid time combo and all variations of it
+	// between a valid date / invalid time combo or any variation thereof
 	const [dateChosen, setDateChosen] = useState<null | Date>(value);
 	const [timeChosen, setTimeChosen] = useState<null | Date>(value);
 
@@ -84,7 +84,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 								label: "",
 								type: "",
 								inputSettings: {
-									placeholder: "MM / DD / YYYY"
+									placeholder: DATE_FORMAT_FULL_PLACEHOLDER
 								},
 								required: fieldDef?.required,
 							}}
@@ -102,7 +102,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 									label: "",
 									type: "timePicker",
 									inputSettings: {
-										placeholder: "00:00 AM/PM"
+										placeholder: TIME_FORMAT_FULL_PLACEHOLDER
 									}
 								}}
 								value={timeChosen}

--- a/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
@@ -47,7 +47,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		setTimeChosen((time) => isEqual(time, value) ? time : value);
 	}, [value]);
 
-	const setError = (msg: string) => dispatch((d) => {
+	const setError = (msg: string) => dispatch && dispatch((d) => {
 		d({
 			type: "FIELD_VALIDATE",
 			name: fieldDef.name,
@@ -55,7 +55,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		})
 	});
 
-	const clearError = () => dispatch((d) => {
+	const clearError = () => dispatch && dispatch((d) => {
 		d({
 			type: "FIELD_UNVALIDATE",
 			name: fieldDef.name

--- a/src/forms/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/src/forms/FormFieldDate/DatePicker/DatePicker.tsx
@@ -37,9 +37,6 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 		/>
 	);
 
-	const d = new Date();
-	d.setMonth(11);
-
 	return (
 		<LocalizationProvider dateAdapter={AdapterDateFns}>
 			<DatePickerWrapper data-testid="date-picker-test-id" error={!!error} isPickerOpen={isPickerOpen}>

--- a/src/forms/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/src/forms/FormFieldDate/DatePicker/DatePicker.tsx
@@ -13,7 +13,7 @@ import {
 } from "./DatePicker.styled";
 
 const DateFieldPicker = (props: DatePickerProps): ReactElement => {
-	const { error, fieldDef, onChange, value, onBlur } = props;
+	const { error, fieldDef, onChange, value = null, onBlur } = props;
 
 	const [isPickerOpen, setIsPickerOpen] = useState(false);
 
@@ -36,6 +36,9 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 			}}
 		/>
 	);
+
+	const d = new Date();
+	d.setMonth(11);
 
 	return (
 		<LocalizationProvider dateAdapter={AdapterDateFns}>

--- a/src/forms/FormFieldDate/DatePicker/DatePickerTypes.tsx
+++ b/src/forms/FormFieldDate/DatePicker/DatePickerTypes.tsx
@@ -1,5 +1,5 @@
 import { MosaicFieldProps } from "@root/components/Field/FieldTypes";
 
 export interface DatePickerProps extends Omit<MosaicFieldProps, "onChange"> {
-  onChange?: (date: Date) => void;
+  onChange?: (date: Date, keyboardInputValue?: string) => void;
 }

--- a/src/forms/FormFieldDate/TimePicker/TimePicker.tsx
+++ b/src/forms/FormFieldDate/TimePicker/TimePicker.tsx
@@ -14,7 +14,7 @@ import { TimePickerDef, TimePickerData  } from "./TimePickerTypes";
 import { ThemeProvider } from "@mui/material/styles";
 
 const TimeFieldPicker = (props: MosaicFieldProps<"timePicker", TimePickerDef, TimePickerData>): ReactElement => {
-	const { error, fieldDef, onChange, value, onBlur } = props;
+	const { error, fieldDef, onChange, value = null, onBlur } = props;
 
 	const [isPickerOpen, setIsPickerOpen] = useState(false);
 

--- a/src/utils/date/index.ts
+++ b/src/utils/date/index.ts
@@ -1,2 +1,3 @@
 export {default as matchTime} from "./matchTime";
-export {default as sanitizeInputDate} from "./sanitizeInputDate";
+export {default as isValidDate} from "./isValidDate";
+export {default as textIsValidDate} from "./textIsValidDate";

--- a/src/utils/date/index.ts
+++ b/src/utils/date/index.ts
@@ -1,0 +1,2 @@
+export {default as matchTime} from "./matchTime";
+export {default as sanitizeInputDate} from "./sanitizeInputDate";

--- a/src/utils/date/isValidDate.ts
+++ b/src/utils/date/isValidDate.ts
@@ -1,4 +1,4 @@
-function sanitizeInputDate(date: Date | null) {
+function validateDate(date: Date | null) {
 	if (!date) {
 		return;
 	}
@@ -13,4 +13,4 @@ function sanitizeInputDate(date: Date | null) {
 	return date;
 }
 
-export default sanitizeInputDate;
+export default validateDate;

--- a/src/utils/date/matchTime.ts
+++ b/src/utils/date/matchTime.ts
@@ -1,11 +1,13 @@
 
-function matchTime(date: Date, time: Date) {
-	date.setHours(
+function matchTime(date: Date, time: Date | [number, number, number, number]) {
+	const [hr, min, sec, ms] = Array.isArray(time) ? time : [
 		time.getHours(),
 		time.getMinutes(),
 		time.getSeconds(),
 		time.getMilliseconds()
-	);
+	];
+
+	date.setHours(hr, min, sec, ms);
 
 	return date;
 }

--- a/src/utils/date/matchTime.ts
+++ b/src/utils/date/matchTime.ts
@@ -1,0 +1,13 @@
+
+function matchTime(date: Date, time: Date) {
+	date.setHours(
+		time.getHours(),
+		time.getMinutes(),
+		time.getSeconds(),
+		time.getMilliseconds()
+	);
+
+	return date;
+}
+
+export default matchTime

--- a/src/utils/date/sanitizeInputDate.ts
+++ b/src/utils/date/sanitizeInputDate.ts
@@ -1,0 +1,16 @@
+function sanitizeInputDate(date: Date | null) {
+	if (!date) {
+		return;
+	}
+
+	const timestamp = date.getTime();
+	const isInvalidDate = timestamp !== timestamp;
+
+	if (isInvalidDate) {
+		return;
+	}
+
+	return date;
+}
+
+export default sanitizeInputDate;

--- a/src/utils/date/textIsValidDate.ts
+++ b/src/utils/date/textIsValidDate.ts
@@ -1,0 +1,8 @@
+import { format, isValid, parse } from "date-fns";
+
+function textIsValidDate(text: string, dateFormat: string) {
+	const date = parse(text, dateFormat, new Date());
+	return isValid(date) && format(date, dateFormat) === text;
+}
+
+export default textIsValidDate


### PR DESCRIPTION
This PR modifies the FormFieldDate so that it emits a date object based on the timezone of the user's browser. It also adds a layer of input validation when the user is changing the date or time fields using their keyboard. Additionally, it shows more informative hints where appropriate.

Note that:
- These hints currently show too early whilst the user is typing, instead of when the field loses focus
- The hints can be flaky due to the form system not having named errors

Both of these are part of a larger form issue, that is being addressed in a refactor for this [ticket](https://simpleviewtools.atlassian.net/browse/MOS-1131)