### PR TITLE
MOS-1132 Update form file extension error message

### DIFF
--- a/src/forms/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/forms/FormFieldUpload/FormFieldUpload.tsx
@@ -190,7 +190,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 
 		await Promise.all(Object.entries(transformedFiles).map(async ([key, file]) => {
 			if (!fileExtensions.isValidFileName(file.rawData.name)) {
-				onError({ uuid: key, message: `Only the following file formats are accepted: ${fileExtensions}` });
+				onError({ uuid: key, message: `We only allow ${fileExtensions} file uploads` });
 				return;
 			}
 

--- a/src/utils/classes/FileExtensions.ts
+++ b/src/utils/classes/FileExtensions.ts
@@ -1,7 +1,7 @@
+import { joinAnd } from "../string";
+
 class FileExtensions {
 	private extensions: string[];
-
-	private extensionsDotted: string[];
 
 	static getExtension(path: string): string {
 		// https://stackoverflow.com/a/12900504
@@ -10,7 +10,6 @@ class FileExtensions {
 
 	constructor(extensions: string[] | undefined = []) {
 		this.extensions = extensions.map(ext => ext.toLowerCase());
-		this.extensionsDotted = this.extensions.map(ext => `.${ext}`);
 	}
 
 	isValidFileName(fileName: string) {
@@ -23,8 +22,12 @@ class FileExtensions {
 		return this.extensions.includes(ext);
 	}
 
+	toCSV() {
+		return this.extensions.join(",");
+	}
+
 	toString() {
-		return this.extensionsDotted.join(", ");
+		return joinAnd(this.extensions.map(ext => `"${ext}"`));
 	}
 }
 

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -1,0 +1,1 @@
+export { default as joinAnd } from "./joinAnd";

--- a/src/utils/string/joinAnd.ts
+++ b/src/utils/string/joinAnd.ts
@@ -1,0 +1,19 @@
+/**
+ *
+ * @param parts The parts to be joined together
+ * @param separator How to join leading parts
+ * @param and How to join the final two parts
+ */
+
+function joinAnd(parts: string[], separator = ", ", and = " and ") {
+	if (parts.length < 3) {
+		return parts.join(and);
+	}
+
+	const first = parts.slice(0, parts.length - 1).join(separator);
+	const last = parts[parts.length - 1];
+
+	return `${first}${and}${last}`;
+}
+
+export default joinAnd;


### PR DESCRIPTION
This PR updates the message that is displayed when a user attempts to upload a file to a `FormFieldUpload` field that has an invalid extension.