### PR TITLE
MOS-1169 Advanced selection limit

### DIFF
--- a/automation_testing/pages/FormFields/FormFieldCheckbox/FormFieldCheckboxPage.ts
+++ b/automation_testing/pages/FormFields/FormFieldCheckbox/FormFieldCheckboxPage.ts
@@ -8,7 +8,7 @@ export class FormFieldCheckboxPage extends BasePage {
 
 	readonly page: Page;
 	readonly regularCheckboxButton: Locator;
-	readonly disabledCheckboxButton: Locator;
+	readonly disableCheckbox: Locator;
 	readonly checkboxLabel: Locator;
 	readonly regularCheckboxLocator: Locator;
 	readonly fromDBCheckboxLocator: Locator;
@@ -17,7 +17,7 @@ export class FormFieldCheckboxPage extends BasePage {
 		super(page);
 		this.page = page;
 		this.regularCheckboxButton = page.locator(".listItem").nth(0);
-		this.disabledCheckboxButton = page.locator("#disabledCheckbox");
+		this.disableCheckbox = page.locator("#disabledCheckbox");
 		this.checkboxLabel = page.locator("label[data-testid='label-test-id']");
 		this.regularCheckboxLocator = page.locator("#checkbox");
 		this.fromDBCheckboxLocator = page.locator("#checkboxFromDB");

--- a/automation_testing/tests/FormFields/FormFieldAddress/FormFieldAddress.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldAddress/FormFieldAddress.spec.ts
@@ -139,6 +139,6 @@ test.describe.parallel("FormFields - FormFieldAddress - Playground", () => {
 
 	test("Validate that button is disabled.", async () => {
 		await ffAddressPage.visit(ffAddressPage.page_path, [knob.knobDisabled + true]);
-		await expect(ffAddressPage.addAddressButton).not.toBeVisible();
+		await expect(ffAddressPage.addAddressButton).toBeDisabled();
 	});
 });

--- a/automation_testing/tests/FormFields/FormFieldAdvancedSelection/FormFieldAdvancedSelectionPlayground.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldAdvancedSelection/FormFieldAdvancedSelectionPlayground.spec.ts
@@ -18,7 +18,7 @@ test.describe.parallel("FormFields - FormFieldAdvancedSelection - Playground", (
 	});
 
 	test.afterAll(async ({ browser }) => {
-		browser.close;
+		// browser.close;
 	});
 
 	test("Validate placeholder text has grey3 as Color.", async () => {
@@ -46,6 +46,6 @@ test.describe.parallel("FormFields - FormFieldAdvancedSelection - Playground", (
 
 	test("Validate the Disabled Advanced Selection.", async () => {
 		await ffAdvancedSelectionPage.visit(ffAdvancedSelectionPage.page_path, [knob.knobDisabled + true]);
-		expect(await ffAdvancedSelectionPage.advancedSelectionLocator.textContent()).toContain("—");
+		await expect(ffAdvancedSelectionPage.advancedSelectionButton).toBeDisabled();
 	});
 });

--- a/automation_testing/tests/FormFields/FormFieldCheckbox/FormFieldCheckbox.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldCheckbox/FormFieldCheckbox.spec.ts
@@ -16,13 +16,13 @@ test.describe.parallel("FormFields - FormFieldsCheckbox - Kitchen Sink", () => {
 		browser.close;
 	});
 
-	test("Validate Regular Radio Button.", async () => {
+	test("Validate Regular Checkbox.", async () => {
 		const selectedOption = await formFieldCheckboxPage.selectRandomCheckboxButton();
 		await expect(formFieldCheckboxPage.regularCheckboxButton.locator("[data-testid='label-test-id']").nth(selectedOption)).toBeChecked();
 	});
 
-	test("Validate Disabled Radio Button only displays a dash.", async () => {
-		expect(await formFieldCheckboxPage.disabledCheckboxButton.textContent()).toContain("—");
+	test("Validate Disabled Checkbox displays disabled inputs", async () => {
+		await expect(formFieldCheckboxPage.disableCheckbox.locator("input").first()).toBeDisabled();
 	});
 
 	test("Validate that the empty value is saved correctly.", async () => {

--- a/automation_testing/tests/FormFields/FormFieldChipSingleSelect/FormFieldChipSingleSelect.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldChipSingleSelect/FormFieldChipSingleSelect.spec.ts
@@ -32,10 +32,6 @@ test.describe.parallel("FormFields - FormFieldChipSingleSelect - Kitchen Sink", 
 		await ffChipSingleSelectPage.saveBtn.click();
 	});
 
-	test("Validate Disabled the Disabled Regular Chip Single Select only displays a dash.", async () => {
-		expect(await ffChipSingleSelectPage.disabledChipSingleSelectDiv.textContent()).toContain("—");
-	});
-
 	test("Validate the selection Required Chip Single Select", async () => {
 		page.once("dialog", async dialog => {
 			expect(dialog.message()).toContain(requiredOptionLabel);

--- a/automation_testing/tests/FormFields/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.spec.ts
@@ -22,10 +22,6 @@ test.describe.parallel("FormFields - FormFieldDropdownSingleSelection - Kitchen 
 		expect(await formFieldDropdownSingleSelectionPage.regularDropdownInput.inputValue()).toBe(option);
 	});
 
-	test("Validate the Disabled Field.", async () => {
-		expect(await formFieldDropdownSingleSelectionPage.disabledField.textContent()).toContain("—");
-	});
-
 	test("Validate xs dropdown size is valid", async () => {
 		expect(await formFieldDropdownSingleSelectionPage.getElementWidth(formFieldDropdownSingleSelectionPage.xsSizeDropdownDiv, true)).toBe(100);
 	});

--- a/automation_testing/tests/FormFields/FormFieldImageUpload/FormFieldImageUpload.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldImageUpload/FormFieldImageUpload.spec.ts
@@ -42,7 +42,7 @@ test.describe.parallel("FormFields - FormFieldImageUpload - Kitchen Sink", () =>
 	});
 
 	test("Validate Disabled Image upload.", async () => {
-		await expect(ffImageUploadPage.disabledImageUploadButton).not.toBeVisible();
+		await expect(ffImageUploadPage.disabledImageUploadButton).toBeDisabled();
 	});
 
 	test("Validate saving Image Upload with menu options and without set Focus", async () => {

--- a/automation_testing/tests/FormFields/FormFieldMapCoordinates/FormFieldMapCoordinates.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldMapCoordinates/FormFieldMapCoordinates.spec.ts
@@ -64,6 +64,6 @@ test.describe.parallel("FormFields - FormFieldMapCoordinates - Kitchen Sink", ()
 
 	test("Validate that button is disabled.", async () => {
 		await ffMapCoordinatesPage.visit(ffMapCoordinatesPage.playground_page_path, [knob.knobDisabled + true]);
-		await expect(ffMapCoordinatesPage.mapWithoutAddressAndAutocoordinatesDisabledButton).not.toBeVisible();
+		await expect(ffMapCoordinatesPage.mapWithoutAddressAndAutocoordinatesDisabledButton).toBeDisabled();
 	});
 });

--- a/automation_testing/tests/FormFields/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.spec.ts
@@ -70,14 +70,6 @@ test.describe.parallel("FormFields - FormFieldPhoneSelectionDropdown - Kitchen S
 		await ffPhoneSelectionDropdownPage.saveBtn.dblclick();
 	});
 
-	test("Validate all the Flag Dropdown have simplyGrey as border color.", async () => {
-		const expectColor = theme.newColors.simplyGrey["100"];
-		const numberOfBDropdown = await ffPhoneSelectionDropdownPage.flagDropdown.count();
-		for (let i = 0; i < numberOfBDropdown; i++) {
-			expect(await ffPhoneSelectionDropdownPage.getSpecificBorderFromElement(ffPhoneSelectionDropdownPage.flagDropdown.nth(i), "right")).toContain(expectColor);
-		}
-	});
-
 	test("Validate phone fields have grey1 as background color.", async () => {
 		const expectedColor = theme.newColors.grey1["100"];
 		expect(await ffPhoneSelectionDropdownPage.getBackgroundColorFromElement(ffPhoneSelectionDropdownPage.regularPhoneField)).toBe(expectedColor);

--- a/automation_testing/tests/FormFields/FormFieldRadio/FormFieldRadio.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldRadio/FormFieldRadio.spec.ts
@@ -27,6 +27,6 @@ test.describe.parallel("FormFields - FormFieldRadio - Kitchen Sink", () => {
 	});
 
 	test("Validate Disabled Radio Button", async () => {
-		expect(await formFieldRadioPage.disabledRadioButton.textContent()).toContain("—");
+		await expect(formFieldRadioPage.disabledRadioButton.locator("input").first()).toBeDisabled();
 	});
 });

--- a/automation_testing/tests/FormFields/FormFieldTextEditor/FormFieldTextEditor.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldTextEditor/FormFieldTextEditor.spec.ts
@@ -44,7 +44,7 @@ test.describe.parallel("FormFields - FormFieldTextEditor - Kitchen Sink", () => 
 	});
 
 	test("Validate the Disabled Text editor.", async () => {
-		expect(await ffTextEditorPage.disabledTextEditor.textContent()).toContain("—");
+		expect(await ffTextEditorPage.disabledTextEditor.textContent()).toContain("Disabled text editor");
 	});
 
 	test("Validate that the provided number is saved when submitted.", async ({ page }) => {

--- a/automation_testing/tests/FormFields/FormFieldUpload/FormFieldUpload.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldUpload/FormFieldUpload.spec.ts
@@ -30,7 +30,7 @@ test.describe.parallel("FormFields - FormFieldUpload - Playground", () => {
 
 	test("Validate that the upload button is disabled when activating the disabled knob.", async () => {
 		await ffUpload.visit(ffUpload.page_path, [commonKnobs.knobDisabled + "true"]);
-		await expect(ffUpload.uploadFilesButton).toHaveCount(0);
+		await expect(ffUpload.uploadFilesButton).toBeDisabled();
 	});
 
 	test("Validate that no more files are allowed to upload once reached the limit.", async () => {

--- a/src/components/DataView/DataView.stories.tsx
+++ b/src/components/DataView/DataView.stories.tsx
@@ -421,6 +421,7 @@ export const Playground = (): ReactElement => {
 	const draggableRows = boolean("draggableRows", true);
 	const showCheckboxes = boolean("Show Checkboxes", true);
 	const preloadedActiveFilters = boolean("Preload active filters", false);
+	const disabled = boolean("Disabled", false);
 	const defaultView: DataViewProps["savedView"] = {
 		...rootDefaultView,
 		state: {
@@ -737,7 +738,8 @@ export const Playground = (): ReactElement => {
 			}, ARTIFICIAL_DELAY);
 
 			setState({...state, loading: true});
-		} : undefined
+		} : undefined,
+		disabled
 	};
 
 	return (

--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -262,6 +262,7 @@ function DataView (props: DataViewProps): ReactElement  {
 							filters={props.filters}
 							activeFilters={props.activeFilters}
 							onActiveFiltersChange={props.onActiveFiltersChange}
+							disabled={props.disabled}
 						/>
 					</div>
 			}
@@ -292,6 +293,7 @@ function DataView (props: DataViewProps): ReactElement  {
 							checkedAllPages={props.checkedAllPages}
 							allChecked={allChecked}
 							anyChecked={anyChecked}
+							disabled={props.disabled}
 						/>
 					</div>
 			}
@@ -309,6 +311,7 @@ function DataView (props: DataViewProps): ReactElement  {
 					sort={props.sort}
 					data={props.data}
 					additionalActions={props.additionalActions}
+					disabled={props.disabled}
 					primaryActions={props.primaryActions}
 					activeColumns={props.activeColumns}
 					gridColumnsMap={props.gridColumnsMap}

--- a/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRow.tsx
+++ b/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRow.tsx
@@ -27,13 +27,14 @@ function DataViewActionsButtonRow(props: DataViewActionsButtonRowProps) {
 			return (
 				<Button
 					{ ...buttonArgs }
+					disabled={buttonArgs.disabled === undefined ? props.disabled : buttonArgs.disabled}
 					key={`primary_${name}`}
 					attrs={{ "data-mosaic-id" : `action_primary_${name}` }}
 					onClick={newOnClick}
 				/>
 			)
 		});
-	}, [props.primaryActions, props.originalRowData]);
+	}, [props.primaryActions, props.originalRowData, props.disabled]);
 
 	const additionalActions = useMemo(() => {
 		if (props.additionalActions === undefined) { return []; }
@@ -55,6 +56,7 @@ function DataViewActionsButtonRow(props: DataViewActionsButtonRowProps) {
 				mIcon={props.activeDisplay && MoreVertIcon}
 				attrs={{ "data-mosaic-id" : "additional_actions_dropdown" }}
 				tooltip="More actions"
+				disabled={props.disabled}
 				menuItems={additionalActions.map(action => {
 					const {
 						name,
@@ -75,7 +77,7 @@ function DataViewActionsButtonRow(props: DataViewActionsButtonRowProps) {
 				})}
 			/>
 		]
-	}, [props.additionalActions, props.originalRowData]);
+	}, [props.additionalActions, props.originalRowData, props.disabled]);
 
 	// concat the buttons into a single row so that we have a single child allowing caching of the ButtonRow
 	const buttons = useMemo(() => {

--- a/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRowTypes.ts
+++ b/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRowTypes.ts
@@ -1,4 +1,4 @@
-import { DataViewAction, DataViewAdditionalAction } from "../DataViewTypes";
+import { DataViewAction, DataViewAdditionalAction, DataViewProps } from "../DataViewTypes";
 import { MosaicObject } from "../../../types";
 
 export type DataViewControlViewOption = "list" | "grid";
@@ -6,6 +6,7 @@ export type DataViewControlViewOption = "list" | "grid";
 export interface DataViewActionsButtonRowProps {
 	primaryActions: DataViewAction[];
 	additionalActions: DataViewAdditionalAction[];
+	disabled?: DataViewProps["disabled"]
 	originalRowData: MosaicObject;
 	activeDisplay?: DataViewControlViewOption;
 }

--- a/src/components/DataView/DataViewActionsRow/DataViewActionsRow.tsx
+++ b/src/components/DataView/DataViewActionsRow/DataViewActionsRow.tsx
@@ -52,6 +52,7 @@ const DataViewActionsRow = (props: DataViewActionsRowProps): ReactElement => {
 								checked={allChecked}
 								indeterminate={!allChecked && anyChecked}
 								onClick={onCheckAllClick}
+								disabled={props.disabled}
 							/>
 						}
 						{

--- a/src/components/DataView/DataViewActionsRow/DataViewActionsRowTypes.ts
+++ b/src/components/DataView/DataViewActionsRow/DataViewActionsRowTypes.ts
@@ -29,4 +29,5 @@ export interface DataViewActionsRowProps {
 	columns?: DataViewColumn[];
 	anyChecked?: boolean;
 	allChecked?: boolean;
+	disabled?: DataViewProps["disabled"]
 }

--- a/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
+++ b/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
@@ -91,6 +91,7 @@ function DataViewDisplayGrid(props: DataViewDisplayGridProps) {
 											additionalActions={props.additionalActions}
 											originalRowData={ row }
 											activeDisplay="grid"
+											disabled={props.disabled}
 										/>
 									</div>
 								</div>

--- a/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGridTypes.ts
+++ b/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGridTypes.ts
@@ -19,4 +19,5 @@ export interface DataViewDisplayGridProps {
 	anyChecked?: boolean;
 	allChecked?: boolean;
 	showBulkAll?: boolean;
+	disabled: DataViewProps["disabled"]
 }

--- a/src/components/DataView/DataViewDisplayList/DataViewDisplayList.tsx
+++ b/src/components/DataView/DataViewDisplayList/DataViewDisplayList.tsx
@@ -47,6 +47,7 @@ function DataViewDisplayList(props: DataViewDisplayListProps) {
 				anyChecked={props.anyChecked}
 				showBulkAll={props.showBulkAll}
 				hasActions={hasActions}
+				disabled={props.disabled}
 			/>
 			<DataViewTBody
 				checked={props.checked}
@@ -56,6 +57,7 @@ function DataViewDisplayList(props: DataViewDisplayListProps) {
 				transformedData={transformedData}
 				bulkActions={props.bulkActions}
 				additionalActions={props.additionalActions}
+				disabled={props.disabled}
 				primaryActions={props.primaryActions}
 				onCheckboxClick={props.onCheckboxClick}
 				onReorder={props.onReorder}

--- a/src/components/DataView/DataViewDisplayList/DataViewDisplayListTypes.ts
+++ b/src/components/DataView/DataViewDisplayList/DataViewDisplayListTypes.ts
@@ -16,6 +16,7 @@ export interface DataViewDisplayListProps {
 	onCheckAllPagesClick?: () => void;
 	onColumnsChange?: DataViewProps["onColumnsChange"];
 	additionalActions?: DataViewProps["additionalActions"];
+	disabled?: DataViewProps["disabled"];
 	primaryActions?: DataViewProps["primaryActions"];
 	onCheckboxClick?: () => void;
 	activeColumnObjs: DataViewProps["columns"];

--- a/src/components/DataView/DataViewTBody/DataViewTBody.tsx
+++ b/src/components/DataView/DataViewTBody/DataViewTBody.tsx
@@ -61,6 +61,7 @@ function DataViewTBody(props: DataViewTBodyProps) {
 								bulkActions={props.bulkActions}
 								primaryActions={props.primaryActions}
 								additionalActions={props.additionalActions}
+								disabled={props.disabled}
 								onCheckboxClick={props.onCheckboxClick ? onCheckboxClick(i) : undefined}
 								checked={props.checked ? props.checked[i] : false}
 								columns={props.columns}

--- a/src/components/DataView/DataViewTBody/DataViewTBodyTypes.ts
+++ b/src/components/DataView/DataViewTBody/DataViewTBodyTypes.ts
@@ -9,6 +9,7 @@ export interface DataViewTBodyProps {
 	bulkActions?: DataViewProps["bulkActions"];
 	primaryActions?: DataViewProps["primaryActions"];
 	additionalActions?: DataViewProps["additionalActions"];
+	disabled?: DataViewProps["disabled"];
 	checked?: DataViewProps["checked"];
 	columns: DataViewProps["columns"];
 	hasActions: boolean;

--- a/src/components/DataView/DataViewTHead/DataViewTHead.tsx
+++ b/src/components/DataView/DataViewTHead/DataViewTHead.tsx
@@ -115,6 +115,7 @@ function DataViewTHead(props: DataViewTHeadProps) {
 							checked={props.allChecked}
 							indeterminate={!props.allChecked && props.anyChecked}
 							onClick={props.onCheckAllClick}
+							disabled={props.disabled}
 						/>
 					</StyledTh>
 				}

--- a/src/components/DataView/DataViewTHead/DataViewTHeadTypes.ts
+++ b/src/components/DataView/DataViewTHead/DataViewTHeadTypes.ts
@@ -19,4 +19,5 @@ export interface DataViewTHeadProps {
 	anyChecked?: boolean;
 	allChecked?: boolean;
 	showBulkAll?: boolean;
+	disabled?: DataViewProps["disabled"]
 }

--- a/src/components/DataView/DataViewTitleBar/DataViewTitleBar.tsx
+++ b/src/components/DataView/DataViewTitleBar/DataViewTitleBar.tsx
@@ -16,9 +16,10 @@ function DataViewTitleBar(props: DataViewTitleBarProps) {
 		return props.buttons.map((button) => {
 			const { name, ...buttonArgs } = button;
 			buttonArgs.attrs = { "data-mosaic-id": `button_${name}` };
+			buttonArgs.disabled = buttonArgs.disabled === undefined ? props.disabled : buttonArgs.disabled
 			return buttonArgs;
 		});
-	}, [props.buttons]);
+	}, [props.buttons, props.disabled]);
 
 	return (
 		<TitleBarWrapper>

--- a/src/components/DataView/DataViewTitleBar/DataViewTitleBarTypes.ts
+++ b/src/components/DataView/DataViewTitleBar/DataViewTitleBarTypes.ts
@@ -17,4 +17,5 @@ export interface DataViewTitleBarProps {
 	activeFilters?: DataViewProps["activeFilters"];
 	onActiveFiltersChange?: DataViewProps["onActiveFiltersChange"];
 	onBack?: DataViewProps["onBack"];
+	disabled?: DataViewProps["disabled"]
 }

--- a/src/components/DataView/DataViewTr/DataViewTr.tsx
+++ b/src/components/DataView/DataViewTr/DataViewTr.tsx
@@ -21,8 +21,8 @@ function DataViewTr(props: DataViewTrProps) {
 				<TableRow {...provider.draggableProps} ref={provider.innerRef} className={props.checked && "checked"}>
 					{
 						props.onReorder &&
-						<DataViewTd key="_draggable" draggableProvider={provider}>
-							<DragIndicatorIcon style={{display: "flex", color: theme.newColors.almostBlack["100"]}}/>
+						<DataViewTd key="_draggable" draggableProvider={props.disabled ? undefined : provider}>
+							<DragIndicatorIcon style={{display: "flex", color: props.disabled ? theme.colors.blackDisabled : theme.newColors.almostBlack["100"]}}/>
 						</DataViewTd>
 					}
 					{
@@ -31,6 +31,7 @@ function DataViewTr(props: DataViewTrProps) {
 							<Checkbox
 								checked={props.checked === true}
 								onClick={props.onCheckboxClick}
+								disabled={props.disabled}
 							/>
 						</DataViewTd>
 					}
@@ -40,6 +41,7 @@ function DataViewTr(props: DataViewTrProps) {
 							<DataViewActionsButtonRow
 								primaryActions={props.primaryActions}
 								additionalActions={props.additionalActions}
+								disabled={props.disabled}
 								originalRowData={props.originalRowData}
 								activeDisplay="list"
 							/>

--- a/src/components/DataView/DataViewTr/DataViewTrTypes.ts
+++ b/src/components/DataView/DataViewTr/DataViewTrTypes.ts
@@ -10,6 +10,7 @@ export interface DataViewTrProps {
 	onCheckboxClick?: React.MouseEventHandler<HTMLButtonElement>;
 	primaryActions?: DataViewProps["primaryActions"];
 	additionalActions?: DataViewProps["additionalActions"];
+	disabled?: DataViewProps["disabled"]
 	originalRowData: MosaicObject;
 	columns: DataViewProps["columns"];
 	row?: {[x: string]: any};

--- a/src/components/DataView/DataViewTypes.ts
+++ b/src/components/DataView/DataViewTypes.ts
@@ -221,6 +221,7 @@ export interface DataViewProps {
 	savedViewAllowSharedViewSave?: boolean
 	primaryActions?: DataViewAction[]
 	additionalActions?: DataViewAdditionalAction[]
+	disabled?: boolean
 	bulkActions?: DataViewBulkAction[]
 	onSortChange?: DataViewOnSortChange
 	onSkipChange?: DataViewOnSkipChange

--- a/src/components/Field/FieldTypes.tsx
+++ b/src/components/Field/FieldTypes.tsx
@@ -12,6 +12,7 @@ import { FieldDefMatrix } from "@root/forms/FormFieldMatrix";
 import { FieldDefNumberTable } from "@root/forms/FormFieldNumberTable";
 import { FieldDefPhoneSelection } from "@root/forms/FormFieldPhoneSelectionDropdown";
 import { FieldDefRadio } from "@root/forms/FormFieldRadio";
+import { FieldDefRaw } from "@root/forms/FormFieldRaw";
 import { FieldDefTable } from "@root/forms/FormFieldTable";
 import { FieldDefText } from "@root/forms/FormFieldText";
 import { FieldDefTextEditor } from "@root/forms/FormFieldTextEditor/FormFieldTextEditorTypes";
@@ -176,5 +177,6 @@ export type FieldDef =
 	| FieldDefAddress
 	| FieldDefUpload
 	| FieldDefCustom
-	| FieldDefNumberTable;
+	| FieldDefNumberTable
+	| FieldDefRaw;
 

--- a/src/components/Form/Col.tsx
+++ b/src/components/Form/Col.tsx
@@ -25,7 +25,6 @@ import FormFieldUpload from "@root/forms/FormFieldUpload";
 import { Sizes } from "@root/theme";
 import FormFieldNumberTable from "@root/forms/FormFieldNumberTable";
 import evaluateShow from "@root/utils/show/evaluateShow";
-import Blank from "@root/components/Blank";
 import RegisteredField from "../Field/RegisteredField";
 
 const StyledCol = styled.div`
@@ -193,25 +192,26 @@ const Col = (props: ColPropsTypes) => {
 					/>
 				), [value, error, onChange, currentField]);
 
-				const shouldRenderEmptyField = value === undefined && currentField.disabled
 				const shouldShow = useMemo(() => evaluateShow(currentField.show, {data: state?.data}), [currentField.show, state?.data]);
 
-				return shouldShow ? ((typeof type === "string" && componentMap[type]) ? (
-					<RegisteredField
-						key={`${name}_${i}`}
-						fieldDef={{ ...currentField, size: maxSize }}
-						value={value}
-						error={error}
-						colsInRow={colsInRow}
-						id={name}
-						name={name}
-						dispatch={dispatch}
-					>
-						{shouldRenderEmptyField ? <Blank /> : children}
-					</RegisteredField>
-				) : (
-					shouldRenderEmptyField ? <Blank /> : children
-				)) : null;
+				return shouldShow ? (
+					(typeof type === "string" && componentMap[type]) ? (
+						<RegisteredField
+							key={`${name}_${i}`}
+							fieldDef={{ ...currentField, size: maxSize }}
+							value={value}
+							error={error}
+							colsInRow={colsInRow}
+							id={name}
+							name={name}
+							dispatch={dispatch}
+						>
+							{children}
+						</RegisteredField>
+					) : (
+						children
+					)
+				) : null;
 			})}
 		</StyledCol>
 	);

--- a/src/components/Form/Col.tsx
+++ b/src/components/Form/Col.tsx
@@ -9,6 +9,7 @@ import FormFieldChipSingleSelect from "@root/forms/FormFieldChipSingleSelect";
 import FormFieldDropdownSingleSelection from "@root/forms/FormFieldDropdownSingleSelection";
 import FormFieldPhoneSelectionDropdown from "@root/forms/FormFieldPhoneSelectionDropdown";
 import FormFieldRadio from "@root/forms/FormFieldRadio";
+import FormFieldRaw from "@root/forms/FormFieldRaw";
 import FormFieldToggleSwitch from "@root/forms/FormFieldToggleSwitch";
 import { FieldDef } from "@root/components/Field";
 import FormFieldImageVideoLinkDocumentBrowsing from "@root/forms/FormFieldImageVideoLinkDocumentBrowsing";
@@ -76,7 +77,8 @@ const Col = (props: ColPropsTypes) => {
 		imageUpload: FormFieldImageUpload,
 		matrix: FormFieldMatrix,
 		upload: FormFieldUpload,
-		numberTable: FormFieldNumberTable
+		numberTable: FormFieldNumberTable,
+		raw: FormFieldRaw
 	}), []);
 
 	const doneTypingInterval = 300;

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -777,6 +777,44 @@ const fields = useMemo(
 );
 ```
 
+## FormFieldRaw
+This field implements the [**FieldDef**](#generic-field-props-fielddef) interface.
+
+This type of field will render the corresponding `value` as-is. It can be used to render anything that is a valid `ReactNode` while maintaining the normal field display behaviour, like the label and field hint. It has no `inputSettings`.
+
+
+### How to use in a form?
+```ts
+
+function RawValue() {
+	return (
+		<RawValueWrapper>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+		</RawValueWrapper>
+	)
+}
+
+async function getFormValues() {
+	return {
+		raw: <RawValue />
+	}
+}
+
+const fields = useMemo(
+	() =>
+		[
+			//...other fields
+			{
+				//...all generic field props,
+				type: "raw",
+			},
+			//...other fields
+		],
+	[]
+);
+
+```
+
 ## FormFieldText
 This field implements the [**FieldDef**](#generic-field-props-fielddef) interface.
 

--- a/src/forms/FormFieldAddress/AddressCard/AddressCard.tsx
+++ b/src/forms/FormFieldAddress/AddressCard/AddressCard.tsx
@@ -31,26 +31,24 @@ const AddressCard = (props: AddressCardProps): ReactElement => {
 				{`${address?.city}, ${address?.state?.label ? address.state.label : ""} ${address?.postalCode}`}
 			</span>
 			<span>{address?.country?.label}</span>
-			{!disabled && (
-				<ButtonsWrapper>
-					<Button
-						label="Edit"
-						color="teal"
-						variant="text"
-						disabled={disabled}
-						muiAttrs={{ disableRipple: true }}
-						onClick={() => onEdit(address, addressIndex)}
-					></Button>
-					<Button
-						color="red"
-						variant="text"
-						muiAttrs={{ disableRipple: true }}
-						disabled={disabled}
-						label="Remove"
-						onClick={() => onRemoveAddress(addressIndex)}
-					></Button>
-				</ButtonsWrapper>
-			)}
+			<ButtonsWrapper>
+				<Button
+					label="Edit"
+					color="teal"
+					variant="text"
+					disabled={disabled}
+					muiAttrs={{ disableRipple: true }}
+					onClick={() => onEdit(address, addressIndex)}
+				></Button>
+				<Button
+					color="red"
+					variant="text"
+					muiAttrs={{ disableRipple: true }}
+					disabled={disabled}
+					label="Remove"
+					onClick={() => onRemoveAddress(addressIndex)}
+				></Button>
+			</ButtonsWrapper>
 		</StyledAddressCard>
 	);
 };

--- a/src/forms/FormFieldAddress/FormFieldAddress.tsx
+++ b/src/forms/FormFieldAddress/FormFieldAddress.tsx
@@ -10,7 +10,6 @@ import Drawer from "@root/components/Drawer";
 import AddressCard from "./AddressCard";
 import { MosaicFieldProps } from "@root/components/Field";
 import { AddressFieldInputSettings, AddressData } from ".";
-import { isEmpty } from "lodash";
 import { AddressItems, Footer } from "./Address.styled";
 
 const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSettings, AddressData>): ReactElement => {
@@ -184,10 +183,10 @@ const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSe
 
 	return (
 		<>
-			{(!fieldDef.disabled || isEmpty(value)) && addressTypes?.length > 0 && (
+			{addressTypes?.length > 0 && (
 				<Footer>
 					<Button
-						disabled={fieldDef.disabled}
+						disabled={fieldDef?.disabled}
 						color="gray"
 						variant="outlined"
 						label="ADD ADDRESS"
@@ -203,7 +202,7 @@ const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSe
 							address={address}
 							addressIndex={idx}
 							onEdit={showEditModal}
-							disabled={fieldDef.disabled}
+							disabled={fieldDef?.disabled}
 							onRemoveAddress={removeAddressHandler}
 						/>
 					))}

--- a/src/forms/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
+++ b/src/forms/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
@@ -35,6 +35,8 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 		fieldDef,
 	} = props;
 
+	console.log(typeof fieldDef?.inputSettings?.selectLimit);
+
 	// State variables
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [isMobileView, setIsMobileView] = useState(false);
@@ -81,15 +83,17 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 		<>
 			{value?.length > 0 && !isModalOpen ? (
 				<AdvancedSelectionWrapper>
-					<Button
-						color="teal"
-						variant="text"
-						label="Add"
-						onClick={handleOpenModal}
-						mIcon={AddIcon}
-						attrs={{ style: { marginBottom: "16px" } }}
-						disabled={fieldDef?.disabled}
-					/>
+					{(!fieldDef?.inputSettings?.selectLimit || value?.length < fieldDef?.inputSettings?.selectLimit) && (
+						<Button
+							color="teal"
+							variant="text"
+							label="Add"
+							onClick={handleOpenModal}
+							mIcon={AddIcon}
+							attrs={{ style: { marginBottom: "16px" } }}
+							disabled={fieldDef?.disabled}
+						/>
+					)}
 					<ChipList
 						value={value}
 						fieldDef={{

--- a/src/forms/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
+++ b/src/forms/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
@@ -26,7 +26,6 @@ import {
 } from "./AdvancedSelection.styled";
 import { BREAKPOINTS } from "@root/theme/theme";
 import { MosaicObject } from "@root/types";
-import { transform_chips } from "@root/transforms";
 
 const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection", AdvancedSelectionInputSettings, AdvancedSelectionData>): ReactElement => {
 	const {
@@ -82,40 +81,35 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 		<>
 			{value?.length > 0 && !isModalOpen ? (
 				<AdvancedSelectionWrapper>
-					{!fieldDef.disabled ? (
-						<>
-							<Button
-								color="teal"
-								variant="text"
-								label="Add"
-								onClick={handleOpenModal}
-								mIcon={AddIcon}
-								attrs={{ style: { marginBottom: "16px" } }}
-							></Button>
-
-							<ChipList
-								value={value}
-								fieldDef={{
-									inputSettings: {
-										isModalOpen,
-										isMobileView,
-										deleteSelectedOption: onChange,
-									},
-									disabled: fieldDef?.disabled,
-								}}
-							/>
-						</>
-					) : <>{transform_chips()({ data: value })}</>}
+					<Button
+						color="teal"
+						variant="text"
+						label="Add"
+						onClick={handleOpenModal}
+						mIcon={AddIcon}
+						attrs={{ style: { marginBottom: "16px" } }}
+						disabled={fieldDef?.disabled}
+					/>
+					<ChipList
+						value={value}
+						fieldDef={{
+							inputSettings: {
+								isModalOpen,
+								isMobileView,
+								deleteSelectedOption: onChange,
+							},
+							disabled: fieldDef?.disabled,
+						}}
+					/>
 				</AdvancedSelectionWrapper>
 			) : (
-				!fieldDef.disabled && (
-					<Button
-						color="gray"
-						variant="outlined"
-						label="ADD"
-						onClick={handleOpenModal}
-					></Button>
-				)
+				<Button
+					color="gray"
+					variant="outlined"
+					label="ADD"
+					onClick={handleOpenModal}
+					disabled={fieldDef?.disabled}
+				/>
 			)}
 			<RefsProvider initialRefs={initialRefs}>
 				<Drawer

--- a/src/forms/FormFieldCheckbox/FormFieldCheckbox.tsx
+++ b/src/forms/FormFieldCheckbox/FormFieldCheckbox.tsx
@@ -6,7 +6,6 @@ import { MosaicFieldProps } from "@root/components/Field";
 import { FormFieldCheckboxInputSettings, CheckboxData } from "./FormFieldCheckboxTypes";
 import { StyledCheckboxList } from "./FormFieldCheckbox.styled";
 import { MosaicLabelValue } from "@root/types";
-import { transform_chips } from "@root/transforms";
 
 const FormFieldCheckbox = (
 	props: MosaicFieldProps<"checkbox", FormFieldCheckboxInputSettings, CheckboxData>
@@ -58,18 +57,16 @@ const FormFieldCheckbox = (
 	}
 
 	return (
-		!fieldDef.disabled ? (
-			<StyledCheckboxList
-				disabled={fieldDef?.disabled}
-				checked={checked}
-				options={internalOptions}
-				onChange={(val) => internalOnChange(val, onChange)}
-				onChangeCb={(val) => internalOnChange(val, fieldDef.onChangeCb)}
-				onBlur={onBlur}
-				style={fieldDef.style}
-				className={fieldDef.className}
-			/>
-		) : value && <>{transform_chips()({ data: value })}</>
+		<StyledCheckboxList
+			disabled={fieldDef?.disabled}
+			checked={checked}
+			options={internalOptions}
+			onChange={(val) => internalOnChange(val, onChange)}
+			onChangeCb={(val) => internalOnChange(val, fieldDef.onChangeCb)}
+			onBlur={onBlur}
+			style={fieldDef.style}
+			className={fieldDef.className}
+		/>
 	);
 };
 

--- a/src/forms/FormFieldChipSingleSelect/FormFieldChipSingleSelect.tsx
+++ b/src/forms/FormFieldChipSingleSelect/FormFieldChipSingleSelect.tsx
@@ -12,7 +12,6 @@ import {
 	FormFieldChipSingleSelectInputSettings,
 } from "./FormFieldChipSingleSelectTypes";
 import { StyledChipGroup } from "./FormFieldChipSingleSelect.styled";
-import { transform_chips } from "@root/transforms";
 
 const FormFieldChipSingleSelect = (props: MosaicFieldProps<"chip", FormFieldChipSingleSelectInputSettings, ChipData>): ReactElement => {
 	const {
@@ -89,7 +88,7 @@ const FormFieldChipSingleSelect = (props: MosaicFieldProps<"chip", FormFieldChip
 
 	const errorWithMessage = typeof error === "string" ? error?.trim().length > 0 : false;
 
-	return !fieldDef.disabled ? (
+	return (
 		<StyledChipGroup
 			error={errorWithMessage || (errorWithMessage && required)}
 			onBlur={onBlur}
@@ -104,8 +103,6 @@ const FormFieldChipSingleSelect = (props: MosaicFieldProps<"chip", FormFieldChip
 				/>
 			))}
 		</StyledChipGroup>
-	) : (
-		value && <>{transform_chips()({ data: [value] })}</>
 	);
 };
 

--- a/src/forms/FormFieldDate/DateField/DateField.test.tsx
+++ b/src/forms/FormFieldDate/DateField/DateField.test.tsx
@@ -26,25 +26,6 @@ describe("DateField component", () => {
 
 	});
 
-	it("Should display the placeholder when date is disabled and no value is provided", () => {
-		const { getByText } = render(
-			<DateField
-				fieldDef={{
-					name: "disableDate",
-					type: "date",
-					label: "Disable Date Input",
-					required: false,
-					disabled: true,
-					inputSettings: {
-						showTime: false
-					}
-				}}
-				value={null}
-			/>
-		);
-		expect(getByText("MM / DD / YYYY")).toBeTruthy();
-	});
-
 	it("Should display the date time values", () => {
 		render(
 			<DateField
@@ -64,26 +45,5 @@ describe("DateField component", () => {
 
 		expect(screen.getByDisplayValue("01/01/2022")).toBeInTheDocument();
 		expect(screen.getByDisplayValue("01:30 pm")).toBeInTheDocument();
-	});
-
-	it("Should display the placeholders when date time is disabled and no value is provided", () => {
-		const { getByText } = render(
-			<DateField
-				fieldDef={{
-					name: "disableDateTime",
-					type: "date",
-					label: "Disable Date Time Input",
-					required: false,
-					disabled: true,
-					inputSettings: {
-						showTime: true
-					}
-				}}
-				value={null}
-
-			/>
-		);
-		expect(getByText("MM / DD / YYYY")).toBeTruthy();
-		expect(getByText("00:00 AM/PM")).toBeTruthy();
 	});
 });

--- a/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/forms/FormFieldDate/DateField/FormFieldDate.tsx
@@ -9,8 +9,6 @@ import TimePicker from "../TimePicker";
 import { DateTimePickerWrapper, DateTimeInputRow } from "./DateField.styled";
 import { MosaicFieldProps } from "@root/components/Field";
 import { DateFieldInputSettings, DateData } from "./DateFieldTypes";
-import { StyledDisabledText } from "@root/forms/shared/styledComponents";
-import { transform_dateFormat } from "@root/transforms";
 import { isEqual } from "date-fns";
 import { matchTime, textIsValidDate } from "@root/utils/date";
 import { DATE_FORMAT_FULL, DATE_FORMAT_FULL_PLACEHOLDER, TIME_FORMAT_FULL, TIME_FORMAT_FULL_PLACEHOLDER } from "@root/constants";
@@ -29,7 +27,6 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		dispatch
 	} = props;
 
-	const { disabled } = fieldDef || {};
 	const showTime = fieldDef?.inputSettings?.showTime;
 
 	// State splitting is necessary because the form value is a
@@ -133,63 +130,47 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 
 	return (
 		<DateTimeInputRow>
-			{!disabled ? (
-				<>
+			<>
+				<DateTimePickerWrapper>
+					<DatePicker
+						error={error}
+						onChange={handleDateChange}
+						fieldDef={{
+							name: fieldDef?.name,
+							label: "",
+							type: "",
+							inputSettings: {
+								placeholder: DATE_FORMAT_FULL_PLACEHOLDER,
+								minDate: fieldDef?.inputSettings?.minDate
+							},
+							required: fieldDef?.required,
+							disabled: fieldDef?.disabled
+						}}
+						value={dateChosen}
+						onBlur={onBlur}
+
+					/>
+				</DateTimePickerWrapper>
+				{showTime &&
 					<DateTimePickerWrapper>
-						<DatePicker
+						<TimePicker
 							error={error}
-							onChange={handleDateChange}
+							onChange={handleTimeChange}
 							fieldDef={{
 								name: fieldDef?.name,
 								label: "",
-								type: "",
+								type: "timePicker",
 								inputSettings: {
-									placeholder: DATE_FORMAT_FULL_PLACEHOLDER,
-									minDate: fieldDef?.inputSettings?.minDate
+									placeholder: TIME_FORMAT_FULL_PLACEHOLDER
 								},
-								required: fieldDef?.required,
+								disabled: fieldDef?.disabled
 							}}
-							value={dateChosen}
+							value={timeChosen}
 							onBlur={onBlur}
 						/>
 					</DateTimePickerWrapper>
-					{showTime &&
-						<DateTimePickerWrapper>
-							<TimePicker
-								error={error}
-								onChange={handleTimeChange}
-								fieldDef={{
-									name: fieldDef?.name,
-									label: "",
-									type: "timePicker",
-									inputSettings: {
-										placeholder: TIME_FORMAT_FULL_PLACEHOLDER
-									}
-								}}
-								value={timeChosen}
-								onBlur={onBlur}
-							/>
-						</DateTimePickerWrapper>
-					}
-				</>
-			) : (
-				<>
-					<StyledDisabledText>
-						{
-							value ? transform_dateFormat()({data: value})
-							: "MM / DD / YYYY"
-						}
-					</StyledDisabledText>
-					{showTime &&
-						<StyledDisabledText>
-							{
-								value ? new Date(value).toLocaleTimeString("en", { timeStyle: "short", hour12: true, timeZone: "UTC" })
-								: "00:00 AM/PM"
-							}
-						</StyledDisabledText>
-					}
-				</>
-			)}
+				}
+			</>
 		</DateTimeInputRow>
 	);
 };

--- a/src/forms/FormFieldDate/DatePicker/DatePicker.styled.tsx
+++ b/src/forms/FormFieldDate/DatePicker/DatePicker.styled.tsx
@@ -56,26 +56,33 @@ export const popperSx = {
 
 export const DatePickerWrapper = styled.div`
   	.MuiOutlinedInput-root {
-		background-color: ${theme.newColors.grey1["100"]};
 		width: ${Sizes.sm};
 		padding-right: 16px;
-
-		&:hover {
-			background-color: ${theme.newColors.grey2["100"]};
-			& fieldset {
-				border-color: ${theme.newColors.simplyGrey["100"]};
-			}
-		}
 
 		& fieldset {
 			border-radius: 0;
 			border: ${pr => pr.isPickerOpen ? `1px solid ${theme.newColors.almostBlack["100"]}` : theme.borders.simplyGrey};
 		}
 
-			.MuiOutlinedInput-input {
-				height: ${theme.fieldSpecs.inputText.height};
-				padding: ${theme.fieldSpecs.inputText.padding};
+		${({$disabled}) => !$disabled ? `
+			background-color: ${theme.newColors.grey1["100"]};
+			&:hover {
+				& fieldset {
+					border-color: ${theme.newColors.simplyGrey["100"]};
+				}
 			}
+		` : `
+			background-color: ${theme.colors.disableBackground};
+		`}
+
+		&.Mui-disabled fieldset.MuiOutlinedInput-notchedOutline{
+			border-color: ${theme.colors.disableBorder};
+		}
+
+		.MuiOutlinedInput-input {
+			height: ${theme.fieldSpecs.inputText.height};
+			padding: ${theme.fieldSpecs.inputText.padding};
+		}
 
 		&.Mui-focused fieldset {
 			border-color: ${theme.newColors.almostBlack["100"]};

--- a/src/forms/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/src/forms/FormFieldDate/DatePicker/DatePicker.tsx
@@ -30,6 +30,7 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 			{...params}
 			onBlur={onBlur}
 			required={fieldDef.required}
+			disabled={fieldDef?.disabled}
 			inputProps={{
 				...params.inputProps,
 				placeholder: fieldDef?.inputSettings?.placeholder,
@@ -39,7 +40,7 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 
 	return (
 		<LocalizationProvider dateAdapter={AdapterDateFns}>
-			<DatePickerWrapper data-testid="date-picker-test-id" error={!!error} isPickerOpen={isPickerOpen}>
+			<DatePickerWrapper data-testid="date-picker-test-id" error={!!error} isPickerOpen={isPickerOpen} $disabled={fieldDef?.disabled}>
 				<DatePicker
 					renderInput={renderInput}
 					inputFormat="MM/dd/yyyy"
@@ -51,6 +52,7 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 						sx: popperSx,
 					}}
 					minDate={fieldDef?.inputSettings?.minDate}
+					disabled={fieldDef?.disabled}
 				/>
 			</DatePickerWrapper>
 		</LocalizationProvider>

--- a/src/forms/FormFieldDate/TimePicker/TimePicker.tsx
+++ b/src/forms/FormFieldDate/TimePicker/TimePicker.tsx
@@ -28,6 +28,7 @@ const TimeFieldPicker = (props: MosaicFieldProps<"timePicker", TimePickerDef, Ti
 			{...params}
 			onBlur={onBlur}
 			required={fieldDef.required}
+			disabled={fieldDef?.disabled}
 			inputProps={{
 				...params.inputProps,
 				placeholder: fieldDef?.inputSettings?.placeholder,
@@ -38,13 +39,14 @@ const TimeFieldPicker = (props: MosaicFieldProps<"timePicker", TimePickerDef, Ti
 	return (
 		<LocalizationProvider dateAdapter={AdapterDateFns}>
 			<ThemeProvider theme={customTheme}>
-				<DatePickerWrapper isPickerOpen={isPickerOpen} error={!!error}>
+				<DatePickerWrapper isPickerOpen={isPickerOpen} error={!!error} $disabled={fieldDef?.disabled}>
 					<TimePicker
 						value={value}
 						onChange={onChange}
 						renderInput={renderInput}
 						onOpen={handleOpenState}
 						onClose={handleOpenState}
+						disabled={fieldDef?.disabled}
 					/>
 				</DatePickerWrapper>
 			</ThemeProvider>

--- a/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.styled.tsx
+++ b/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.styled.tsx
@@ -8,18 +8,30 @@ import Popper from "@mui/material/Popper";
 
 export const StyledAutocomplete = styled(MUIAutocomplete)`
   & .MuiFormControl-root .MuiInputBase-root {
-    background-color: ${theme.newColors.grey1["100"]};
     font-family: ${theme.fontFamily};
     color: ${theme.newColors.almostBlack["100"]};
 
-    &:hover {
-      background-color: ${theme.newColors.grey2["100"]}
-    }
+    ${({disabled}) => !disabled ? (`
+      background-color: ${theme.newColors.grey1["100"]};
+			&:hover {
+				& fieldset {
+					border-color: ${theme.colors.disabledBorderFocus};
+				}
+			}
+		`) : (`
+      background-color: ${theme.colors.disableBackground};
+		`)}
   }
 
   & .MuiFormControl-root .MuiInputBase-root .MuiOutlinedInput-notchedOutline {
-    border: ${(pr) =>
-		pr.error ? theme.borders.error : theme.borders.fieldGray};
+    ${({disabled, error}) => disabled ? `
+      border-color: ${theme.colors.disableBorder};
+    ` : error ? `
+      ${theme.borders.error};
+    ` : `
+      ${theme.borders.fieldGray};
+    `}
+
     border-radius: 0px;
   }
 

--- a/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.test.tsx
+++ b/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.test.tsx
@@ -13,7 +13,7 @@ const topFilms = [
 	{ label: "The Dark Knight", value: "2008" },
 ];
 
-const { queryByTestId, getByRole } = screen;
+const { getByRole } = screen;
 
 afterEach(cleanup);
 
@@ -41,27 +41,6 @@ describe("DropdownSingleSelection component", () => {
 	 */
 		const input = getByRole("combobox") as HTMLInputElement;
 		expect(input.value).toEqual("The Shawshank Redemption");
-	});
-});
-
-describe("DropdownSingleSelection disabled state", () => {
-	it("should not render the Dropdown since does not have a value", () => {
-		render(
-			<DropdownSingleSelection
-				fieldDef={{
-					name: "dropdownSingleSelect",
-					type: "dropdown",
-					label: "Label test",
-					disabled: true,
-					inputSettings: {
-						options: topFilms,
-						placeholder: "placeholder",
-					}
-				}}
-			/>
-		);
-
-		expect(queryByTestId("dropdown-single-selection-test-id")).toBe(null);
 	});
 });
 

--- a/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
+++ b/src/forms/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
@@ -13,7 +13,6 @@ import InputWrapper from "../../components/InputWrapper";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import TextField from "@mui/material/TextField";
 import { MosaicLabelValue } from "@root/types";
-import { transform_chips } from "@root/transforms";
 
 const DropdownSingleSelection = (props: MosaicFieldProps<"dropdown", DropdownSingleSelectionInputSettings, DropdownData>) => {
 	const {
@@ -84,29 +83,25 @@ const DropdownSingleSelection = (props: MosaicFieldProps<"dropdown", DropdownSin
 	};
 
 	return (
-		<>
-			{!fieldDef?.disabled ?
-				<SingleDropdownWrapper data-testid="dropdown-single-selection-test-id" innerWidth={fieldDef?.size}>
-					<StyledAutocomplete
-						value={value || null}
-						onOpen={handleOpen}
-						onClose={handleOpen}
-						data-testid="autocomplete-test-id"
-						options={internalOptions}
-						getOptionLabel={(option) => option?.label ? option.label : ""}
-						isOptionEqualToValue={isOptionEqualToValue}
-						onChange={(_event, option) => onDropDownChange(option)}
-						error={(fieldDef?.required && error) ? error : undefined}
-						renderInput={renderInput}
-						PopperComponent={CustomPopper}
-						popupIcon={<ExpandMoreIcon />}
-						onBlur={(e) => onBlur && onBlur(e.target.value)}
-						open={isOpen}
-					/>
-				</SingleDropdownWrapper>
-				: value && <>{transform_chips()({ data: [value] })}</>
-			}
-		</>
+		<SingleDropdownWrapper data-testid="dropdown-single-selection-test-id" innerWidth={fieldDef?.size}>
+			<StyledAutocomplete
+				value={value || null}
+				onOpen={handleOpen}
+				onClose={handleOpen}
+				data-testid="autocomplete-test-id"
+				options={internalOptions}
+				getOptionLabel={(option) => option?.label ? option.label : ""}
+				isOptionEqualToValue={isOptionEqualToValue}
+				onChange={(_event, option) => onDropDownChange(option)}
+				error={(fieldDef?.required && error) ? error : undefined}
+				renderInput={renderInput}
+				PopperComponent={CustomPopper}
+				popupIcon={<ExpandMoreIcon />}
+				onBlur={(e) => onBlur && onBlur(e.target.value)}
+				open={isOpen}
+				disabled={fieldDef?.disabled}
+			/>
+		</SingleDropdownWrapper>
 	);
 };
 

--- a/src/forms/FormFieldImageUpload/FormFieldImageUpload.tsx
+++ b/src/forms/FormFieldImageUpload/FormFieldImageUpload.tsx
@@ -240,9 +240,11 @@ const FormFieldImageUpload = (
 						</DragAndDropSpan>
 					) : (
 						<>
-							<DragAndDropSpan isOver={isOver}>
-								Drag & Drop files here or
-							</DragAndDropSpan>
+							{!fieldDef?.disabled && (
+								<DragAndDropSpan isOver={isOver}>
+									Drag & Drop files here or
+								</DragAndDropSpan>
+							)}
 							<UploadButton
 								color="gray"
 								variant="outlined"
@@ -262,6 +264,7 @@ const FormFieldImageUpload = (
 						title=""
 						type="file"
 						value=""
+						disabled={fieldDef?.disabled}
 					/>
 				</DragAndDropContainer>
 			) : (
@@ -300,38 +303,42 @@ const FormFieldImageUpload = (
 								</Row>
 							</ImagePropertiesColumn>
 						)}
-						{fieldDef?.inputSettings?.options && !focusMode && !fieldDef.disabled && (
+						{fieldDef?.inputSettings?.options && !focusMode && (
 							<MenuColumn data-testid="menu-container-test">
 								<MenuFormFieldCard
 									options={fieldDef?.inputSettings?.options}
+									disabled={fieldDef?.disabled}
 								/>
 							</MenuColumn>
 						)}
-						{!fieldDef.disabled && (
-							<ButtonsContainer>
-								{focusMode && fieldDef?.inputSettings.handleSetFocus ? (
+						<ButtonsContainer>
+							{focusMode && fieldDef?.inputSettings.handleSetFocus ? (
+								<Button
+									color="teal"
+									variant="text"
+									label="Set Focus"
+									onClick={setFocus}
+									disabled={fieldDef?.disabled}
+								/>
+							) : (
+								fieldDef?.inputSettings?.handleSetFocus && (
 									<Button
-										color="teal"
-										variant="text"
-										label="Set Focus"
-										onClick={setFocus}
-									></Button>
-								) : (
-									fieldDef?.inputSettings?.handleSetFocus ? <Button
 										color="teal"
 										variant="text"
 										label="View"
 										onClick={handleView}
-									></Button> : null
-								)}
-								<Button
-									color="red"
-									variant="text"
-									label="Remove"
-									onClick={removeFile}
-								></Button>
-							</ButtonsContainer>
-						)}
+										disabled={fieldDef?.disabled}
+									/>
+								)
+							)}
+							<Button
+								color="red"
+								variant="text"
+								label="Remove"
+								onClick={removeFile}
+								disabled={fieldDef?.disabled}
+							/>
+						</ButtonsContainer>
 					</ImageCard>
 				</>
 			)}

--- a/src/forms/FormFieldImageVideoLinkDocumentBrowsing/FormFieldImageVideoLinkDocumentBrowsing.tsx
+++ b/src/forms/FormFieldImageVideoLinkDocumentBrowsing/FormFieldImageVideoLinkDocumentBrowsing.tsx
@@ -225,7 +225,7 @@ const FormFieldImageVideoLinkDocumentBrowsing = (
 							<tbody>{assetPropertiesRows}</tbody>
 						</table>
 					</AssetPropertiesColumn>
-					{fieldDef?.inputSettings?.options && !fieldDef.disabled && (
+					{fieldDef?.inputSettings?.options && (
 						<MenuColumn>
 							<MenuFormFieldCard
 								disabled={fieldDef?.disabled}
@@ -233,27 +233,25 @@ const FormFieldImageVideoLinkDocumentBrowsing = (
 							/>
 						</MenuColumn>
 					)}
-					{!fieldDef.disabled && (
-						<ButtonsWrapper>
-							<Button
-								className="first"
-								color="teal"
-								variant="text"
-								label="Browse"
-								muiAttrs={{ disableRipple: true }}
-								disabled={fieldDef?.disabled}
-								onClick={async (e) => await handleBrowse(e, assetType)}
-							></Button>
-							<Button
-								color="red"
-								variant="text"
-								label="Remove"
-								muiAttrs={{ disableRipple: true }}
-								disabled={fieldDef?.disabled}
-								onClick={(e) => handleRemove(e)}
-							></Button>
-						</ButtonsWrapper>
-					)}
+					<ButtonsWrapper>
+						<Button
+							className="first"
+							color="teal"
+							variant="text"
+							label="Browse"
+							muiAttrs={{ disableRipple: true }}
+							disabled={fieldDef?.disabled}
+							onClick={async (e) => await handleBrowse(e, assetType)}
+						></Button>
+						<Button
+							color="red"
+							variant="text"
+							label="Remove"
+							muiAttrs={{ disableRipple: true }}
+							disabled={fieldDef?.disabled}
+							onClick={(e) => handleRemove(e)}
+						></Button>
+					</ButtonsWrapper>
 				</AssetCard>
 			)}
 		</ImageVideoLinkDocumentBrowsingContainer>

--- a/src/forms/FormFieldMapCoordinates/FormFieldMapCoordinates.tsx
+++ b/src/forms/FormFieldMapCoordinates/FormFieldMapCoordinates.tsx
@@ -131,24 +131,22 @@ const FormFieldMapCoordinates = (props: MosaicFieldProps<"mapCoordinates", MapCo
 								<Blank />
 							)}
 						</Column>
-						{!fieldDef.disabled && (
-							<ButtonsWrapper>
-								<Button
-									color="teal"
-									variant="text"
-									label="Edit"
-									disabled={fieldDef?.disabled}
-									onClick={handleAddCoordinates}
-								/>
-								<Button
-									color="red"
-									disabled={fieldDef?.disabled}
-									variant="text"
-									label="Remove"
-									onClick={removeLocation}
-								/>
-							</ButtonsWrapper>
-						)}
+						<ButtonsWrapper>
+							<Button
+								color="teal"
+								variant="text"
+								label="Edit"
+								disabled={fieldDef?.disabled}
+								onClick={handleAddCoordinates}
+							/>
+							<Button
+								color="red"
+								disabled={fieldDef?.disabled}
+								variant="text"
+								label="Remove"
+								onClick={removeLocation}
+							/>
+						</ButtonsWrapper>
 					</CoordinatesCard>
 				</div>
 			) : (
@@ -158,9 +156,8 @@ const FormFieldMapCoordinates = (props: MosaicFieldProps<"mapCoordinates", MapCo
 					color="gray"
 					variant="outlined"
 					label="ADD COORDINATES"
-				></Button>
+				/>
 			)}
-
 			<Drawer open={isModalOpen} onClose={handleClose}>
 				<MapCoordinatesDrawer
 					value={value}

--- a/src/forms/FormFieldMatrix/FormFieldMatrix.tsx
+++ b/src/forms/FormFieldMatrix/FormFieldMatrix.tsx
@@ -25,14 +25,18 @@ const FormFieldMatrix = (
 			<MatrixActions hasValue={hasValue}>
 				<ButtonRow>
 					{buttons.map((button, idx) => (
-						<Button key={`${button.label}-${idx}`} {...button} />
+						<Button
+							key={`${button.label}-${idx}`}
+							{...button}
+							disabled={button.disabled === undefined ? fieldDef?.disabled : button.disabled}
+						/>
 					))}
 				</ButtonRow>
 			</MatrixActions>
 			{hasValue && (
 				<DataView
 					data={[]}
-					{...{...dataView, data}}
+					{...{...dataView, disabled: fieldDef?.disabled, data}}
 				/>
 			)}
 		</MatrixWrapper>

--- a/src/forms/FormFieldNumberTable/FormFieldNumberTable.tsx
+++ b/src/forms/FormFieldNumberTable/FormFieldNumberTable.tsx
@@ -20,7 +20,6 @@ import {
 	RowSubtitle,
 } from "./FormFieldNumberTable.styled";
 import { isValidRowCol } from "./numberTableUtils";
-import { StyledDisabledText } from "../shared/styledComponents";
 import { StyledTextField } from "../FormFieldText/FormFieldText.styled";
 
 const FormFieldNumberTable = (
@@ -186,24 +185,21 @@ const FormFieldNumberTable = (
 
 							return (
 								<Td key={`${row.name}-${column.name}`}>
-									{!fieldDef.disabled ?
-										<StyledTextField
-											inputProps={{ "data-testid": `${row.name}-${column.name}` }}
-											placeholder="0"
-											value={strValue}
-											onChange={(e) => onChangeCell(e, row.name, column.name)}
-											fieldSize={"90px"}
-											inputRef={(el) => {
-												if (cellRefs?.current) {
-													cellRefs.current[rowIdx] = cellRefs.current[rowIdx] || [];
-													cellRefs.current[rowIdx][colIdx] = el;
-												}
-											}}
-											onKeyDown={(e) => onKeyDown(e, rowIdx, colIdx)}
-										/>
-										:
-										<StyledDisabledText width={"72px"}>{strValue !== "" ? strValue : "0"}</StyledDisabledText>
-									}
+									<StyledTextField
+										inputProps={{ "data-testid": `${row.name}-${column.name}` }}
+										placeholder="0"
+										value={strValue}
+										onChange={(e) => onChangeCell(e, row.name, column.name)}
+										fieldSize={"90px"}
+										disabled={fieldDef?.disabled}
+										inputRef={(el) => {
+											if (cellRefs?.current) {
+												cellRefs.current[rowIdx] = cellRefs.current[rowIdx] || [];
+												cellRefs.current[rowIdx][colIdx] = el;
+											}
+										}}
+										onKeyDown={(e) => onKeyDown(e, rowIdx, colIdx)}
+									/>
 								</Td>
 							);
 						})}

--- a/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.styled.tsx
+++ b/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.styled.tsx
@@ -6,40 +6,78 @@ import theme from "@root/theme";
 export const PhoneInputWrapper = styled.div`
   .react-tel-input {
     .form-control {
-	  ${(pr) => pr.error && `border: 1px solid ${theme.newColors.darkRed["100"]}`}
-      background-color: ${theme.newColors.grey1["100"]};
       border-radius: 0px;
+      border-color: ${theme.newColors.simplyGrey["100"]};
       font-family: ${theme.fontFamily};
       height: ${theme.fieldSpecs.inputText.totalHeight};
-      padding: 12px 16px 12px 98px;
+      padding: 12px 16px 12px 70px;
+      outline: 0;
       width: 280px;
+      box-shadow: none;
+      transition: none;
+
+      border-width: 1px;
+      border-style: solid;
+
+      ${({error}) => error ? `
+        border-color: ${theme.newColors.darkRed["100"]};
+      ` : `
+        border-color: ${theme.newColors.simplyGrey["100"]};
+      `}
+
+      ${({$disabled}) => !$disabled ? `
+			  background-color: ${theme.newColors.grey1["100"]};
+        color: ${theme.newColors.almostBlack["100"]};
+        &:hover {
+          border-color: ${theme.colors.disabledBorderFocus};
+        }
+      ` : `
+        background-color: ${theme.colors.disableBackground};
+        border-color: ${theme.colors.disableBorder};
+        color: ${theme.colors.disabledTextColor};
+      `}
+
       &:focus {
         color: ${theme.newColors.almostBlack["100"]};
-        border-color: ${theme.newColors.simplyGrey["100"]};
-        box-shadow: none;
-      }
-      &:focus + .flag-dropdown {
-        border: ${theme.borders.black};
-		border-radius: 0px;
+        border-color: ${theme.newColors.almostBlack["100"]};
+        box-shadow: ${theme.fieldSpecs.inputText.shadow};
       }
     }
 
     .flag-dropdown {
-      border-right: ${theme.borders.simplyGrey};
-      &:focus-within {
-        border: ${theme.borders.black};
-        border-radius: 0px;
-      }
+      border: 1px solid transparent;
     }
 
     .selected-flag {
+      &::after{
+        background: none;
+        content: "";
+        display: block;
+        position: absolute;
+        top: 10px;
+        right: -15px;
+        bottom: 10px;
+        border-right: 1px solid #CCCCCC;
+      }
+
       border-radius: 0;
       width: 100%;
-      padding: 15px 56px 15px 16px;
+      padding: 15px 30px 15px 15px;
+
       &:focus:before {
         border-color: transparent;
         box-shadow: none;
       }
+
+      .flag{
+        border-radius: 2px;
+      }
+
+      ${({$disabled}) => $disabled && `
+        .flag{
+          opacity: 0.25;
+        }
+      `}
     }
     .selected-flag.open {
       &:before {

--- a/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.test.tsx
+++ b/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.test.tsx
@@ -54,39 +54,6 @@ describe("FormFieldPhoneSelectionDropdown component", () => {
 	});
 });
 
-describe("FormFieldPhoneSelectionDropdown disabled state", () => {
-	it('should display "Phone field disabled" when no value is passed', () => {
-		render(
-			<FormFieldPhoneSelectionDropdown
-				fieldDef={{
-					name: "phoneSelectDropdown",
-					type: "phone",
-					label: "Label",
-					disabled: true,
-				}}
-			/>
-		);
-
-		expect(getByText("Disabled field")).toBeDefined();
-	});
-
-	it('should display "Phone value:" text plus the value', () => {
-		render(
-			<FormFieldPhoneSelectionDropdown
-				fieldDef={{
-					name: "phoneSelectDropdown",
-					type: "phone",
-					label: "Label",
-					disabled: true,
-				}}
-				value='345'
-			/>
-		);
-
-		expect(getByText("345")).toBeDefined();
-	});
-});
-
 describe("FormFieldPhoneSelectionDropdown country code prop", () => {
 	it("should display US phone number prefix when no country code is provided ", () => {
 		const { container } = render(

--- a/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
+++ b/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
@@ -11,7 +11,6 @@ import {
 	PhoneInputWrapper,
 } from "./FormFieldPhoneSelectionDropdown.styled";
 import { MosaicFieldProps } from "@root/components/Field";
-import { StyledDisabledText } from "../shared/styledComponents";
 
 const FormFieldPhoneSelectionDropdown = (
 	props: MosaicFieldProps<"phone", PhoneSelectionInputSettings, PhoneDropdownData>
@@ -35,10 +34,11 @@ const FormFieldPhoneSelectionDropdown = (
 		}
 	}
 
-	return !fieldDef?.disabled ? (
+	return (
 		<PhoneInputWrapper
 			error={!!(fieldDef?.required && error)}
 			onBlur={(e) => onBlur && onBlur(e.target.value)}
+			$disabled={fieldDef?.disabled}
 		>
 			<PhoneInput
 				autoFormat={!!fieldDef?.inputSettings?.autoFormat}
@@ -52,8 +52,6 @@ const FormFieldPhoneSelectionDropdown = (
 				}}
 			/>
 		</PhoneInputWrapper>
-	) : (
-		<StyledDisabledText>{value ?? "Disabled field"}</StyledDisabledText>
 	);
 };
 export default memo(FormFieldPhoneSelectionDropdown);

--- a/src/forms/FormFieldRadio/FormFieldRadio.tsx
+++ b/src/forms/FormFieldRadio/FormFieldRadio.tsx
@@ -9,7 +9,6 @@ import { MosaicFieldProps } from "@root/components/Field";
 import { RadioInputSettings, RadioData } from "./FormFieldRadioTypes";
 import { StyledRadioGroup } from "./FormFieldRadio.styled";
 import { MosaicLabelValue } from "@root/types";
-import { transform_chips } from "@root/transforms";
 
 const FormFieldRadio = (props: MosaicFieldProps<"radio", RadioInputSettings, RadioData>): ReactElement => {
 	const {
@@ -64,15 +63,14 @@ const FormFieldRadio = (props: MosaicFieldProps<"radio", RadioInputSettings, Rad
 	}
 
 	return (
-		!fieldDef.disabled ? (
-			<StyledRadioGroup
-				onChange={(e) => onChange && updateSelectedOption(e.target.value)}
-				value={value ? value.value : ""}
-				onBlur={(e) => onBlur && onBlur(e.target.value)}
-			>
-				{listOfRadios}
-			</StyledRadioGroup>
-		) : value && <>{transform_chips()({ data: [value] })}</>
+		<StyledRadioGroup
+			onChange={(e) => onChange && updateSelectedOption(e.target.value)}
+			value={value ? value.value : ""}
+			onBlur={(e) => onBlur && onBlur(e.target.value)}
+			disabled={fieldDef?.disabled}
+		>
+			{listOfRadios}
+		</StyledRadioGroup>
 	);
 };
 

--- a/src/forms/FormFieldRaw/FormFieldRaw.stories.mdx
+++ b/src/forms/FormFieldRaw/FormFieldRaw.stories.mdx
@@ -1,0 +1,18 @@
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import * as stories from './FormFieldRaw.stories';
+
+<Meta title='FormFields/FormFieldRaw/Readme' />
+
+# FormFieldRaw
+
+The `FormFieldRaw` component is a simple way to render anything that is a valid `ReactNode`. The `value` corresponding to this field will be rendered as-is.
+
+## Props
+
+For more information about the props this Field receives, how to use it in a form, and what data it sends back, please follow this [**link**](https://simpleviewinc.github.io/sv-mosaic/master/?path=/docs/components-form-readme--page#formfieldraw).
+
+## FormFieldRaw
+
+<Preview withSource='none'>
+  <stories.Playground />
+</Preview>

--- a/src/forms/FormFieldRaw/FormFieldRaw.stories.tsx
+++ b/src/forms/FormFieldRaw/FormFieldRaw.stories.tsx
@@ -1,0 +1,123 @@
+import * as React from "react";
+import { ReactElement, useMemo } from "react";
+import { boolean, withKnobs, text } from "@storybook/addon-knobs";
+import { Meta } from "@storybook/addon-docs/blocks";
+
+// Components
+import Form, { useForm } from "@root/components/Form";
+import { FieldDef } from "@root/components/Field";
+import { renderButtons } from "@root/utils/storyUtils";
+import { RawValueWrapper } from "./FormFieldRaw.styled";
+
+export default {
+	title: "FormFields/FormFieldRaw",
+	decorators: [withKnobs],
+} as Meta;
+
+function RawValue() {
+	return (
+		<RawValueWrapper>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+		</RawValueWrapper>
+	)
+}
+
+async function getFormValues() {
+	return {
+		raw: <RawValue />
+	}
+}
+
+export const Playground = (): ReactElement => {
+	const { state, dispatch } = useForm();
+
+	const disabled = boolean("Disabled", false);
+	const label = text("Label", "Label");
+	const helperText = text("Helper text", "Helper Text");
+	const instructionText = text("Instruction text", "Instruction text");
+	const required = boolean("Required", false);
+
+	const fields: FieldDef[] = useMemo(
+		(): FieldDef[] =>
+			[
+				{
+					name: "raw",
+					label,
+					type: "raw",
+					required,
+					disabled,
+					helperText,
+					instructionText,
+				},
+			],
+		[required, disabled, label, helperText, instructionText]
+	);
+
+	return (
+		<>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title={text("Title", "Form Title")}
+				description={text("Description", "This is a description example")}
+				state={state}
+				fields={fields}
+				dispatch={dispatch}
+				getFormValues={getFormValues}
+			/>
+		</>
+	);
+};
+
+const fields: FieldDef[] = [
+	{
+		name: "toggleSwitchDefault",
+		label: "Default example",
+		type: "toggleSwitch",
+		required: false,
+		disabled: false,
+		inputSettings: {
+			toggleLabel: "Toggle label",
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "toggleSwitchDisabled",
+		label: "Disabled example",
+		type: "toggleSwitch",
+		required: false,
+		disabled: true,
+		inputSettings: {
+			toggleLabel: "Toggle label",
+		},
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+	{
+		name: "toggleSwitchWithoutLabel",
+		label: "Toggle switch without label",
+		type: "toggleSwitch",
+		required : false,
+		disabled: false,
+		helperText: "Helper text",
+		instructionText: "Instruction text",
+	},
+];
+
+export const KitchenSink = (): ReactElement => {
+	const { state, dispatch } = useForm();
+
+	return (
+		<>
+			<pre>{JSON.stringify(state, null, "  ")}</pre>
+			<Form
+				buttons={renderButtons(dispatch)}
+				title='Form Title'
+				description='This is a description example'
+				state={state}
+				fields={fields}
+				dispatch={dispatch}
+			/>
+		</>
+	);
+};

--- a/src/forms/FormFieldRaw/FormFieldRaw.styled.ts
+++ b/src/forms/FormFieldRaw/FormFieldRaw.styled.ts
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export const RawValueWrapper = styled.div`
+    background-color: #aa1919;
+    border: 3px solid #570202;
+    color: white;
+    padding: 1rem 2rem;
+    border-radius: 99999em;
+`

--- a/src/forms/FormFieldRaw/FormFieldRaw.test.tsx
+++ b/src/forms/FormFieldRaw/FormFieldRaw.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import * as React from "react";
+import FormFieldRaw from "./FormFieldRaw";
+import { RawValueWrapper } from "./FormFieldRaw.styled";
+
+afterEach(cleanup);
+
+const { getByRole } = screen;
+
+function RawValue() {
+	return (
+		<RawValueWrapper role="presentation">
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+		</RawValueWrapper>
+	)
+}
+
+const FormFieldRawExample = () => {
+	return (
+		<FormFieldRaw
+			fieldDef={{
+				label: "Field label",
+				type: "raw",
+				name: "raw"
+			}}
+			value={<RawValue />}
+		/>
+	);
+};
+
+describe("FormFieldRaw component", () => {
+	it("should display the custom component's text", () => {
+		render(<FormFieldRawExample />);
+
+		const rawValue = getByRole("presentation");
+
+		expect(rawValue.textContent).toBe("Lorem ipsum dolor sit amet, consectetur adipiscing elit.");
+	});
+});

--- a/src/forms/FormFieldRaw/FormFieldRaw.tsx
+++ b/src/forms/FormFieldRaw/FormFieldRaw.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { ReactElement } from "react";
+
+// Types and styles
+import { MosaicFieldProps } from "@root/components/Field";
+import { RawInputSettings, FieldDefRawData } from "./FormFieldRawTypes";
+
+const FormFieldRaw = (
+	props: MosaicFieldProps<"raw", RawInputSettings, FieldDefRawData>
+): ReactElement => {
+	const {
+		value,
+	} = props;
+
+	return <>{value}</>;
+};
+
+export default FormFieldRaw;

--- a/src/forms/FormFieldRaw/FormFieldRawTypes.tsx
+++ b/src/forms/FormFieldRaw/FormFieldRawTypes.tsx
@@ -1,0 +1,8 @@
+import { FieldDefBase } from "@root/components/Field";
+import { ReactNode } from "react";
+
+export type RawInputSettings = never;
+
+export type FieldDefRawData = ReactNode;
+
+export type FieldDefRaw = FieldDefBase<"raw", RawInputSettings, FieldDefRawData>

--- a/src/forms/FormFieldRaw/index.ts
+++ b/src/forms/FormFieldRaw/index.ts
@@ -1,0 +1,3 @@
+export { default } from "./FormFieldRaw";
+export * from "./FormFieldRaw";
+export * from "./FormFieldRawTypes";

--- a/src/forms/FormFieldText/FormFieldText.styled.tsx
+++ b/src/forms/FormFieldText/FormFieldText.styled.tsx
@@ -13,12 +13,16 @@ export const StyledTextField = styled(({ fieldSize, ...rest }) => (
 	width: ${pr => pr.fieldSize ? pr.fieldSize : Sizes.sm};
 
 	&.MuiFormControl-root {
-		background-color: ${theme.newColors.grey1["100"]};
-		&:hover {
-			background-color: ${theme.newColors.grey2["100"]};
-			& fieldset {
-				border-color: ${theme.newColors.simplyGrey["100"]};
+		${({disabled}) => !disabled ? (`
+			background-color: ${theme.newColors.grey1["100"]};
+			&:hover {
+				& fieldset {
+					border-color: ${theme.colors.disabledBorderFocus};
+				}
 			}
+		`) : (`
+			background-color: ${theme.colors.disableBackground};
+		`)}
 		}
 
 		& svg {
@@ -32,8 +36,13 @@ export const StyledTextField = styled(({ fieldSize, ...rest }) => (
 	}
 
 	.MuiOutlinedInput-input {
-		color: ${theme.newColors.almostBlack["100"]};
 		font-family: ${theme.fontFamily};
+
+		${({disabled}) => !disabled ? `
+			color: ${theme.newColors.almostBlack["100"]};
+		` : `
+			color: ${theme.colors.disabledTextColor};
+		`};
 
 		::placeholder {
 			font-weight: ${theme.fontWeight.normal};
@@ -56,6 +65,10 @@ export const StyledTextField = styled(({ fieldSize, ...rest }) => (
 	fieldset {
 		border-radius: 0px;
 		border-color: ${theme.newColors.simplyGrey["100"]};
+	}
+
+	& .Mui-disabled fieldset.MuiOutlinedInput-notchedOutline{
+		border-color: ${theme.colors.disableBorder};
 	}
 
 	& .MuiOutlinedInput-root {

--- a/src/forms/FormFieldText/FormFieldText.tsx
+++ b/src/forms/FormFieldText/FormFieldText.tsx
@@ -8,8 +8,6 @@ import InputAdornment from "@mui/material/InputAdornment";
 import { TextFieldData, TextFieldInputSettings } from "./FormFieldTextTypes";
 import { StyledTextField } from "./FormFieldText.styled";
 import { MosaicFieldProps } from "@root/components/Field";
-import { StyledDisabledText } from "../shared/styledComponents";
-import { Sizes } from "@root/theme";
 
 const TextField = (
 	props: MosaicFieldProps<"text", TextFieldInputSettings, TextFieldData>
@@ -45,7 +43,7 @@ const TextField = (
 
 	const errorWithMessage = typeof error === "string" ?  error?.trim().length > 0 : false;
 
-	return !fieldDef?.disabled ? (
+	return (
 		<StyledTextField
 			id={fieldDef?.name}
 			data-testid="form-field-text-test-id"
@@ -64,9 +62,8 @@ const TextField = (
 			type={fieldDef?.inputSettings?.type === "number" ? "text" : fieldDef?.inputSettings?.type}
 			minRows={fieldDef?.inputSettings?.minRows}
 			maxRows={fieldDef?.inputSettings?.maxRows}
+			disabled={fieldDef?.disabled}
 		/>
-	) : (
-		<StyledDisabledText width={fieldDef?.size ?? Sizes.sm}>{value ?? fieldDef?.inputSettings?.placeholder ?? "Disabled field"}</StyledDisabledText>
 	);
 };
 

--- a/src/forms/FormFieldTextEditor/FormFieldTextEditor.test.tsx
+++ b/src/forms/FormFieldTextEditor/FormFieldTextEditor.test.tsx
@@ -64,14 +64,6 @@ mockResizeObserver.mockReturnValue({
 window.ResizeObserver = mockResizeObserver;
 
 describe("TextEditor component", () => {
-	it("should show empty content when is disabled", async () => {
-		await act(() => {
-			render(<TextEditorExample disabled={true} />);
-		});
-
-		expect(screen.getByText("—")).toBeDefined()
-	});
-
 	it("should have an ltr direction", async () => {
 		await act(() => {
 			render(<TextEditorExample direction={"ltr"} />);

--- a/src/forms/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/forms/FormFieldUpload/FormFieldUpload.tsx
@@ -223,7 +223,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 
 	return (
 		<>
-			{!isMaxedOut && !fieldDef.disabled && (
+			{!isMaxedOut && (
 				<DragAndDropContainer
 					isOver={isOver}
 					onDragOver={dragOver}
@@ -238,14 +238,17 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 						</DragAndDropSpan>
 					) : (
 						<>
-							<DragAndDropSpan isOver={isOver}>
-							Drag & Drop files here or
-							</DragAndDropSpan>
+							{!fieldDef?.disabled && (
+								<DragAndDropSpan isOver={isOver}>
+								Drag & Drop files here or
+								</DragAndDropSpan>
+							)}
 							<Button
 								color="gray"
 								variant="outlined"
 								label="UPLOAD FILES"
 								onClick={uploadFiles}
+								disabled={fieldDef?.disabled}
 							/>
 						</>
 					)}
@@ -257,6 +260,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 						type="file"
 						value=""
 						multiple={limit === undefined || limit > 1 ? true : false}
+						disabled={fieldDef?.disabled}
 					/>
 				</DragAndDropContainer>
 			)}

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -105,12 +105,17 @@ const colors = {
 	simplyGoldHover : "#E3A520",
 	simplyGoldOpacity : "rgb(253, 185, 36, 0.3)",
 	simplyGray : "#BEBEBE",
+	disabledTextColor: "rgba(0, 0, 0, 0.38)",
+	disableBackground: "rgb(249, 250, 251)",
+	disableBorder: "rgb(228, 228, 228)",
+	disabledBorderFocus: "rgb(164, 164, 164)",
 	simplyGrayOpacity : "rgb(190, 190, 190, 0.3)",
 	teal : "#008DA8",
 	label : "#3B424E", //Same as gray700
 	almostBlack : "#1A1A1A",
 	errorBackground: "#B100000D",
-	white: "#FFFFFF"
+	white: "#FFFFFF",
+	blackDisabled: "rgba(0, 0, 0, 0.26)"
 };
 
 const borders = {


### PR DESCRIPTION
Prevent the rendering of the add button if the `FormFieldAdvancedSelection` has a `selectLimit` and the number of selected items has reached this limit.