### PR TITLE
MOS-1073 matrix padding

### DIFF
--- a/src/components/ButtonRow/ButtonRow.styled.tsx
+++ b/src/components/ButtonRow/ButtonRow.styled.tsx
@@ -15,7 +15,6 @@ export const Row = styled.div`
 	${({wrap}) => wrap && `
 		flex-wrap: wrap;
 	`}
-
 `;
 
 export const Item = styled.div`

--- a/src/components/DataView/DataView.stories.mdx
+++ b/src/components/DataView/DataView.stories.mdx
@@ -29,6 +29,7 @@ The other non-converted props are listed below:
     * **args** - `object` - An object detailing arguments to be passed into the jsx component.
 * **checked** - `boolean[]` -  Array containing the rows that are going to be checked.
 * **checkedAllPages** - `boolean[]` -  Defines whether all pages are checked or not.
+* **noResults** - `ReactElement | string` - When there are no results to show in the data view, this component will be displayed. If omitted, a generic message `"No results were found."` will be displayed instead.
 * **filter** - `object` - An object representing the total filtering logic applied to data in the `DataView`.
 * **activeFilters** - `array` of `string` - List of filter names from the filters array which are active in the `DataView`.
 * **activeColumns** - `array` of `string` - List of column names from the columns array which are displayed in the `DataView`.

--- a/src/components/DataView/DataView.stories.tsx
+++ b/src/components/DataView/DataView.stories.tsx
@@ -406,6 +406,7 @@ const StyledDiv = styled.div`
 `;
 
 export const Playground = (): ReactElement => {
+	const noData = boolean("Empty dataset", false);
 	const onBack = boolean("onBack", false);
 	const savedViewAllowSharedViewSave = boolean("savedViewAllowSharedViewSave", true);
 	const bulkActions = boolean("bulkActions", true);
@@ -717,7 +718,7 @@ export const Playground = (): ReactElement => {
 			}));
 		},
 		savedViewAllowSharedViewSave,
-		data: state.data,
+		data: noData ? [] : state.data,
 		limit: state.limit,
 		sort: state.sort,
 		filter: state.filter,

--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -70,6 +70,8 @@ function DataView (props: DataViewProps): ReactElement  {
 		})
 	}, [props.activeFilters, props.filters]);
 
+	const { noResults = "No results were found." } = props;
+
 	// set defaults
 	const display = props.display || "list";
 	const displayOptions = useMemo(() => props.displayOptions || [display], [display, props.displayOptions]);
@@ -199,7 +201,6 @@ function DataView (props: DataViewProps): ReactElement  {
 
 	const shouldRenderActionsRow: boolean = useMemo(() => {
 		if (
-			props.display ??
 			validBulkActions ??
 			props.limitOptions ??
 			props.onColumnsChange ??
@@ -326,10 +327,14 @@ function DataView (props: DataViewProps): ReactElement  {
 					anyChecked={anyChecked}
 				/>
 			</div>
-			{props.loading === false && !props.data.length && (
-				<div className="noResults">
-					<p>No results were found.</p>
-				</div>
+			{!props.loading && !props.data.length && (
+				typeof noResults === "string" ? (
+					<div className="noResults">
+						<p>{noResults}</p>
+					</div>
+				) : (
+					noResults
+				)
 			)}
 		</StyledWrapper>
 	);

--- a/src/components/DataView/DataViewTypes.ts
+++ b/src/components/DataView/DataViewTypes.ts
@@ -1,3 +1,4 @@
+import { ReactElement } from "react";
 import { MosaicObject, MosaicCallback, MosaicLabelValue, MosaicShow } from "@root/types";
 import { ButtonProps } from "../Button";
 import { MenuItemProps } from "../MenuItem";
@@ -203,6 +204,7 @@ export interface DataViewProps {
 	sticky?: boolean
 	checked?: boolean[];
 	checkedAllPages?: boolean;
+	noResults?: ReactElement | string,
 	/** A list of actions which are always visible for each item in the DataView. */
 	filters?: DataViewFilterDef[]
 	filter?: MosaicObject

--- a/src/forms/FormFieldMatrix/FormFieldMatrix.stories.tsx
+++ b/src/forms/FormFieldMatrix/FormFieldMatrix.stories.tsx
@@ -21,6 +21,7 @@ import useMosaicSettings from "@root/utils/useMosaicSettings";
 import rawData from "@root/components/DataView/example/rawData.json";
 import PageHeader from "@root/components/PageHeader";
 import { ButtonProps } from "@root/components/Button";
+import Button from "@root/components/Button/Button";
 
 export default {
 	title: "FormFields/FormFieldMatrix",
@@ -121,7 +122,33 @@ export const FormVariant = (): ReactElement => {
 		removeDrawer();
 	};
 
+	const onAddClick = () =>
+		addDrawer({
+			config: {
+				type: "form",
+				title: "Drawer Form",
+				fields: [
+					{
+						name: "title",
+						label: "Title",
+						type: "text",
+					},
+					{
+						name: "description",
+						label: "Description",
+						type: "text",
+					},
+				],
+			}
+		})
+
 	const gridConfig: DataViewProps = {
+		noResults: (
+			<div style={{ padding: "1rem 0.5rem", alignItems: "center", justifyContent: "center", display: "flex", flexDirection: "column", gap: 10 }}>
+				<div>Custom <em>no results</em> component.</div>
+				<Button variant="outlined" color="gray" label="Create one" onClick={onAddClick} />
+			</div>
+		),
 		columns: listColumns,
 		primaryActions: [
 			{
@@ -209,25 +236,7 @@ export const FormVariant = (): ReactElement => {
 						buttons: [
 							{
 								label: "Add",
-								onClick: () =>
-									addDrawer({
-										config: {
-											type: "form",
-											title: "Drawer Form",
-											fields: [
-												{
-													name: "title",
-													label: "Title",
-													type: "text",
-												},
-												{
-													name: "description",
-													label: "Description",
-													type: "text",
-												},
-											],
-										}
-									}),
+								onClick: onAddClick,
 								color: "teal",
 								variant: "text",
 								mIcon: AddIcon
@@ -459,6 +468,7 @@ export const Browse = (): ReactElement => {
 		display: "list",
 		activeColumns: ["id", "title", "description"],
 		savedView: defaultView,
+		noResults: "No records selected"
 	};
 
 	const mosaicSettings = useMosaicSettings();
@@ -513,7 +523,7 @@ export const Browse = (): ReactElement => {
 										},
 									}),
 								color: "teal",
-								variant: "text",
+								variant: "outlined",
 								mIcon: AddIcon,
 							},
 						],

--- a/src/forms/FormFieldMatrix/FormFieldMatrix.styled.tsx
+++ b/src/forms/FormFieldMatrix/FormFieldMatrix.styled.tsx
@@ -2,18 +2,21 @@ import styled from "styled-components";
 import theme from "@root/theme";
 
 export const MatrixWrapper = styled.div`
