### PR TITLE
MOS-1125 Improve FormFieldAddress UI/UX

### DIFF
--- a/src/components/Form/stories/Playground.stories.tsx
+++ b/src/components/Form/stories/Playground.stories.tsx
@@ -496,6 +496,11 @@ export const Playground = (): ReactElement => {
 					]
 				},
 				{
+					name: "address",
+					type: "address",
+					label: "Address",
+				},
+				{
 					name: "imageUpload",
 					label: "Image Upload example",
 					type: "imageUpload",
@@ -602,7 +607,7 @@ export const Playground = (): ReactElement => {
 					[["textField"], ["check"]],
 					// row 2
 					[["chipSelect"], ["dropdownSingle"]],
-					[["table"]],
+					[["address"], ["table"]],
 					// row 3
 					[["phoneSelect"], ["radio"]]
 				]

--- a/src/forms/FormFieldAddress/Address.styled.tsx
+++ b/src/forms/FormFieldAddress/Address.styled.tsx
@@ -12,13 +12,12 @@ export const AddAddressWrapper = styled.div`
   width: 300px;
 `;
 
-export const FlexContainer = styled.div`
-  border-style: solid;
-  border-color: ${theme.newColors.grey2["100"]};
-  border-width: 2px;
-	padding: 0.5rem;
-
-  flex-grow: 1;
-  width: 600px;
-  max-width: 100%;
+export const AddressItems = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
 `;
+
+export const Footer = styled.div`
+  margin-top: 16px;
+`

--- a/src/forms/FormFieldAddress/Address.styled.tsx
+++ b/src/forms/FormFieldAddress/Address.styled.tsx
@@ -19,5 +19,5 @@ export const AddressItems = styled.div`
 `;
 
 export const Footer = styled.div`
-  margin-top: 16px;
+  margin-bottom: 16px;
 `

--- a/src/forms/FormFieldAddress/Address.styled.tsx
+++ b/src/forms/FormFieldAddress/Address.styled.tsx
@@ -13,29 +13,12 @@ export const AddAddressWrapper = styled.div`
 `;
 
 export const FlexContainer = styled.div`
-  display: flex;
-  flex-wrap: wrap;
+  border-style: solid;
+  border-color: ${theme.newColors.grey2["100"]};
+  border-width: 2px;
+	padding: 0.5rem;
 
-  & > :not(:last-child) {
-    margin-right: 25px;
-  }
-
-  & > * {
-    margin-bottom: 20px;
-  }
-
-  @media (min-width: 1440px) {
-    & > :not(:last-child) {
-      margin-right: 80px;
-    }
-  }
-
-  @media (max-width: ${theme.breakpoints.mobile}) {
-    & > :not(:last-child) {
-      margin-bottom: 20px;
-      margin-right: 0px;
-    }
-    display: flex;
-    flex-direction: column;
-  }
+  flex-grow: 1;
+  width: 600px;
+  max-width: 100%;
 `;

--- a/src/forms/FormFieldAddress/FormFieldAddress.tsx
+++ b/src/forms/FormFieldAddress/FormFieldAddress.tsx
@@ -7,7 +7,7 @@ import Button from "@root/components/Button";
 import Drawer from "@root/components/Drawer";
 
 // Styles
-import { AddAddressWrapper, FlexContainer } from "./Address.styled";
+import { FlexContainer } from "./Address.styled";
 
 // Utils
 import AddressCard from "./AddressCard";
@@ -187,8 +187,33 @@ const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSe
 	return (
 		<div>
 			<FlexContainer>
+				{value ? (
+					<div style={{display: "flex", flexWrap: "wrap", gap: 16}}>
+						{value.map((address, idx) => (
+							<AddressCard
+								key={`${idx}`}
+								address={address}
+								addressIndex={idx}
+								onEdit={showEditModal}
+								disabled={fieldDef.disabled}
+								onRemoveAddress={removeAddressHandler}
+							/>
+						))}
+					</div>
+				) : (
+					<div style={{
+						width: 300,
+						backgroundColor: "#fafafa",
+						color: "#444",
+						fontStyle: "italic",
+						padding: "24px 16px 24px 24px",
+						fontSize: 14
+					}}>
+						No address provided
+					</div>
+				)}
 				{(!fieldDef.disabled || isEmpty(value)) && (
-					<AddAddressWrapper>
+					<div style={{marginTop: "0.5rem"}}>
 						<Button
 							disabled={addressTypes?.length === 0 ? true : fieldDef.disabled}
 							color="gray"
@@ -196,19 +221,8 @@ const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSe
 							label="ADD ADDRESS"
 							onClick={addAddressHandler}
 						></Button>
-					</AddAddressWrapper>
+					</div>
 				)}
-				{value &&
-					value.map((address, idx) => (
-						<AddressCard
-							key={`${idx}`}
-							address={address}
-							addressIndex={idx}
-							onEdit={showEditModal}
-							disabled={fieldDef.disabled}
-							onRemoveAddress={removeAddressHandler}
-						/>
-					))}
 			</FlexContainer>
 			<Drawer open={open} onClose={handleClose}>
 				<AddressDrawer

--- a/src/forms/FormFieldAddress/FormFieldAddress.tsx
+++ b/src/forms/FormFieldAddress/FormFieldAddress.tsx
@@ -6,14 +6,12 @@ import AddressDrawer from "./AddressDrawer";
 import Button from "@root/components/Button";
 import Drawer from "@root/components/Drawer";
 
-// Styles
-import { FlexContainer } from "./Address.styled";
-
 // Utils
 import AddressCard from "./AddressCard";
 import { MosaicFieldProps } from "@root/components/Field";
 import { AddressFieldInputSettings, AddressData } from ".";
 import { isEmpty } from "lodash";
+import { AddressItems, Footer } from "./Address.styled";
 
 const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSettings, AddressData>): ReactElement => {
 	const {
@@ -185,45 +183,32 @@ const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSe
 	};
 
 	return (
-		<div>
-			<FlexContainer>
-				{value ? (
-					<div style={{display: "flex", flexWrap: "wrap", gap: 16}}>
-						{value.map((address, idx) => (
-							<AddressCard
-								key={`${idx}`}
-								address={address}
-								addressIndex={idx}
-								onEdit={showEditModal}
-								disabled={fieldDef.disabled}
-								onRemoveAddress={removeAddressHandler}
-							/>
-						))}
-					</div>
-				) : (
-					<div style={{
-						width: 300,
-						backgroundColor: "#fafafa",
-						color: "#444",
-						fontStyle: "italic",
-						padding: "24px 16px 24px 24px",
-						fontSize: 14
-					}}>
-						No address provided
-					</div>
-				)}
-				{(!fieldDef.disabled || isEmpty(value)) && (
-					<div style={{marginTop: "0.5rem"}}>
-						<Button
-							disabled={addressTypes?.length === 0 ? true : fieldDef.disabled}
-							color="gray"
-							variant="outlined"
-							label="ADD ADDRESS"
-							onClick={addAddressHandler}
-						></Button>
-					</div>
-				)}
-			</FlexContainer>
+		<>
+			{!!value && (
+				<AddressItems>
+					{value.map((address, idx) => (
+						<AddressCard
+							key={`${idx}`}
+							address={address}
+							addressIndex={idx}
+							onEdit={showEditModal}
+							disabled={fieldDef.disabled}
+							onRemoveAddress={removeAddressHandler}
+						/>
+					))}
+				</AddressItems>
+			)}
+			{(!fieldDef.disabled || isEmpty(value)) && addressTypes?.length > 0 && (
+				<Footer>
+					<Button
+						disabled={fieldDef.disabled}
+						color="gray"
+						variant="outlined"
+						label="ADD ADDRESS"
+						onClick={addAddressHandler}
+					/>
+				</Footer>
+			)}
 			<Drawer open={open} onClose={handleClose}>
 				<AddressDrawer
 					googleMapsApiKey={fieldDef.inputSettings.googleMapsApiKey}
@@ -244,7 +229,7 @@ const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSe
 					getOptionsStates={fieldDef.inputSettings?.getOptionsStates}
 				/>
 			</Drawer>
-		</div>
+		</>
 	);
 };
 

--- a/src/forms/FormFieldAddress/FormFieldAddress.tsx
+++ b/src/forms/FormFieldAddress/FormFieldAddress.tsx
@@ -184,6 +184,17 @@ const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSe
 
 	return (
 		<>
+			{(!fieldDef.disabled || isEmpty(value)) && addressTypes?.length > 0 && (
+				<Footer>
+					<Button
+						disabled={fieldDef.disabled}
+						color="gray"
+						variant="outlined"
+						label="ADD ADDRESS"
+						onClick={addAddressHandler}
+					/>
+				</Footer>
+			)}
 			{!!value && (
 				<AddressItems>
 					{value.map((address, idx) => (
@@ -197,17 +208,6 @@ const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSe
 						/>
 					))}
 				</AddressItems>
-			)}
-			{(!fieldDef.disabled || isEmpty(value)) && addressTypes?.length > 0 && (
-				<Footer>
-					<Button
-						disabled={fieldDef.disabled}
-						color="gray"
-						variant="outlined"
-						label="ADD ADDRESS"
-						onClick={addAddressHandler}
-					/>
-				</Footer>
 			)}
 			<Drawer open={open} onClose={handleClose}>
 				<AddressDrawer


### PR DESCRIPTION
This PR modifies the `FormFieldAddress` field to bring the style more in line with the existing repeatable field components. It removes the large grey wasted space surrounding the "Add Address" button and displays the button below the address items. It also removes the button entirely when the address item limit has been reached.