### PR TITLE
MOS-1135 Updates number table types to support ReactNode labels

### DIFF
--- a/src/forms/FormFieldNumberTable/FormFieldNumberTable.test.tsx
+++ b/src/forms/FormFieldNumberTable/FormFieldNumberTable.test.tsx
@@ -115,16 +115,16 @@ describe("FormFieldNumberTable component", () => {
 
 	it("should display the columns titles", () => {
 		for (const column of columns) {
-			expect(screen.getByText(column.title)).toBeInTheDocument();
+			expect(screen.getByText(column.title as string)).toBeInTheDocument();
 		}
 	});
 
 	it("should display the rows titles", () => {
 		for (const row of rows) {
 			if (row.subtitle) {
-				expect(screen.getByText(row.subtitle)).toBeInTheDocument();
+				expect(screen.getByText(row.subtitle as string)).toBeInTheDocument();
 			}
-			expect(screen.getByText(row.title)).toBeInTheDocument();
+			expect(screen.getByText(row.title as string)).toBeInTheDocument();
 		}
 	});
 

--- a/src/forms/FormFieldNumberTable/FormFieldNumberTableTypes.ts
+++ b/src/forms/FormFieldNumberTable/FormFieldNumberTableTypes.ts
@@ -1,3 +1,4 @@
+import { ReactNode} from "react"
 import { FieldDefBase } from "@root/components/Field";
 
 export type NumberTableInputSettings = {
@@ -8,7 +9,7 @@ export type NumberTableInputSettings = {
   /**
    * Label shown on the column that displays the totals.
    */
-  columnTotalLabel?: string;
+  columnTotalLabel?: ReactNode;
   /**
    * Shows or hides the column that cointains the totals sums.
    */
@@ -29,11 +30,11 @@ export type NumberTableInputSettings = {
   /**
    * Label shown on the total row.
    */
-  rowTotalLabel?: string;
+  rowTotalLabel?: ReactNode;
   /**
    * 	Label placed on the top left corner i.e the first column.
    */
-  topLeftLabel?: string;
+  topLeftLabel?: ReactNode;
 };
 
 export interface Col {
@@ -44,14 +45,14 @@ export interface Col {
   /**
    * Label displayed on the table.
    */
-  title: string;
+  title: ReactNode;
 }
 
 export interface Row extends Col {
   /**
    * Optional label shown below the title of the row.
    */
-  subtitle?: string;
+  subtitle?: ReactNode;
 }
 
 /**


### PR DESCRIPTION
This PR updates `FormFieldNumberTable` types to support `ReactNode` labels, titles and subtitles.