### PR TITLE
MOS-1148 Add optional chain to field map when validating

### DIFF
--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -85,7 +85,7 @@ export const formActions = {
 			 * the field had an error message and then became disabled,
 			 * the error would get removed from the state.
 			 */
-			if (extraArgs?.fieldMap[name].disabled) {
+			if (extraArgs?.fieldMap[name]?.disabled) {
 				await dispatch({
 					type: "FIELD_UNVALIDATE",
 					name


### PR DESCRIPTION
This PR adds an optional chain to the `extraArgs.fieldMap` reference to prevent throwing errors.