### PR TITLE
MOS 1088 Upload catch

### DIFF
--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -1023,7 +1023,7 @@ This field implements the [**FieldDef**](#generic-field-props-fielddef) interfac
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| **`onFileAdd`** | `(addedData: OnFileAddData) => Promise<void>` | required - Callback function executed per uploaded file. |
+| **`onFileAdd`** | `(addedData: OnFileAddData) => Promise<void>` | required - Callback function executed per uploaded file.<br /><br />If an error is thrown in this callback, its message will be displayed for the uploaded item |
 | **`onFileDelete`** | `({id: string or number}) => Promise<void>` | required - Callback function executed when the user deletes an uploaded file. |
 | **`limit`** | `number` | optional - Limits the amount of files users can upload. If not passed users can add as many files as needed. |
 
@@ -1034,7 +1034,7 @@ This field implements the [**FieldDef**](#generic-field-props-fielddef) interfac
 | **`file`** | `File` | required - File uploaded by the user. |
 | **`onChunkComplete`** | `({percent: number}) => Promise<void>` | required - Callback function that allows the file cards to update their progress spinner. The expected percent should be a value between 0 and 1. |
 | **`onUploadComplete`** | `(data: UploadData) => Promise<void>` | required - Callback function that allows the component to update the file cards with the newest data |
-| **`onError`** | `(message: string) => Promise<void>` | required - Callback function that allows the file cards to update their style and error message. |
+| ❌ **`onError`** | `(message: string) => Promise<void>` | required - Callback function that allows the file cards to update their style and error message.<br /><br />**DEPRECATED** - Throw an error within `onFileAdd` callback instead. |
 
 ### How to use in a form?
 

--- a/src/forms/FormFieldUpload/FormFieldUpload.stories.tsx
+++ b/src/forms/FormFieldUpload/FormFieldUpload.stories.tsx
@@ -12,6 +12,7 @@ import Form, { formActions, useForm } from "@root/components/Form";
 import { renderButtons } from "@root/utils/storyUtils";
 import { nanoid } from "nanoid";
 import { defaultValues } from "./uploadUtils";
+import { UploadFieldInputSettings } from "./FormFieldUploadTypes";
 
 export default {
 	title: "FormFields/FormFieldUpload",
@@ -45,7 +46,7 @@ export const Playground = (): ReactElement => {
 		mockDB ? resetForm() : setLoadReady(false);
 	}, [mockDB]);
 
-	const onFileAdd = async ({ file, onChunkComplete, onUploadComplete, onError }) => {
+	const onFileAdd: UploadFieldInputSettings["onFileAdd"] = async ({ file, onChunkComplete, onUploadComplete }) => {
 		for (let i = 0; i < 10; i++) {
 			await new Promise(resolve => setTimeout(() =>
 				resolve(
@@ -55,8 +56,7 @@ export const Playground = (): ReactElement => {
 		}
 
 		if (error) {
-			await onError("File size exceeded");
-			return;
+			throw new Error("File size exceeded");
 		}
 
 		await onUploadComplete({

--- a/src/forms/FormFieldUpload/FormFieldUpload.stories.tsx
+++ b/src/forms/FormFieldUpload/FormFieldUpload.stories.tsx
@@ -31,7 +31,7 @@ export const Playground = (): ReactElement => {
 	const helperText = text("Helper text", "Helper text");
 	const instructionText = text("Instruction text", "Instruction text");
 	const label = text("Label", "Label");
-	const error = boolean("Trigger errors when loading", true);
+	const error = boolean("Trigger errors when loading", false);
 	const mockDB = boolean("Mock get files from DB", false);
 	const timeToLoad = number("Time to load (seconds)", 2);
 
@@ -54,7 +54,7 @@ export const Playground = (): ReactElement => {
 			);
 		}
 
-		if (error && Math.random() < 0.3) {
+		if (error) {
 			await onError("File size exceeded");
 			return;
 		}
@@ -63,7 +63,7 @@ export const Playground = (): ReactElement => {
 			id: nanoid(),
 			name: file.name,
 			size: `${file.size} bytes`,
-			url: Math.random() < 0.7 ? URL.createObjectURL(file) : undefined
+			url: URL.createObjectURL(file)
 		});
 	};
 
@@ -102,7 +102,8 @@ export const Playground = (): ReactElement => {
 			helperText,
 			instructionText,
 			limit,
-			timeToLoad
+			timeToLoad,
+			error
 		]
 	);
 

--- a/src/forms/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/forms/FormFieldUpload/FormFieldUpload.tsx
@@ -189,12 +189,17 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 		setPendingFiles({...pendingFiles, ...transformedFiles});
 
 		for (const [key, file] of Object.entries(transformedFiles) as [string, TransformedFile][]) {
-			onFileAdd({
-				file: file?.rawData,
-				onChunkComplete: ({ percent }) => onChunkComplete({uuid: key, percent}),
-				onUploadComplete: (data) => onUploadComplete({uuid: key, data}),
-				onError: (message) => onError({uuid: key, message}),
-			})
+			try {
+				await onFileAdd({
+					file: file?.rawData,
+					onChunkComplete: ({ percent }) => onChunkComplete({uuid: key, percent}),
+					onUploadComplete: (data) => onUploadComplete({uuid: key, data}),
+					onError: (message) => onError({uuid: key, message}),
+				})
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				onError({ uuid: key, message });
+			}
 		}
 	};
 

--- a/src/forms/FormFieldUpload/FormFieldUploadTypes.ts
+++ b/src/forms/FormFieldUpload/FormFieldUploadTypes.ts
@@ -27,6 +27,9 @@ type OnFileAddData = {
 	file: File;
 	onChunkComplete: (data: {percent: number}) => Promise<void>;
 	onUploadComplete: (data: UploadData) => Promise<void>;
+	/**
+	 * @deprecated - Throw an error within `onFileAdd` callback instead.
+	 */
 	onError: OnError;
 }
 


### PR DESCRIPTION
This PR adds support for throwing errors on `onFileAdd` and deprecates the `onError` callback