-	border: ${(props) =>
-		props.hasValue
-			? `2px solid ${theme.newColors.grey2["100"]}`
-			: "transparent"};
+	width: 600px;
+	max-width: 100%;
+
+	${({hasValue}) => hasValue && `
+		border: 2px solid ${theme.newColors.grey2["100"]};
+		border-bottom-width: 1px;
+	`}
 
 	& > div > .viewContainer {
 		margin: 0;
 	}
 `;
 
-export const ButtonsWrapper = styled.div`
-	display: flex;
-	margin: 10px 0 0px 8px;
-	gap: 16px;
-`;
+export const MatrixActions = styled.div`
+	${({hasValue}) => hasValue && `
+		padding: 0.5rem;
+	`}
+`

--- a/src/forms/FormFieldMatrix/FormFieldMatrix.styled.tsx
+++ b/src/forms/FormFieldMatrix/FormFieldMatrix.styled.tsx
@@ -5,9 +5,12 @@ export const MatrixWrapper = styled.div`
 	width: 600px;
 	max-width: 100%;
 
-	${({hasValue}) => hasValue && `
-		border: 2px solid ${theme.newColors.grey2["100"]};
-		border-bottom-width: 1px;
+	border-style: solid;
+	border-color: ${theme.newColors.grey2["100"]};
+	border-width: 2px;
+
+	${({hasValue}) => `
+		border-bottom-width: ${hasValue ? 1 : 2}px;
 	`}
 
 	& > div > .viewContainer {
@@ -16,7 +19,5 @@ export const MatrixWrapper = styled.div`
 `;
 
 export const MatrixActions = styled.div`
-	${({hasValue}) => hasValue && `
-		padding: 0.5rem;
-	`}
+	padding: 0.5rem;
 `

--- a/src/forms/FormFieldMatrix/FormFieldMatrix.tsx
+++ b/src/forms/FormFieldMatrix/FormFieldMatrix.tsx
@@ -2,10 +2,11 @@ import * as React from "react";
 import { ReactElement, memo } from "react";
 
 import { MosaicFieldProps } from "@root/components/Field";
-import { MatrixWrapper, ButtonsWrapper } from "./FormFieldMatrix.styled";
+import { MatrixActions, MatrixWrapper } from "./FormFieldMatrix.styled";
 import Button from "@root/components/Button";
 import DataView from "@root/components/DataView";
 import { MatrixData, MatrixInputSettings } from "./FormFieldMatrixTypes";
+import ButtonRow from "@root/components/ButtonRow/ButtonRow";
 
 const FormFieldMatrix = (
 	props: MosaicFieldProps<"matrix", MatrixInputSettings, MatrixData>
@@ -16,20 +17,21 @@ const FormFieldMatrix = (
 	} = props;
 
 	const { buttons, dataView } = fieldDef.inputSettings;
+	const data = (dataView.data !== undefined ? dataView.data : value) || [];
 
 	return (
-		<MatrixWrapper hasValue={value}>
-			<ButtonsWrapper>
-				{buttons.map((button, idx) => (
-					<Button key={`${button.label}-${idx}`} {...button} />
-				))}
-			</ButtonsWrapper>
-			{value &&
-				<DataView
-					data={value}
-					{...dataView}
-				></DataView>
-			}
+		<MatrixWrapper hasValue>
+			<MatrixActions hasValue>
+				<ButtonRow>
+					{buttons.map((button, idx) => (
+						<Button key={`${button.label}-${idx}`} {...button} />
+					))}
+				</ButtonRow>
+			</MatrixActions>
+			<DataView
+				data={[]}
+				{...{...dataView, data}}
+			/>
 		</MatrixWrapper>
 	);
 };

--- a/src/forms/FormFieldMatrix/FormFieldMatrix.tsx
+++ b/src/forms/FormFieldMatrix/FormFieldMatrix.tsx
@@ -18,10 +18,11 @@ const FormFieldMatrix = (
 
 	const { buttons, dataView } = fieldDef.inputSettings;
 	const data = (dataView.data !== undefined ? dataView.data : value) || [];
+	const hasValue = data.length > 0;
 
 	return (
-		<MatrixWrapper hasValue>
-			<MatrixActions hasValue>
+		<MatrixWrapper hasValue={hasValue}>
+			<MatrixActions hasValue={hasValue}>
 				<ButtonRow>
 					{buttons.map((button, idx) => (
 						<Button key={`${button.label}-${idx}`} {...button} />


### PR DESCRIPTION
This PR makes changes to:

- The `DataView` component, which now takes an optional `noResults` property. When there is no data to display, this component will be rendered if provided. If it is not provided, a generic string will be rendered. It also addresses a small issue where the actions row renders even though there are no children
- The `FormFieldMatrix` component, which will now display the integrated `DataView` component, even when there are no matrix items selected.