### PR TITLE
MOS-1127 mindate support

### DIFF
--- a/src/components/DataViewFilterDate/DataViewFilterDate.stories.mdx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.stories.mdx
@@ -5,7 +5,7 @@ import * as stories from "./DataViewFilterDate.stories";
 
 # DataViewFilterDate
 
-`DataViewFilterDate` is a filter that can be used to select records between a set of dates. The filter also allows developers to pass a specific set of "magic values" that when clicked will automatically set a date (e.g. "Today", "Last 2 months", etc). For more please take a look at the props.
+`DataViewFilterDate` is a filter that can be used to select records between a set of dates. The filter also allows developers to pass a specific set of "magic values" that when clicked will automatically set a date (e.g. "Today", "Last 2 months", etc). For more please take a look at the props. The `args` object takes an optional `minDate` prop which can be used to define a minimum date that can be chosen using the datepicker. By default, the minimum date is 01/01/1900.
 
 ## Props
 

--- a/src/components/DataViewFilterDate/DataViewFilterDate.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.tsx
@@ -29,7 +29,7 @@ export default function DataViewFilterDate(props: DataViewFilterDateProps): Reac
 		setAnchorEl(null);
 	}
 
-	let valueString: string | undefined = undefined;
+	let valueString: string | undefined = undefined
 
 	if (props.data)
 		if ("rangeStart" in props.data || "rangeEnd" in props.data) {
@@ -69,6 +69,7 @@ export default function DataViewFilterDate(props: DataViewFilterDateProps): Reac
 					rangeEnd={props.data && "rangeEnd" in props.data ? props.data?.rangeEnd : undefined}
 					options={props.args.options}
 					selectedOption={props.data && "option" in props.data ? props.data?.option : undefined}
+					minDate={props?.args.minDate}
 				/>
 			</DataViewFilterDropdown>
 		</StyledWrapper>

--- a/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
@@ -144,8 +144,9 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 									label: "",
 									type: "",
 									inputSettings: {
-										placeholder: t("mosaic:DataViewFilterDate.choose_a_date___")
-									},
+										placeholder: t("mosaic:DataViewFilterDate.choose_a_date___"),
+										minDate: props.minDate
+									}
 								}}
 							/>
 						</Field>
@@ -168,8 +169,9 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 									label: "",
 									type: "",
 									inputSettings: {
-										placeholder: t("mosaic:DataViewFilterDate.choose_a_date___")
-									},
+										placeholder: t("mosaic:DataViewFilterDate.choose_a_date___"),
+										minDate: props.minDate
+									}
 								}}
 							/>
 						</Field>

