### PR TITLE
MOS-1120 Implement a form loading queue

### DIFF
--- a/src/components/Form/Form.styled.ts
+++ b/src/components/Form/Form.styled.ts
@@ -8,7 +8,7 @@ export const StyledForm = styled.form`
 `;
 
 export const StyledContainerForm = styled.div`
-	&.loading {
+	&.disabled {
 		opacity: .5;
 		pointer-events: none;
 	}

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -191,6 +191,19 @@ const Form = (props: FormProps) => {
 		setActiveSection(Number(args.item.name))
 	}, [setActiveSection]);
 
+	const submitWarningContent = typeof state.submitWarning === "object" ? (
+		<>
+			<div>{state.submitWarning.lead}</div>
+			<ul>
+				{state.submitWarning.reasons.map(reason => (
+					<li key={reason}>{reason}</li>
+				))}
+			</ul>
+		</>
+	) : (
+		state.submitWarning
+	);
+
 	return (
 		<>
 			<ViewProvider value={view}>
@@ -261,7 +274,7 @@ const Form = (props: FormProps) => {
 				You have unsaved changes. If you leave all your changes will be lost.
 			</Dialog>
 			<Snackbar
-				label={state.submitWarning}
+				label={submitWarningContent}
 				open={Boolean(state.submitWarning)}
 				onClose={() => dispatch(formActions.setSubmitWarning({ value: "" }))}
 				autoHideDuration={4000}

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -15,6 +15,7 @@ import { ButtonProps } from "../Button";
 import { useRefsDispatch } from "../../forms/shared/refsContext/RefsContext";
 import SideNav, { Item, SideNavArgs } from "../SideNav";
 import useScrollSpy from "@root/utils/hooks/useScrollSpy";
+import Snackbar from "../Snackbar/Snackbar";
 
 const Form = (props: FormProps) => {
 	const {
@@ -190,6 +191,8 @@ const Form = (props: FormProps) => {
 		setActiveSection(Number(args.item.name))
 	}, [setActiveSection]);
 
+	// const loading = Object.values(state.loading).filter(Boolean).length > 0;
+
 	return (
 		<>
 			<ViewProvider value={view}>
@@ -197,7 +200,7 @@ const Form = (props: FormProps) => {
 					data-testid="form-test-id"
 					style={{ position: "relative", height: "100%" }}
 					ref={formContainerRef}
-					className={state.disabled ? "loading" : ""}
+					className={state.disabled ? "disabled" : ""}
 				>
 					<StyledForm autoComplete="off">
 						{title &&
@@ -259,6 +262,12 @@ const Form = (props: FormProps) => {
 			>
 				You have unsaved changes. If you leave all your changes will be lost.
 			</Dialog>
+			<Snackbar
+				label={state.submitWarning}
+				open={Boolean(state.submitWarning)}
+				onClose={() => dispatch(formActions.setSubmitWarning({ value: "" }))}
+				autoHideDuration={4000}
+			/>
 		</>
 	);
 }

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -191,8 +191,6 @@ const Form = (props: FormProps) => {
 		setActiveSection(Number(args.item.name))
 	}, [setActiveSection]);
 
-	// const loading = Object.values(state.loading).filter(Boolean).length > 0;
-
 	return (
 		<>
 			<ViewProvider value={view}>

--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -199,16 +199,16 @@ export const formActions = {
 	},
 	submitForm() {
 		return async function (dispatch, getState, extraArgs): Promise<{ valid: boolean; data: any; }> {
-			const { disabled, data, mounted, loading } = getState();
+			const { disabled, data, mounted, busy } = getState();
 
 			if (disabled)
 				return;
 
-			const loadingMessages = Object.values(loading).filter(Boolean);
-			if (loadingMessages.length > 0) {
+			const busyMessages = Object.values(busy).filter(Boolean);
+			if (busyMessages.length > 0) {
 				dispatch({
 					type: "SET_SUBMIT_WARNING",
-					value: `The form cannot be submitted at this time: ${loadingMessages.join(" ")}`
+					value: `The form cannot be submitted at this time: ${busyMessages.join(" ")}`
 				});
 
 				return;
@@ -265,19 +265,19 @@ export const formActions = {
 			});
 		}
 	},
-	startLoad({ name, value }: { name: string, value: string }) {
+	startBusy({ name, value }: { name: string, value: string }) {
 		return async function (dispatch): Promise<void> {
 			await dispatch({
-				type: "FORM_START_LOAD",
+				type: "FORM_START_BUSY",
 				name,
 				value
 			});
 		}
 	},
-	endLoad({ name }: { name: string }) {
+	endBusy({ name }: { name: string }) {
 		return async function (dispatch): Promise<void> {
 			await dispatch({
-				type: "FORM_END_LOAD",
+				type: "FORM_END_BUSY",
 				name,
 			});
 		}

--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -41,6 +41,14 @@ export const formActions = {
 			extraArgs.fieldMap = fieldMap;
 		};
 	},
+	setSubmitWarning({ value }: { value: string }) {
+		return async function(dispatch): Promise<void> {
+			return dispatch({
+				type: "SET_SUBMIT_WARNING",
+				value
+			})
+		}
+	},
 	setFieldValue({
 		name,
 		value,
@@ -191,10 +199,20 @@ export const formActions = {
 	},
 	submitForm() {
 		return async function (dispatch, getState, extraArgs): Promise<{ valid: boolean; data: any; }> {
-			const { disabled, data, mounted } = getState();
+			const { disabled, data, mounted, loading } = getState();
 
 			if (disabled)
 				return;
+
+			const loadingMessages = Object.values(loading).filter(Boolean);
+			if (loadingMessages.length > 0) {
+				dispatch({
+					type: "SET_SUBMIT_WARNING",
+					value: `The form cannot be submitted at this time: ${loadingMessages.join(" ")}`
+				});
+
+				return;
+			}
 
 			const valid = await dispatch(
 				formActions.validateForm({ fields: extraArgs.fields })
@@ -244,6 +262,23 @@ export const formActions = {
 			await dispatch({
 				type: disabled ? "FORM_START_DISABLE" : "FORM_END_DISABLE",
 				value: disabled,
+			});
+		}
+	},
+	startLoad({ name, value }: { name: string, value: string }) {
+		return async function (dispatch): Promise<void> {
+			await dispatch({
+				type: "FORM_START_LOAD",
+				name,
+				value
+			});
+		}
+	},
+	endLoad({ name }: { name: string }) {
+		return async function (dispatch): Promise<void> {
+			await dispatch({
+				type: "FORM_END_LOAD",
+				name,
 			});
 		}
 	},

--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -11,6 +11,8 @@ type State = {
 	disabled: boolean;
 	touched: MosaicObject<boolean>;
 	mounted: MosaicObject<boolean>;
+	loading: MosaicObject<boolean>;
+	submitWarning: string
 }
 
 type ActionTypes =
@@ -28,6 +30,9 @@ type ActionTypes =
 	| "PROPERTY_RESET"
 	| "MOUNT_FIELD"
 	| "UNMOUNT_FIELD"
+	| "FORM_START_LOAD"
+	| "FORM_END_LOAD"
+	| "SET_SUBMIT_WARNING"
 
 type Action = {
 	type: ActionTypes;
@@ -122,6 +127,30 @@ export function coreReducer(state: State, action: Action): State {
 				[action.name]: false
 			}
 		}
+	case "FORM_START_LOAD": {
+		return {
+			...state,
+			loading: {
+				...state.loading,
+				[action.name]: action.value
+			}
+		}
+	}
+	case "FORM_END_LOAD": {
+		return {
+			...state,
+			loading: {
+				...state.loading,
+				[action.name]: undefined
+			}
+		}
+	}
+	case "SET_SUBMIT_WARNING": {
+		return {
+			...state,
+			submitWarning: action.value
+		}
+	}
 	default:
 		return state;
 	}
@@ -151,7 +180,9 @@ export function useForm(): UseFormReturn {
 			validForm: false,
 			disabled: false,
 			touched: {},
-			mounted: {}
+			mounted: {},
+			loading: {},
+			submitWarning: ""
 		},
 		extraArgs.current
 	);

--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -11,7 +11,7 @@ type State = {
 	disabled: boolean;
 	touched: MosaicObject<boolean>;
 	mounted: MosaicObject<boolean>;
-	busy: MosaicObject<boolean>;
+	busyFields: MosaicObject<boolean>;
 	submitWarning: string
 }
 
@@ -130,8 +130,8 @@ export function coreReducer(state: State, action: Action): State {
 	case "FORM_START_BUSY": {
 		return {
 			...state,
-			busy: {
-				...state.busy,
+			busyFields: {
+				...state.busyFields,
 				[action.name]: action.value
 			}
 		}
@@ -139,8 +139,8 @@ export function coreReducer(state: State, action: Action): State {
 	case "FORM_END_BUSY": {
 		return {
 			...state,
-			busy: {
-				...state.busy,
+			busyFields: {
+				...state.busyFields,
 				[action.name]: undefined
 			}
 		}

--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -11,7 +11,7 @@ type State = {
 	disabled: boolean;
 	touched: MosaicObject<boolean>;
 	mounted: MosaicObject<boolean>;
-	loading: MosaicObject<boolean>;
+	busy: MosaicObject<boolean>;
 	submitWarning: string
 }
 
@@ -30,8 +30,8 @@ type ActionTypes =
 	| "PROPERTY_RESET"
 	| "MOUNT_FIELD"
 	| "UNMOUNT_FIELD"
-	| "FORM_START_LOAD"
-	| "FORM_END_LOAD"
+	| "FORM_START_BUSY"
+	| "FORM_END_BUSY"
 	| "SET_SUBMIT_WARNING"
 
 type Action = {
@@ -127,20 +127,20 @@ export function coreReducer(state: State, action: Action): State {
 				[action.name]: false
 			}
 		}
-	case "FORM_START_LOAD": {
+	case "FORM_START_BUSY": {
 		return {
 			...state,
-			loading: {
-				...state.loading,
+			busy: {
+				...state.busy,
 				[action.name]: action.value
 			}
 		}
 	}
-	case "FORM_END_LOAD": {
+	case "FORM_END_BUSY": {
 		return {
 			...state,
-			loading: {
-				...state.loading,
+			busy: {
+				...state.busy,
 				[action.name]: undefined
 			}
 		}

--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -181,7 +181,7 @@ export function useForm(): UseFormReturn {
 			disabled: false,
 			touched: {},
 			mounted: {},
-			loading: {},
+			busyFields: {},
 			submitWarning: ""
 		},
 		extraArgs.current

--- a/src/components/Form/stories/Playground.stories.tsx
+++ b/src/components/Form/stories/Playground.stories.tsx
@@ -154,11 +154,6 @@ export const Playground = (): ReactElement => {
 			);
 		}
 
-		if (Math.random() < 0.3) {
-			await onError("File size exceeded");
-			return;
-		}
-
 		await onUploadComplete({
 			id: nanoid(),
 			name: file.name,

--- a/src/forms/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/forms/FormFieldUpload/FormFieldUpload.tsx
@@ -1,6 +1,6 @@
 import Button from "@root/components/Button";
 import { MosaicFieldProps } from "@root/components/Field";
-import { Snackbar } from "@root/index";
+import { formActions, Snackbar } from "@root/index";
 import _ from "lodash";
 import * as React from "react";
 import { memo, SyntheticEvent, useEffect, useMemo, useRef, useState } from "react";
@@ -14,6 +14,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 		fieldDef,
 		value,
 		onChange,
+		dispatch
 	} = props;
 
 	const {
@@ -98,6 +99,8 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 
 
 	const onUploadComplete = async ({ uuid, data }) => {
+		dispatch && dispatch(formActions.endLoad({ name: `uploading/${fieldDef.name}/${uuid}` }));
+
 		onChange(prevValueRef?.current ? [...prevValueRef.current, data] : [data]);
 
 		setPendingFiles((prevState) => {
@@ -108,6 +111,8 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 	};
 
 	const onError = async ({ uuid, message }) => {
+		dispatch && dispatch(formActions.endLoad({ name: `uploading/${fieldDef.name}/${uuid}` }));
+
 		setPendingFiles((prevState) => (
 			{
 				...prevState,
@@ -168,6 +173,11 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 		setPendingFiles({...pendingFiles, ...transformedFiles});
 
 		for (const [key, file] of Object.entries(transformedFiles) as [string, TransformedFile][]) {
+			dispatch && dispatch(formActions.startLoad({
+				name: `uploading/${fieldDef.name}/${key}`,
+				value: `${fieldDef.label} currently has an upload in progress`
+			}));
+
 			onFileAdd({
 				file: file?.rawData,
 				onChunkComplete: ({ percent }) => onChunkComplete({uuid: key, percent}),

--- a/src/forms/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/forms/FormFieldUpload/FormFieldUpload.tsx
@@ -108,9 +108,14 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 		}
 
 		if (pendingWithoutError) {
-			dispatch(formActions.startBusy({ name: fieldDef.name, value: `${fieldDef.label} is currently uploading` }));
+			dispatch(formActions.startBusy({
+				name: fieldDef.name,
+				value: `${fieldDef.label} is currently uploading ${pendingWithoutError} files(s)`
+			}));
 		} else {
-			dispatch(formActions.endBusy({ name: fieldDef.name }));
+			dispatch(formActions.endBusy({
+				name: fieldDef.name
+			}));
 		}
 	}, [pendingWithoutError]);
 


### PR DESCRIPTION
This PR adds support for a form loading queue. This can be used to prevent submissions when one or more components is in a loading state. It also has the `FormFieldUpload` component utilise the new loading queue functionality to prevent users from submitting the form whilst file uploads are in progress.