### PR TITLE
MOS-1132 Adds file extension restriction support to FormFieldUpload

### DIFF
--- a/src/forms/FormFieldUpload/FormFieldUpload.stories.tsx
+++ b/src/forms/FormFieldUpload/FormFieldUpload.stories.tsx
@@ -63,6 +63,9 @@ export const Playground = (): ReactElement => {
 	const fileUrl = text("Override onUploadComplete file URL", "");
 	const downloadUrl = text("Override onUploadComplete download URL", "");
 	const error = boolean("Trigger errors when loading", false);
+	const acceptCsv = text("Comma separated accepted extensions", "");
+
+	const accept = acceptCsv.trim() ? acceptCsv.split(",") : undefined;
 
 	const [loadReady, setLoadReady] = useState(false);
 
@@ -127,7 +130,8 @@ export const Playground = (): ReactElement => {
 					inputSettings: {
 						limit: limit === "No limit" ? undefined : limit,
 						onFileAdd,
-						onFileDelete
+						onFileDelete,
+						accept
 					}
 				},
 			],
@@ -138,9 +142,8 @@ export const Playground = (): ReactElement => {
 			helperText,
 			instructionText,
 			limit,
-			timeToLoad,
 			onFileAdd,
-			error
+			accept
 		]
 	);
 

--- a/src/forms/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/forms/FormFieldUpload/FormFieldUpload.tsx
@@ -8,6 +8,7 @@ import { DragAndDropContainer, DragAndDropSpan, FileInput } from "../shared/styl
 import FileCard from "./FileCard";
 import { StyledFileGrid } from "./FormFieldUpload.styled";
 import { TransformedFile, UploadData, UploadFieldInputSettings } from "./FormFieldUploadTypes";
+import { FileExtensions } from "@root/utils/classes";
 
 const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSettings, UploadData[]>) => {
 	const {
@@ -21,6 +22,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 		limit = -1,
 		onFileAdd,
 		onFileDelete,
+		accept
 	} = fieldDef.inputSettings;
 
 	const [isOver, setIsOver] = useState(false);
@@ -30,6 +32,8 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 	const prevValueRef = useRef([]);
 	const currentLength = Object.keys(pendingFiles).length + (value || []).length;
 	const isMaxedOut = limit >= 0 && currentLength >= limit;
+
+	const fileExtensions = useMemo(() => new FileExtensions(accept), [accept]);
 
 	const pendingWithoutError = useMemo(() =>
 		Object.values(pendingFiles).filter((pendingFile: {error: string}) => pendingFile.error === undefined).length,
@@ -184,7 +188,12 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 		 */
 		setPendingFiles({...pendingFiles, ...transformedFiles});
 
-		for (const [key, file] of Object.entries(transformedFiles) as [string, TransformedFile][]) {
+		await Promise.all(Object.entries(transformedFiles).map(async ([key, file]) => {
+			if (!fileExtensions.isValidFileName(file.rawData.name)) {
+				onError({ uuid: key, message: `Only the following file formats are accepted: ${fileExtensions}` });
+				return;
+			}
+
 			try {
 				await onFileAdd({
 					file: file?.rawData,
@@ -196,7 +205,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 				const message = err instanceof Error ? err.message : String(err);
 				onError({ uuid: key, message });
 			}
-		}
+		}));
 	};
 
 	const handleFileDelete = async ({id}) => {
@@ -261,6 +270,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 						value=""
 						disabled={fieldDef?.disabled}
 						multiple={limit < 0 || (limit > 1 && limit - currentLength > 1)}
+						accept={fileExtensions.toString()}
 					/>
 				</DragAndDropContainer>
 			)}

--- a/src/forms/FormFieldUpload/FormFieldUploadTypes.ts
+++ b/src/forms/FormFieldUpload/FormFieldUploadTypes.ts
@@ -16,6 +16,7 @@ export type UploadFieldInputSettings = {
 	onFileDelete: OnFileDelete;
 	onFileAdd: OnFileAdd;
 	limit?: number;
+	accept?: string[]
 };
 
 export type UploadData =  {

--- a/src/utils/classes/FileExtensions.ts
+++ b/src/utils/classes/FileExtensions.ts
@@ -1,0 +1,31 @@
+class FileExtensions {
+	private extensions: string[];
+
+	private extensionsDotted: string[];
+
+	static getExtension(path: string): string {
+		// https://stackoverflow.com/a/12900504
+		return path.slice((Math.max(0, path.lastIndexOf(".")) || Infinity) + 1);
+	}
+
+	constructor(extensions: string[] | undefined = []) {
+		this.extensions = extensions.map(ext => ext.toLowerCase());
+		this.extensionsDotted = this.extensions.map(ext => `.${ext}`);
+	}
+
+	isValidFileName(fileName: string) {
+		if (!this.extensions.length) {
+			return true;
+		}
+
+		const ext = FileExtensions.getExtension(fileName).toLowerCase();
+
+		return this.extensions.includes(ext);
+	}
+
+	toString() {
+		return this.extensionsDotted.join(", ");
+	}
+}
+
+export default FileExtensions;

--- a/src/utils/classes/index.ts
+++ b/src/utils/classes/index.ts
@@ -1,0 +1,1 @@
+export { default as FileExtensions } from "./FileExtensions";


### PR DESCRIPTION
This PR adds support for file extension restriction. `FormFieldUpload` fields now allow an `accept` property on their input settings. This will do the following:

- Provide the `accept` attribute to the underlying `input` element, assisting the user when selecting files to upload
- Show an error for the file card if the chosen file's format is not in the list of accepted file formats

Note: this does not check the file's mime type and relies solely on the chosen file name's extension.