--- a/src/components/DataViewFilterDate/DataViewFilterDateTypes.ts
+++ b/src/components/DataViewFilterDate/DataViewFilterDateTypes.ts
@@ -19,7 +19,7 @@ export interface DataViewFilterDateOnChange {
 export interface DataViewFilterDateProps extends DataViewFilterProps {
 	data: DataViewFilterDateData,
 	onChange: DataViewFilterDateOnChange
-	args: { options?: MosaicLabelValue[] }
+	args: { options?: MosaicLabelValue[], minDate?: Date }
 }
 
 interface DataViewFilterDateDropdownContentOptions {
@@ -35,4 +35,5 @@ interface DataViewFilterDateDropdownContentRange {
 export type DataViewFilterDateDropdownContentProps = {
 	onChange: DataViewFilterDateOnChange
 	onClose: () => void
+	minDate?: Date
 } & (DataViewFilterDateDropdownContentOptions | DataViewFilterDateDropdownContentRange)

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -689,6 +689,7 @@ This field implements the [**FieldDef**](#generic-field-props-fielddef) interfac
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | **`showTime`** | `boolean` | optional - When true a time field will appear next to the date field. |
+| **`minDate`** | `Date` | optional - The minimum date that can be chosen using the datepicker. Defaults to 01/01/1900 |
 
 
 ### How to use in a form?

--- a/src/forms/FormFieldDate/DateField/DateField.stories.tsx
+++ b/src/forms/FormFieldDate/DateField/DateField.stories.tsx
@@ -4,6 +4,8 @@ import { boolean, text, withKnobs } from "@storybook/addon-knobs";
 import { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
 import { renderButtons } from "@root/utils/storyUtils";
+import { textIsValidDate } from "@root/utils/date";
+import { DATE_FORMAT_FULL } from "@root/constants";
 
 export default {
 	title: "FormFields/FormFieldDateField",
@@ -19,6 +21,13 @@ export const Playground = (): ReactElement => {
 	const disabled = boolean("Disabled", false);
 	const required = boolean("Required", false);
 	const showTime = boolean("Show time", false);
+	const minDateStr = text("Minimum Date", "");
+
+	const minDate = minDateStr && textIsValidDate(minDateStr, DATE_FORMAT_FULL) ? new Date(
+		Number(minDateStr.split("/")[2]),
+		Number(minDateStr.split("/")[1]) - 1,
+		Number(minDateStr.split("/")[0])
+	) : undefined;
 
 	const fields = useMemo(
 		(): FieldDef[] => [
@@ -31,11 +40,12 @@ export const Playground = (): ReactElement => {
 				helperText,
 				instructionText,
 				inputSettings: {
-					showTime
+					showTime,
+					minDate
 				}
 			}
 		],
-		[label, required, disabled, helperText, instructionText, showTime]
+		[label, required, disabled, helperText, instructionText, showTime, minDate]
 	);
 
 	return (

--- a/src/forms/FormFieldDate/DateField/DateFieldTypes.tsx
+++ b/src/forms/FormFieldDate/DateField/DateFieldTypes.tsx
@@ -5,6 +5,11 @@ export type DateFieldInputSettings = {
 	 * Value to trigger time field
 	 */
 	showTime?: boolean;
+	/**
+	 * The minimum date to allow,
+	 * defaults to 1st January 1900
+	 */
+	minDate?: Date
 };
 
 export type DateData = Date;

--- a/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
@@ -145,7 +145,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 								type: "",
 								inputSettings: {
 									placeholder: DATE_FORMAT_FULL_PLACEHOLDER,
-									minDate: fieldDef?.inputSettings.minDate
+									minDate: fieldDef?.inputSettings?.minDate
 								},
 								required: fieldDef?.required,
 							}}

--- a/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
@@ -144,7 +144,8 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 								label: "",
 								type: "",
 								inputSettings: {
-									placeholder: DATE_FORMAT_FULL_PLACEHOLDER
+									placeholder: DATE_FORMAT_FULL_PLACEHOLDER,
+									minDate: fieldDef?.inputSettings.minDate
 								},
 								required: fieldDef?.required,
 							}}

--- a/src/forms/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/src/forms/FormFieldDate/DatePicker/DatePicker.tsx
@@ -50,6 +50,7 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 					PopperProps={{
 						sx: popperSx,
 					}}
+					minDate={fieldDef?.inputSettings?.minDate}
 				/>
 			</DatePickerWrapper>
 		</LocalizationProvider>

--- a/src/forms/FormFieldDate/DatePicker/DatePickerTypes.tsx
+++ b/src/forms/FormFieldDate/DatePicker/DatePickerTypes.tsx
@@ -2,4 +2,5 @@ import { MosaicFieldProps } from "@root/components/Field/FieldTypes";
 
 export interface DatePickerProps extends Omit<MosaicFieldProps, "onChange"> {
   onChange?: (date: Date, keyboardInputValue?: string) => void;
+  minDate?: Date
 }


### PR DESCRIPTION
This PR adds support for a custom `Datepicker` minimum date. By default, MUI sets this minimum date to 01/01/1900, but setting this prop will allow for it to be earlier or later.