### PR TITLE
MOS-1173 Disables phone field country guessing

### DIFF
--- a/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
+++ b/src/forms/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
@@ -50,6 +50,7 @@ const FormFieldPhoneSelectionDropdown = (
 				inputProps={{
 					required: fieldDef?.required,
 				}}
+				disableCountryGuess
 			/>
 		</PhoneInputWrapper>
 	);


### PR DESCRIPTION
This PR prevents the `FormFieldPhoneSelectionDropdown` from attempting to guess the country based on the country code. This is to avoid a [known `react-phone-input-2` bug.](https://github.com/bl00mber/react-phone-input-2/issues/377)