### PR TITLE
MOS-1174 FormFieldMapCoordinates initial position

### DIFF
--- a/src/forms/FormFieldMapCoordinates/Map/Map.tsx
+++ b/src/forms/FormFieldMapCoordinates/Map/Map.tsx
@@ -10,6 +10,7 @@ import { MapContainer } from "../MapCoordinates.styled";
 import AddressAutocomplete from "@root/forms/FormFieldAddress/AddressAutocomplete/AddressAutocomplete";
 import { StyledClearIcon } from "@root/forms/FormFieldAddress/AddressAutocomplete/AddressAutocomplete.styled";
 import MarkerFollower from "./MarkerFollower";
+import { defaultMapPosition, isValidLatLng } from "../MapCoordinatesUtils";
 
 const containerStyle = {
 	display: "flex",
@@ -33,6 +34,7 @@ const Map = (props: MapProps): ReactElement => {
 
 	// State variables
 	const [addressValue, setAddressValue] = useState("");
+	const center = isValidLatLng(initialCenter) ? initialCenter : defaultMapPosition;
 
 	/**
  * Gets lat and lng values from the selected suggestion and
@@ -58,7 +60,6 @@ const Map = (props: MapProps): ReactElement => {
 		setAddressValue("");
 	};
 
-	const map = React.useRef<GoogleMap | undefined>();
 	const shouldPanRef = React.useRef<boolean>(true);
 
 	const onMapMouseEvent = ({ latLng }: google.maps.MapMouseEvent) => {
@@ -98,16 +99,16 @@ const Map = (props: MapProps): ReactElement => {
 			<div>
 				<GoogleMap
 					mapContainerStyle={containerStyle}
-					center={initialCenter}
+					center={center}
 					zoom={value ? focusZoom : zoom}
 					onClick={onMapMouseEvent}
 					options={mapOptions}
-					ref={(ref) => map.current = ref}
 				>
 					<MarkerFollower
 						value={value}
 						initialCenter={initialCenter}
 						onDragMarkerEnd={onMapMouseEvent}
+						zoom={zoom}
 						focusZoom={focusZoom}
 						shouldPanRef={shouldPanRef}
 					/>

--- a/src/forms/FormFieldMapCoordinates/Map/MarkerFollower.tsx
+++ b/src/forms/FormFieldMapCoordinates/Map/MarkerFollower.tsx
@@ -5,7 +5,7 @@ import { ReactElement } from "react";
 import { MapFocusProps } from "../MapCoordinatesTypes";
 
 // Styles
-import { getMapBounds, isValidLatLng } from "../MapCoordinatesUtils";
+import { defaultMapPosition, getMapBounds, isValidLatLng } from "../MapCoordinatesUtils";
 
 const MarkerFollower = ({
 	value,
@@ -23,7 +23,7 @@ const MarkerFollower = ({
 			const latLng = isValidLatLng(value) ? value : undefined;
 
 			const bounds = await getMapBounds(map);
-			const { lat, lng } = latLng ? value : initialCenter ? initialCenter : {lat: 0, lng: 0};
+			const { lat, lng } = latLng ? value : isValidLatLng(initialCenter) ? initialCenter : defaultMapPosition;
 			const target = new google.maps.LatLng(lat, lng);
 			const willZoomIn = latLng && map.getZoom() < focusZoom;
 
@@ -52,7 +52,7 @@ const MarkerFollower = ({
 				map.setZoom(initialZoom)
 			}
 		})();
-	}, [map, value, shouldPanRef.current]);
+	}, [initialZoom, map, value, shouldPanRef.current]);
 
 	if (!value || value.lat === undefined || value.lng === undefined) {
 		return;

--- a/src/forms/FormFieldMapCoordinates/MapCoordinates.stories.tsx
+++ b/src/forms/FormFieldMapCoordinates/MapCoordinates.stories.tsx
@@ -7,9 +7,6 @@ import { renderButtons } from "@root/utils/storyUtils";
 // Components
 import Form, { useForm } from "@root/components/Form";
 
-// Utils
-import { defaultMapPosition } from "./MapCoordinatesUtils";
-
 export default {
 	title: "FormFields/FormFieldMapCoordinates",
 	decorators: [withKnobs],
@@ -32,7 +29,7 @@ export const Playground = (): ReactElement => {
 
 	const disabled = boolean("Disabled", false);
 	const label = text("Label", "Map Coordinates Example");
-	const initialCenterKnob = object("Initial map position", defaultMapPosition);
+	const initialCenterKnob = object("Initial map position", { lat: 48.858321470423576, lng: 2.2945004162050564 });
 	const required = boolean("Required", false);
 	const zoom = number("Zoom", 7, { min: 0, max: 18, range: true });
 	const prepopulate = boolean("Prepopulate", false);

--- a/src/forms/FormFieldMapCoordinates/MapCoordinatesUtils.ts
+++ b/src/forms/FormFieldMapCoordinates/MapCoordinatesUtils.ts
@@ -16,7 +16,7 @@ export const getAddressStringFromAddressObject = (addressObj: IAddress): string 
 /**
  * Default map position
  */
-export const defaultMapPosition = { lat: 48.858321470423576, lng: 2.2945004162050564 }
+export const defaultMapPosition = { lat: 0, lng: 0 }
 
 /**
  * Example of an address object.


### PR DESCRIPTION
This PR ensures the `FormFieldMapCoordinate`'s initial position falls back to 0,0 if the field def's `inputSettings.initialPosition` provided is malformed