### PR TITLE
MOS-1073 - Fix matrix button padding and dataview empty actions

### DIFF
--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -199,7 +199,6 @@ function DataView (props: DataViewProps): ReactElement  {
 
 	const shouldRenderActionsRow: boolean = useMemo(() => {
 		if (
-			props.display ??
 			validBulkActions ??
 			props.limitOptions ??
 			props.onColumnsChange ??

--- a/src/forms/FormFieldMatrix/FormFieldMatrix.stories.tsx
+++ b/src/forms/FormFieldMatrix/FormFieldMatrix.stories.tsx
@@ -229,7 +229,7 @@ export const FormVariant = (): ReactElement => {
 										}
 									}),
 								color: "teal",
-								variant: "text",
+								variant: "outlined",
 								mIcon: AddIcon
 							},
 						]
@@ -513,7 +513,7 @@ export const Browse = (): ReactElement => {
 										},
 									}),
 								color: "teal",
-								variant: "text",
+								variant: "outlined",
 								mIcon: AddIcon,
 							},
 						],

--- a/src/forms/FormFieldMatrix/FormFieldMatrix.styled.tsx
+++ b/src/forms/FormFieldMatrix/FormFieldMatrix.styled.tsx
@@ -2,18 +2,17 @@ import styled from "styled-components";
 import theme from "@root/theme";
 
 export const MatrixWrapper = styled.div`
-	border: ${(props) =>
-		props.hasValue
-			? `2px solid ${theme.newColors.grey2["100"]}`
-			: "transparent"};
+	${({ hasValue }) => hasValue && `
+		border: 2px solid ${theme.newColors.grey2["100"]};
+	`}
 
 	& > div > .viewContainer {
 		margin: 0;
 	}
 `;
 
-export const ButtonsWrapper = styled.div`
-	display: flex;
-	margin: 10px 0 0px 8px;
-	gap: 16px;
-`;
+export const MatrixButtons = styled.div`
+	${({ hasValue }) => hasValue && `
+		padding: 0.5rem;
+	`}
+`

--- a/src/forms/FormFieldMatrix/FormFieldMatrix.tsx
+++ b/src/forms/FormFieldMatrix/FormFieldMatrix.tsx
@@ -2,10 +2,11 @@ import * as React from "react";
 import { ReactElement, memo } from "react";
 
 import { MosaicFieldProps } from "@root/components/Field";
-import { MatrixWrapper, ButtonsWrapper } from "./FormFieldMatrix.styled";
+import { MatrixWrapper, MatrixButtons } from "./FormFieldMatrix.styled";
 import Button from "@root/components/Button";
 import DataView from "@root/components/DataView";
 import { MatrixData, MatrixInputSettings } from "./FormFieldMatrixTypes";
+import ButtonRow from "@root/components/ButtonRow/ButtonRow";
 
 const FormFieldMatrix = (
 	props: MosaicFieldProps<"matrix", MatrixInputSettings, MatrixData>
@@ -16,14 +17,17 @@ const FormFieldMatrix = (
 	} = props;
 
 	const { buttons, dataView } = fieldDef.inputSettings;
+	const hasValue = Boolean(value);
 
 	return (
-		<MatrixWrapper hasValue={value}>
-			<ButtonsWrapper>
-				{buttons.map((button, idx) => (
-					<Button key={`${button.label}-${idx}`} {...button} />
-				))}
-			</ButtonsWrapper>
+		<MatrixWrapper hasValue={hasValue}>
+			<MatrixButtons hasValue={hasValue}>
+				<ButtonRow>
+					{buttons.map((button, idx) => (
+						<Button key={`${button.label}-${idx}`} {...button} />
+					))}
+				</ButtonRow>
+			</MatrixButtons>
 			{value &&
 				<DataView
 					data={value}


### PR DESCRIPTION
This PR fixes the padding issue that occurs around `FormFieldMatrix`'s buttons when there are no matrix items. It also addresses a small `DataView` component issue where the actions row renders even though there are no children.