### PR TITLE
Swaps out field validation actions for correct invalidate action

### DIFF
--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -87,9 +87,8 @@ export const formActions = {
 			 */
 			if (extraArgs?.fieldMap[name].disabled) {
 				await dispatch({
-					type: "FIELD_VALIDATE",
-					name,
-					value: undefined
+					type: "FIELD_UNVALIDATE",
+					name
 				});
 
 				return;
@@ -112,11 +111,18 @@ export const formActions = {
 			const currentValue = getState().data[name];
 
 			if (startValue === currentValue) {
-				await dispatch({
-					type: "FIELD_VALIDATE",
-					name,
-					value: result?.errorMessage ?? undefined
-				});
+				if (result?.errorMessage) {
+					await dispatch({
+						type: "FIELD_VALIDATE",
+						name,
+						value: result?.errorMessage
+					});
+				} else {
+					await dispatch({
+						type: "FIELD_UNVALIDATE",
+						name
+					});
+				}
 			}
 		};
 	},

--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -56,7 +56,7 @@ export function coreReducer(state: State, action: Action): State {
 	case "FIELD_VALIDATE":
 		// TODO this is bad there's no support for multiple errors, but will be refactored in
 		// https://simpleviewtools.atlassian.net/browse/MOS-1131
-		return state.errors[action.name] ? state : {
+		return state.errors[action.name] !== undefined ? state : {
 			...state,
 			errors: {
 				...state.errors,


### PR DESCRIPTION
This PR addresses a bug that was introduced in MOS-1059 where, in some scenarios, fields are not revalidated after user has fixed errors, preventing the form from ever being submitted.