### PR TITLE
MOS-1098 Refactors the content component

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -13,6 +13,7 @@ import AddIcon from "@mui/icons-material/Add";
 import ContactsIcon from "@mui/icons-material/Contacts";
 import CreateIcon from "@mui/icons-material/Create";
 import DeleteIcon from "@mui/icons-material/Delete";
+import { DATE_FORMAT_FULL } from "@root/constants";
 
 export default {
 	title: "Components/Card",
@@ -112,19 +113,19 @@ export const Playground = (): ReactElement => {
 const recentActivityContent = [
 	<ActivityWrapper key="activity-1">
 		<ActivityDescription>First Activity</ActivityDescription>
-		<ActivityDate>{format(new Date(), "MM/dd/yyyy")}</ActivityDate>
+		<ActivityDate>{format(new Date(), DATE_FORMAT_FULL)}</ActivityDate>
 	</ActivityWrapper>,
 	<ActivityWrapper key="activity-2">
 		<ActivityDescription>Second Activity</ActivityDescription>
-		<ActivityDate>{format(new Date(), "MM/dd/yyyy")}</ActivityDate>
+		<ActivityDate>{format(new Date(), DATE_FORMAT_FULL)}</ActivityDate>
 	</ActivityWrapper>,
 	<ActivityWrapper key="activity-3">
 		<ActivityDescription>Third Activity</ActivityDescription>
-		<ActivityDate>{format(new Date(), "MM/dd/yyyy")}</ActivityDate>
+		<ActivityDate>{format(new Date(), DATE_FORMAT_FULL)}</ActivityDate>
 	</ActivityWrapper>,
 	<ActivityWrapper key="activity-4">
 		<ActivityDescription>Fourth Activity</ActivityDescription>
-		<ActivityDate>{format(new Date(), "MM/dd/yyyy")}</ActivityDate>
+		<ActivityDate>{format(new Date(), DATE_FORMAT_FULL)}</ActivityDate>
 	</ActivityWrapper>,
 ];
 

--- a/src/components/Content/Content.stories.mdx
+++ b/src/components/Content/Content.stories.mdx
@@ -20,7 +20,7 @@ https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/components/Content/C
 	* **show** - [`MosaicShow`](/docs/components-form-readme--page#mosaicshow-t-type) optional - No params are given to the show callback
 	* **column** - `string` optional - If a column is given then it will be used as the name hence, defaults to name.
 * **data** - `MosaicObject` required - Data that will be used by the transform function of each field to generate the corresponding JSX element.
-* **sections** - `string[][][]` optional - Defines the position of each field. It is based in columns with a maximun allowed of two, if no sections are passed the content will be render in one column. Look at the following example to see how it is declared.
+* **sections** - `MosaicGridConfig` optional - Defines the position of each field. It is based in columns with a maximun allowed of two, if no sections are passed the content will be render in one column. Look at the following example to see how it is declared.
 * **title** - `string` required - Name of the section or subsection.
 * **buttons** - `ButtonProps[]` optional - Array of buttons that will be display on the top-right corner of the component.
 * **variant** - `"standard" | "card"` optional - Variant of the component defines what styles should render. If "card" is passed, content component looks like a card component

--- a/src/components/Content/Content.styled.ts
+++ b/src/components/Content/Content.styled.ts
@@ -88,7 +88,7 @@ export const ColorValue = styled.p`
 	margin-top: 0;
 `;
 
-export const ContentRow = styled.div`
+export const ContentRowWrapper = styled.div`
 	display: flex;
 	width: 100%;
 

--- a/src/components/Content/Content.tsx
+++ b/src/components/Content/Content.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import {
 	ReactElement,
 	useMemo,
-	Fragment
 } from "react";
 import { ContentProps } from "./ContentTypes";
 
@@ -11,101 +10,17 @@ import {
 	MainWrapper,
 	TitleWrapper,
 	Title,
-	Label,
-	FieldContainer,
-	TransformContainer,
-	ContentRow,
+	ContentRowWrapper,
 } from "./Content.styled";
 import evaluateShow from "@root/utils/show/evaluateShow";
-import Blank from "@root/components/Blank";
 import ButtonRow from "../ButtonRow/ButtonRow";
+import ContentRow from "./ContentRow";
+import { MosaicGridConfig } from "@root/types";
 
 const Content = (props: ContentProps): ReactElement => {
 	const { fields, data, sections, title, buttons = [], variant } = props;
 
 	const cardVariant = variant === "card" ? true : false;
-
-	/**
-	 * Checks if the field exists, can be shown and executes its transform function
-	 * if any otherwise it will render the data.
-	 * @param field the name of the field specified in the sections array
-	 * @param rowIndex this index is by the error that is thrown to point where
-	 * an invalid field was defined within the sections layout
-	 * @param sectionLength the name of the field specified in the sections array
-	 * @returns the JSX element created by the transform function.
-	 */
-	const renderRow = (field: string, rowIdx: number, sectionLength: number) => {
-		const currentField = fields?.find((fieldDef) => {
-			if (fieldDef?.column) {
-				return field === fieldDef.column;
-			}
-
-			return field === fieldDef.name;
-		});
-
-		if (!field) {
-			return (
-				<FieldContainer key={`value-${rowIdx}`} columns={sectionLength} />
-			)
-		}
-
-		if (!currentField && field) {
-			throw new Error(
-				`No field declared for field name '${field}' in the ${rowIdx + 1} row.`
-			);
-		}
-
-		if (!evaluateShow(currentField?.show)) {
-			return;
-		}
-
-		const fieldName = currentField?.column ? currentField?.column : currentField?.name;
-		let fieldValue = data[fieldName];
-
-		if (fieldValue === undefined || fieldValue === "") {
-			return (
-				<FieldContainer key={`value-${currentField.name}`} columns={sectionLength}>
-					{renderField(currentField.label, <Blank />)}
-				</FieldContainer>
-			)
-		}
-
-		if (currentField && !currentField?.transforms) {
-			return (
-				<FieldContainer key={`value-${currentField.name}`} columns={sectionLength}>
-					{renderField(currentField.label, data[fieldName])}
-				</FieldContainer>
-			)
-		}
-
-		currentField?.transforms.forEach(transform => {
-			fieldValue = transform({ data: fieldValue });
-		})
-
-		return (
-			<FieldContainer key={`transformed-${currentField.name}`} columns={sectionLength}>
-				{renderField(currentField?.label, fieldValue)}
-			</FieldContainer>
-		)
-	};
-
-	/**
-	 * Renders the content created either by the transform funcion or the
-	 * raw data in case the transform function is not defined for the current field.
-	 * @param content JSX Element | raw data
-	 * @param label Text positioned above each field
-	 * @returns JSX Element corresponding to the current field.
-	 */
-	const renderField = (label: React.ReactNode, content?: unknown) => {
-		return (
-			<>
-				<Label>{label}</Label>
-				<TransformContainer>
-					{content}
-				</TransformContainer>
-			</>
-		)
-	};
 
 	/**
 	 * Generates the sections that will be iterated to render the fields
@@ -114,7 +29,7 @@ const Content = (props: ContentProps): ReactElement => {
 	 * @returns the sections that contains the names of the fields
 	 */
 	const sectionsToRender = useMemo(() => {
-		const newSections = []
+		const newSections: MosaicGridConfig = []
 
 		if (!sections) {
 			fields.forEach(field => {
@@ -147,13 +62,18 @@ const Content = (props: ContentProps): ReactElement => {
 			</TitleWrapper>
 			<div className={cardVariant ? "card-content" : ""}>
 				{data && sectionsToRender.map((section, idx) => (
-					<ContentRow key={`${idx}-row`} className={cardVariant ? "card-row" : ""}>
+					<ContentRowWrapper key={`${idx}-row`} className={cardVariant ? "card-row" : ""}>
 						{section.map((field, idx) => (
-							<Fragment key={`${field[0]}-${idx}`}>
-								{renderRow(field[0], idx, section?.length)}
-							</Fragment>
+							<ContentRow
+								key={`${field[0]}-${idx}`}
+								fields={fields}
+								field={field[0]}
+								rowIndex={idx}
+								sectionLength={section?.length}
+								data={data}
+							/>
 						))}
-					</ContentRow>
+					</ContentRowWrapper>
 				))}
 			</div>
 		</MainWrapper>

--- a/src/components/Content/ContentField.tsx
+++ b/src/components/Content/ContentField.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { ContentFieldProps} from "./ContentTypes";
+
+// Components
+import {
+	Label,
+	TransformContainer,
+} from "./Content.styled";
+
+/**
+ * Renders the content created either by the transform funcion or the
+ * raw data in case the transform function is not defined for the current field.
+ */
+const ContentField = ({label, content}: ContentFieldProps) => {
+	return (
+		<>
+			<Label>{label}</Label>
+			<TransformContainer>
+				{content}
+			</TransformContainer>
+		</>
+	)
+};
+
+export default ContentField

--- a/src/components/Content/ContentRow.tsx
+++ b/src/components/Content/ContentRow.tsx
@@ -1,0 +1,73 @@
+
+import * as React from "react";
+import { ContentRowProps } from "./ContentTypes";
+
+import {
+	FieldContainer,
+} from "./Content.styled";
+import evaluateShow from "@root/utils/show/evaluateShow";
+import Blank from "@root/components/Blank";
+import ContentField from "./ContentField";
+
+/**
+ * Checks if the field exists, can be shown and executes its transform function
+ * if any otherwise it will render the data.
+ */
+const ContentRow = ({ fields, field, rowIndex, sectionLength, data }: ContentRowProps) => {
+	const currentField = fields?.find((fieldDef) => {
+		if (fieldDef?.column) {
+			return field === fieldDef.column;
+		}
+
+		return field === fieldDef.name;
+	});
+
+	if (!field) {
+		return (
+			<FieldContainer columns={sectionLength} />
+		)
+	}
+
+	if (!currentField && field) {
+		throw new Error(
+			`No field declared for field name '${field}' in the ${rowIndex + 1} row.`
+		);
+	}
+
+	if (!evaluateShow(currentField?.show)) {
+		return (
+			<FieldContainer columns={sectionLength} />
+		)
+	}
+
+	const fieldName = currentField?.column ? currentField?.column : currentField?.name;
+	let fieldValue = data[fieldName];
+
+	if (fieldValue === undefined || fieldValue === "") {
+		return (
+			<FieldContainer columns={sectionLength}>
+				<ContentField label={currentField.label} content={<Blank />} />
+			</FieldContainer>
+		)
+	}
+
+	if (currentField && !currentField?.transforms) {
+		return (
+			<FieldContainer key={`value-${currentField.name}`} columns={sectionLength}>
+				<ContentField label={currentField.label} content={data[fieldName]} />
+			</FieldContainer>
+		)
+	}
+
+	currentField?.transforms.forEach(transform => {
+		fieldValue = transform({ data: fieldValue });
+	})
+
+	return (
+		<FieldContainer key={`transformed-${currentField.name}`} columns={sectionLength}>
+			<ContentField label={currentField.label} content={fieldValue} />
+		</FieldContainer>
+	)
+}
+
+export default ContentRow;

--- a/src/components/Content/ContentTypes.ts
+++ b/src/components/Content/ContentTypes.ts
@@ -60,3 +60,32 @@ export interface ContentProps {
    */
   variant?: "standard" | "card";
 }
+
+export interface ContentFieldProps{
+  /**
+   * Text positioned above each field
+   */
+  label: React.ReactNode,
+  /**
+   * JSX Element | raw data
+   */
+  content?: unknown
+}
+
+export interface ContentRowProps{
+  fields: ContentField[]
+  /**
+   * The name of the field specified in the sections array
+   */
+  field: string
+  /**
+   * This index is by the error that is thrown to point where
+   * an invalid field was defined within the sections layout
+   */
+  rowIndex: number
+  /**
+   * The name of the field specified in the sections array
+   */
+  sectionLength?: number
+  data: MosaicObject
+}

--- a/src/components/DataViewFilterDate/DataViewFilterDate.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.tsx
@@ -7,6 +7,7 @@ import DataViewPrimaryFilter from "../DataViewPrimaryFilter";
 import DataViewFilterDateDropdownContent from "./DataViewFilterDateDropdownContent";
 import DataViewFilterDropdown from "../DataViewFilterDropdown";
 import { DataViewFilterDateProps } from "./DataViewFilterDateTypes";
+import { DATE_FORMAT_FULL } from "@root/constants";
 
 const StyledWrapper = styled.span``;
 
@@ -15,8 +16,6 @@ function isSame(dateLeft, dateRight) {
 		return fn(dateLeft, dateRight);
 	})
 }
-
-const dateFormat = "M/d/yyyy";
 
 export default function DataViewFilterDate(props: DataViewFilterDateProps): ReactElement {
 	const [anchorEl, setAnchorEl] = useState(null);
@@ -35,8 +34,8 @@ export default function DataViewFilterDate(props: DataViewFilterDateProps): Reac
 		if ("rangeStart" in props.data || "rangeEnd" in props.data) {
 			const hasStart = props.data.rangeStart !== undefined;
 			const hasEnd = props.data.rangeEnd !== undefined;
-			const startFormat = hasStart ? format(props.data.rangeStart, dateFormat) : undefined;
-			const endFormat = hasEnd ? format(props.data.rangeEnd, dateFormat) : undefined;
+			const startFormat = hasStart ? format(props.data.rangeStart, DATE_FORMAT_FULL) : undefined;
+			const endFormat = hasEnd ? format(props.data.rangeEnd, DATE_FORMAT_FULL) : undefined;
 
 			if (isSame(props.data.rangeStart, props.data.rangeEnd)) {
 				valueString = startFormat;

--- a/src/components/DataViewFilterDate/DataViewFilterDate.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.tsx
@@ -7,7 +7,7 @@ import DataViewPrimaryFilter from "../DataViewPrimaryFilter";
 import DataViewFilterDateDropdownContent from "./DataViewFilterDateDropdownContent";
 import DataViewFilterDropdown from "../DataViewFilterDropdown";
 import { DataViewFilterDateProps } from "./DataViewFilterDateTypes";
-import { DATE_FORMAT_FULL } from "@root/constants";
+import { DATE_FORMAT_SHORT } from "@root/constants";
 
 const StyledWrapper = styled.span``;
 
@@ -34,8 +34,8 @@ export default function DataViewFilterDate(props: DataViewFilterDateProps): Reac
 		if ("rangeStart" in props.data || "rangeEnd" in props.data) {
 			const hasStart = props.data.rangeStart !== undefined;
 			const hasEnd = props.data.rangeEnd !== undefined;
-			const startFormat = hasStart ? format(props.data.rangeStart, DATE_FORMAT_FULL) : undefined;
-			const endFormat = hasEnd ? format(props.data.rangeEnd, DATE_FORMAT_FULL) : undefined;
+			const startFormat = hasStart ? format(props.data.rangeStart, DATE_FORMAT_SHORT) : undefined;
+			const endFormat = hasEnd ? format(props.data.rangeEnd, DATE_FORMAT_SHORT) : undefined;
 
 			if (isSame(props.data.rangeStart, props.data.rangeEnd)) {
 				valueString = startFormat;

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -138,7 +138,7 @@ Sections follow the next set of rules:
 | ---- | ---- | ----------- |
 | **`title`** | `string` | optional - Text that helps users identify the section. This is also used when rendering tabs to scroll the user to the selected section. |
 | **`description`** | `string` or `JSX.Element` | optional - Additional text that allows users to understand the purpose or instructions of a section better. |
-| **`fields`** | `string[][][]` | required - Structure that serves as a map to position fields across rows and columns. Each section can have multiple rows, each row multiple columns, and each column multiple fields ([rows][columns][fields]) |
+| **`fields`** | `MosaicGridConfig` | required - Structure that serves as a map to position fields across rows and columns. Each section can have multiple rows, each row multiple columns, and each column multiple fields ([rows][columns][fields]) |
 | **`collapsed`** | `boolean` | optional - Allows developers to decide whether the section will be first rendered collapsed or expanded. It defaults to false when no value is provided. |
 | **`show`** | [`MosaicShow`](#mosaicshow-t-type) | optional - Show callbacks will be called with `{data: formState.data}` |
 

--- a/src/components/Form/FormTypes.tsx
+++ b/src/components/Form/FormTypes.tsx
@@ -1,12 +1,14 @@
 import { ButtonProps } from "@root/components/Button";
 import { FieldDef } from "@root/components/Field";
 import { Section } from "@root/forms/FormNav/FormNavTypes";
-import { MosaicObject, MosaicShow } from "@root/types";
+import { MosaicGridConfig, MosaicObject, MosaicShow } from "@root/types";
+
+
 
 export interface SectionDef extends Section {
 	title?: string;
 	description?: string | JSX.Element;
-	fields: string[][][];
+	fields: MosaicGridConfig;
 	collapsed?: boolean;
 	show?: MosaicShow
 }

--- a/src/components/Form/Section.tsx
+++ b/src/components/Form/Section.tsx
@@ -14,7 +14,7 @@ import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { MosaicShow } from "@root/types";
+import { MosaicGridConfig, MosaicShow } from "@root/types";
 
 const StyledAccordion = styled(Accordion)`
 	box-shadow: none !important;
@@ -67,7 +67,7 @@ interface SectionPropTypes {
 	sectionIdx: number;
 	description: string | JSX.Element;
 	fieldsDef: FieldDef[];
-	rows: string[][][];
+	rows: MosaicGridConfig;
 	dispatch: any;
 	state: any;
 	view: ViewType;

--- a/src/constants/formats.ts
+++ b/src/constants/formats.ts
@@ -1,4 +1,6 @@
+export const DATE_FORMAT_SHORT = "M/d/yyyy";
 export const DATE_FORMAT_FULL = "MM/dd/yyyy";
+export const DATE_FORMAT_SHORT_PLACEHOLDER = "M / D / YYYY";
 export const DATE_FORMAT_FULL_PLACEHOLDER = "MM / DD / YYYY";
 export const TIME_FORMAT_FULL = "hh:mm aaa";
 export const TIME_FORMAT_FULL_PLACEHOLDER = "00:00 AM/PM";

--- a/src/forms/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/src/forms/FormFieldDate/DatePicker/DatePicker.tsx
@@ -11,6 +11,7 @@ import {
 	DatePickerWrapper,
 	popperSx,
 } from "./DatePicker.styled";
+import { DATE_FORMAT_FULL } from "@root/constants";
 
 const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 	const { error, fieldDef, onChange, value = null, onBlur } = props;
@@ -42,7 +43,7 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 			<DatePickerWrapper data-testid="date-picker-test-id" error={!!error} isPickerOpen={isPickerOpen}>
 				<DatePicker
 					renderInput={renderInput}
-					inputFormat="MM/dd/yyyy"
+					inputFormat={DATE_FORMAT_FULL}
 					value={value}
 					onChange={onChange}
 					onOpen={handleOpenState}

--- a/src/transforms/column_transforms.tsx
+++ b/src/transforms/column_transforms.tsx
@@ -8,6 +8,7 @@ import { ChipsWrapper, ColorValue } from "@root/components/Content/Content.style
 import ColorSelected from "@root/forms/FormFieldColorPicker/ColorSelected";
 import Image from "@root/components/Image";
 import React from "react";
+import { DATE_FORMAT_FULL } from "@root/constants";
 
 export function transform_boolean(): DataViewColumnTransform<boolean> {
 	return function({ data }): string {
@@ -21,7 +22,7 @@ export function transform_boolean(): DataViewColumnTransform<boolean> {
 
 export function transform_dateFormat(): DataViewColumnTransform<Date> {
 	return function({ data }): string {
-		return format(data, "M/d/yyyy");
+		return format(data, DATE_FORMAT_FULL);
 	}
 }
 

--- a/src/transforms/column_transforms.tsx
+++ b/src/transforms/column_transforms.tsx
@@ -8,7 +8,7 @@ import { ChipsWrapper, ColorValue } from "@root/components/Content/Content.style
 import ColorSelected from "@root/forms/FormFieldColorPicker/ColorSelected";
 import Image from "@root/components/Image";
 import React from "react";
-import { DATE_FORMAT_FULL } from "@root/constants";
+import { DATE_FORMAT_SHORT } from "@root/constants";
 
 export function transform_boolean(): DataViewColumnTransform<boolean> {
 	return function({ data }): string {
@@ -22,7 +22,7 @@ export function transform_boolean(): DataViewColumnTransform<boolean> {
 
 export function transform_dateFormat(): DataViewColumnTransform<Date> {
 	return function({ data }): string {
-		return format(data, DATE_FORMAT_FULL);
+		return format(data, DATE_FORMAT_SHORT);
 	}
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,3 +21,5 @@ export type MosaicShowResult = boolean;
 export type MosaicShowCallback<T> = (params: T) => MosaicShowResult;
 
 export type MosaicShow<T = unknown> = MosaicShowResult | MosaicShowCallback<T> | Array<MosaicShowResult | MosaicShowCallback<T>>
+
+export type MosaicGridConfig = string[][][];


### PR DESCRIPTION
- Refactors the `Content` component, splitting nested functions into components of their own rather than redefining on each render
- Minimises reliance on hard coded date format value, opting for the `DATE_FORMAT_FULL` constant for now.
- Introduces the `MosaicGridConfig` type to replace the reuse of `string[][][]` across the board.