### PR TITLE
MOS 1053 Form status and aria attributes

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -215,7 +215,7 @@ const Form = (props: FormProps) => {
 					ref={formContainerRef}
 					className={state.disabled ? "disabled" : ""}
 					aria-busy={isBusy ? "true" : "false"}
-					aria-role="form"
+					role="form"
 					aria-label={title}
 				>
 					<StyledForm autoComplete="off">

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -97,7 +97,6 @@ const Form = (props: FormProps) => {
 	useEffect(() => {
 		const loadFormValues = async () => {
 			let values: MosaicObject;
-			await dispatch(formActions.disableForm({ disabled: true }));
 
 			values = getFormValues ? await getFormValues() : undefined;
 

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -97,6 +97,7 @@ const Form = (props: FormProps) => {
 	useEffect(() => {
 		const loadFormValues = async () => {
 			let values: MosaicObject;
+			await dispatch(formActions.disableForm({ disabled: true }));
 
 			values = getFormValues ? await getFormValues() : undefined;
 
@@ -203,6 +204,8 @@ const Form = (props: FormProps) => {
 		state.submitWarning
 	);
 
+	const isBusy = state.disabled || Object.values(state.busyFields).filter(Boolean).length;
+
 	return (
 		<>
 			<ViewProvider value={view}>
@@ -211,6 +214,9 @@ const Form = (props: FormProps) => {
 					style={{ position: "relative", height: "100%" }}
 					ref={formContainerRef}
 					className={state.disabled ? "disabled" : ""}
+					aria-busy={isBusy ? "true" : "false"}
+					aria-role="form"
+					aria-label={title}
 				>
 					<StyledForm autoComplete="off">
 						{title &&

--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -178,7 +178,7 @@ export function useForm(): UseFormReturn {
 			validating: {},
 			custom: {},
 			validForm: false,
-			disabled: false,
+			disabled: true,
 			touched: {},
 			mounted: {},
 			busyFields: {},


### PR DESCRIPTION
This PR changes the form controller's initial state to make the form disabled by default. It also adds `aria-*` labels for both accessibility and ease of testing.