### PR TITLE
Adds backLabel to all components that support onBack

### DIFF
--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -252,6 +252,7 @@ function DataView (props: DataViewProps): ReactElement  {
 						<DataViewTitleBar
 							title={props.title}
 							onBack={props.onBack}
+							backLabel={props.backLabel}
 							buttons={props.buttons}
 							savedViewEnabled={savedViewEnabled}
 							savedView={props.savedView}

--- a/src/components/DataView/DataViewColumDrawer/DataViewColumnDrawerContent.tsx
+++ b/src/components/DataView/DataViewColumDrawer/DataViewColumnDrawerContent.tsx
@@ -87,6 +87,7 @@ function DataViewColumnDrawerContent(props: DataViewColumnDrawerContentProps) {
 				title={t("mosaic:DataView.table_settings")}
 				buttons={drawerButton}
 				onBack={props.onClose}
+				backLabel={t("mosaic:DataView.cancel_table_settings")}
 			/>
 			<StyledWrapper>
 				<div className="left">

--- a/src/components/DataView/DataViewLocales.json
+++ b/src/components/DataView/DataViewLocales.json
@@ -23,7 +23,9 @@
 		"selected_options": "Selected Options",
 		"show_for_all_users": "Show for all Users",
 		"table_settings": "Table Settings",
-		"type": "Type"
+		"type": "Type",
+		"cancel_save_view": "Cancel save view",
+		"cancel_table_settings": "Cancel table settings"
 	},
 	"es" : {
 		"clear_filters": "Limpiar filtros",

--- a/src/components/DataView/DataViewLocales.json
+++ b/src/components/DataView/DataViewLocales.json
@@ -25,6 +25,7 @@
 		"table_settings": "Table Settings",
 		"type": "Type",
 		"cancel_save_view": "Cancel save view",
+		"cancel_saved_views": "Cancel saved views",
 		"cancel_table_settings": "Cancel table settings"
 	},
 	"es" : {

--- a/src/components/DataView/DataViewTitleBar/DataViewTitleBar.tsx
+++ b/src/components/DataView/DataViewTitleBar/DataViewTitleBar.tsx
@@ -29,6 +29,7 @@ function DataViewTitleBar(props: DataViewTitleBarProps) {
 						<TitleWrapper
 							title={props.title}
 							onBack={props.onBack}
+							backLabel={props.backLabel}
 						/>
 					}
 					{props.savedViewEnabled && (

--- a/src/components/DataView/DataViewTitleBar/DataViewTitleBarTypes.ts
+++ b/src/components/DataView/DataViewTitleBar/DataViewTitleBarTypes.ts
@@ -17,5 +17,6 @@ export interface DataViewTitleBarProps {
 	activeFilters?: DataViewProps["activeFilters"];
 	onActiveFiltersChange?: DataViewProps["onActiveFiltersChange"];
 	onBack?: DataViewProps["onBack"];
+	backLabel?: DataViewProps["backLabel"]
 	disabled?: DataViewProps["disabled"]
 }

--- a/src/components/DataView/DataViewTypes.ts
+++ b/src/components/DataView/DataViewTypes.ts
@@ -5,6 +5,7 @@ import { MenuItemProps } from "../MenuItem";
 import * as React from "react";
 import { DataViewActionsButtonRowProps } from "./DataViewActionsButtonRow";
 import { DataViewBulkActionsButtonsRowProps } from "./DataViewBulkActionsButtonsRow";
+import { TitleWrapperProps } from "@root/forms/TopComponent/Utils/TitleWrapperTypes";
 
 export interface DataViewColumnTransformArgs<T = unknown> {
 	/** The value of the specific column that is being transformed */
@@ -236,4 +237,5 @@ export interface DataViewProps {
 	onCheckChange?: DataViewOnCheckChange;
 	onCheckAllPagesChange?: DataViewOnCheckAllPagesChange;
 	onBack?: () => void;
+	backLabel?: TitleWrapperProps["backLabel"]
 }

--- a/src/components/DataView/DataViewViewDrawerContent/DataViewViewDrawerContent.tsx
+++ b/src/components/DataView/DataViewViewDrawerContent/DataViewViewDrawerContent.tsx
@@ -128,6 +128,7 @@ function DataViewViewDrawerContent(props: DataViewViewDrawerContentProps) {
 		<DrawerContent
 			title={t("mosaic:DataView.saved_views")}
 			onBack={props.onClose}
+			backLabel={t("mosaic:DataView.cancel_saved_views")}
 		>
 			{
 				state.options &&

--- a/src/components/DataView/DataViewViewSaveDrawerContent/DataViewViewSaveDrawerContent.tsx
+++ b/src/components/DataView/DataViewViewSaveDrawerContent/DataViewViewSaveDrawerContent.tsx
@@ -68,6 +68,7 @@ function DataViewViewSaveDrawerContent(props: DataViewViewSaveDrawerContentProps
 			title={t("mosaic:DataView.save_view")}
 			onSave={onSave}
 			onBack={props.onClose}
+			backLabel={t("mosaic:DataView.cancel_save_view")}
 			onCancel={props.onClose}
 			background="gray"
 		>

--- a/src/components/DrawerContent/DrawerContent.tsx
+++ b/src/components/DrawerContent/DrawerContent.tsx
@@ -61,6 +61,7 @@ function DrawerContent(props: DrawerContentProps) {
 				title={t(`mosaic:${props.title}`)}
 				buttons={drawerButtons}
 				onBack={props.onBack}
+				backLabel={props.backLabel}
 			/>
 			<DrawerBottom
 				background={props.background}

--- a/src/components/DrawerContent/DrawerTopBar.tsx
+++ b/src/components/DrawerContent/DrawerTopBar.tsx
@@ -6,6 +6,7 @@ import { H1 } from "../Typography";
 import Button from "../Button";
 import ButtonRow from "../ButtonRow";
 import { useMosaicTranslation } from "@root/i18n";
+import { TitleWrapperProps } from "@root/forms/TopComponent/Utils/TitleWrapperTypes";
 
 const StyledWrapper = styled.div`
 	& {
@@ -32,6 +33,7 @@ const StyledWrapper = styled.div`
 export interface DrawerTopBarProps {
 	title: string | JSX.Element;
 	onBack: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+	backLabel?: TitleWrapperProps["backLabel"]
 	onCancel?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 	onSave?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 	onApply?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -23,6 +23,7 @@ const Form = (props: FormProps) => {
 		state,
 		title,
 		onBack,
+		backLabel,
 		fields,
 		sections,
 		dispatch,
@@ -224,6 +225,7 @@ const Form = (props: FormProps) => {
 							ref={topComponentRef}
 							title={title}
 							onBack={onBack}
+							backLabel={backLabel}
 							description={description}
 							sections={topComponentSections}
 							view={view}

--- a/src/components/Form/FormTypes.tsx
+++ b/src/components/Form/FormTypes.tsx
@@ -1,6 +1,7 @@
 import { ButtonProps } from "@root/components/Button";
 import { FieldDef } from "@root/components/Field";
 import { Section } from "@root/forms/FormNav/FormNavTypes";
+import { TitleWrapperProps } from "@root/forms/TopComponent/Utils/TitleWrapperTypes";
 import { MosaicGridConfig, MosaicObject, MosaicShow } from "@root/types";
 
 
@@ -17,6 +18,7 @@ export interface FormProps {
 	state: any;
 	title?: string;
 	onBack?: (() => void) | ((...args: any) => void);
+	backLabel?: TitleWrapperProps["backLabel"]
 	fields: FieldDef[];
 	sections?: SectionDef[];
 	dispatch: any;

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -9,15 +9,20 @@ const PageHeader = forwardRef((props: PageHeaderProps, ref) => {
 	const {
 		title,
 		buttons,
-		onBack
+		onBack,
+		backLabel
 	} = props;
 
 	return (
 		<StyledPageHeader ref={ref} data-testid="page-header-test-id">
 			<StyledTitleRow>
-				{title &&
-					<TitleWrapper title={title} onBack={onBack} />
-				}
+				{title && (
+					<TitleWrapper
+						title={title}
+						onBack={onBack}
+						backLabel={backLabel}
+					/>
+				)}
 			</StyledTitleRow>
 			{buttons &&
 				<ButtonRow buttons={buttons} />

--- a/src/components/PageHeader/PageHeaderTypes.ts
+++ b/src/components/PageHeader/PageHeaderTypes.ts
@@ -1,8 +1,9 @@
 import { ButtonProps } from "@root/components/Button";
-import { FormProps } from "../Form";
+import { TitleWrapperProps } from "@root/forms/TopComponent/Utils/TitleWrapperTypes";
 
 export interface PageHeaderProps {
 	title?: string;
 	buttons?: ButtonProps[];
-	onBack?: FormProps["onBack"];
+	onBack?: TitleWrapperProps["onBack"];
+	backLabel?: TitleWrapperProps["backLabel"]
 }

--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponent.stories.tsx
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponent.stories.tsx
@@ -143,6 +143,7 @@ export const Example = (): ReactElement => {
 		<SummaryPageTopComponent
 			title={title}
 			onBack={onBack ? () => alert("Cancelling, going back to previous site") : undefined}
+			backLabel="Go back"
 			favorite={showFavorite && favorite}
 			img={img && "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1436900668/clients/grandrapids/Covered%20bridge%20in%20Ada_19c2ee0d-a43b-4aab-b102-65a0db32288b.jpg"}
 			mainActions={showMainActions && mainActions}

--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponent.tsx
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponent.tsx
@@ -24,6 +24,7 @@ const SumaryPageTopComponent = (props: SummaryPageTopComponentTypes): ReactEleme
 	const {
 		title,
 		onBack,
+		backLabel,
 		favorite,
 		img,
 		mainActions,
@@ -61,7 +62,7 @@ const SumaryPageTopComponent = (props: SummaryPageTopComponentTypes): ReactEleme
 			<Container>
 				<Row>
 					<ContainerTitle>
-						<TitleWrapper title={title} onBack={onBack} />
+						<TitleWrapper title={title} onBack={onBack} backLabel={backLabel} />
 						{
 							favorite &&
 								<>

--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponentTypes.ts
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponentTypes.ts
@@ -1,3 +1,4 @@
+import { TitleWrapperProps } from "@root/forms/TopComponent/Utils/TitleWrapperTypes";
 import { ButtonProps } from "../Button";
 import { MenuItemProps } from "../MenuItem";
 
@@ -42,4 +43,6 @@ export interface SummaryPageTopComponentTypes {
 	 * Optional. If present, the Back icon is displayed on the left side of the title.
 	*/
 	onBack?: () => void;
+
+	backLabel?: TitleWrapperProps["backLabel"]
   }

--- a/src/forms/FormFieldAdvancedSelection/AdvancedSelectionDrawer.tsx
+++ b/src/forms/FormFieldAdvancedSelection/AdvancedSelectionDrawer.tsx
@@ -73,6 +73,7 @@ const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactE
 				title={fieldDef?.label}
 				buttons={buttons}
 				onBack={handleClose}
+				backLabel="Cancel advanced selection"
 			/>
 			<DataViewFilterMultiselectDropdownContent
 				comparison={""}

--- a/src/forms/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
+++ b/src/forms/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
@@ -35,8 +35,6 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 		fieldDef,
 	} = props;
 
-	console.log(typeof fieldDef?.inputSettings?.selectLimit);
-
 	// State variables
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [isMobileView, setIsMobileView] = useState(false);

--- a/src/forms/TopComponent/TopComponent.tsx
+++ b/src/forms/TopComponent/TopComponent.tsx
@@ -29,6 +29,7 @@ const TopComponent = forwardRef<HTMLDivElement, TopComponentProps>((props: TopCo
 		showActive,
 		title,
 		onBack,
+		backLabel,
 		tooltipInfo,
 		sections,
 		activeSection,
@@ -80,6 +81,7 @@ const TopComponent = forwardRef<HTMLDivElement, TopComponentProps>((props: TopCo
 			ref={ref}
 			title={title}
 			onBack={onBack}
+			backLabel={backLabel}
 			description={description}
 			showActive={showActive}
 			tooltipInfo={tooltipInfo}
@@ -99,6 +101,7 @@ const TopComponent = forwardRef<HTMLDivElement, TopComponentProps>((props: TopCo
 			buttons={buttons}
 			title={title}
 			onBack={onBack}
+			backLabel={backLabel}
 			description={description}
 			helpIcon={helpIcon}
 			checkbox={checkbox}

--- a/src/forms/TopComponent/TopComponentTypes.tsx
+++ b/src/forms/TopComponent/TopComponentTypes.tsx
@@ -22,6 +22,7 @@ export type BaseTopComponentProps = {
 	 * Optional. If present, the Back icon is displayed on the left side of the title.
 	*/
 	onBack?: FormProps["onBack"];
+	backLabel?: FormProps["backLabel"]
 	/**
 	 * If present, the help icon is display with the
 	 * string defined with this prop.

--- a/src/forms/TopComponent/Utils/TitleWrapper.tsx
+++ b/src/forms/TopComponent/Utils/TitleWrapper.tsx
@@ -9,6 +9,7 @@ import theme from "@root/theme/theme";
 import { H1 } from "@root/components/Typography";
 import Button from "@root/components/Button";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import { TitleWrapperProps } from "./TitleWrapperTypes";
 
 const StyledWrapper = styled.div`
 	display: flex;
@@ -31,25 +32,26 @@ const Description = styled.span`
 	}
 `;
 
-export type TitleWrapperProps = {
-	title: string;
-	description?: string;
-	onBack?: (() => void) | ((e: any) => void)
-}
-
 const TitleWrapper = (props: TitleWrapperProps): ReactElement => {
 	const {
 		title,
 		description,
+		backLabel
 	} = props;
 
 	return (
 		<>
 			<StyledWrapper>
-				{
-					props.onBack &&
-						<Button className="back-button" color="black" variant="icon" mIcon={ChevronLeftIcon} onClick={props.onBack}/>
-				}
+				{props.onBack && (
+					<Button
+						className="back-button"
+						color="black"
+						variant="icon"
+						mIcon={ChevronLeftIcon}
+						onClick={props.onBack}
+						muiAttrs={{ "aria-label": backLabel }}
+					/>
+				)}
 				<H1 attrs={{ title }} >{title}</H1>
 			</StyledWrapper>
 			{description && <Description>{description}</Description>}

--- a/src/forms/TopComponent/Utils/TitleWrapper.tsx
+++ b/src/forms/TopComponent/Utils/TitleWrapper.tsx
@@ -36,7 +36,7 @@ const TitleWrapper = (props: TitleWrapperProps): ReactElement => {
 	const {
 		title,
 		description,
-		backLabel
+		backLabel = "Go back"
 	} = props;
 
 	return (

--- a/src/forms/TopComponent/Utils/TitleWrapperTypes.ts
+++ b/src/forms/TopComponent/Utils/TitleWrapperTypes.ts
@@ -1,0 +1,6 @@
+export type TitleWrapperProps = {
+	title: string;
+	description?: string;
+	onBack?: (() => void) | ((e: any) => void)
+    backLabel?: string
+}

--- a/src/forms/TopComponent/Views/DesktopView.tsx
+++ b/src/forms/TopComponent/Views/DesktopView.tsx
@@ -36,6 +36,7 @@ const DesktopView = forwardRef((props: DesktopViewProps, ref): ReactElement => {
 	const {
 		title,
 		onBack,
+		backLabel,
 		description,
 		tooltipInfo,
 		buttons,
@@ -55,6 +56,7 @@ const DesktopView = forwardRef((props: DesktopViewProps, ref): ReactElement => {
 					<TitleWrapper
 						title={title}
 						onBack={onBack}
+						backLabel={backLabel}
 						description={description}
 					/>
 				</TitleRow>

--- a/src/forms/TopComponent/Views/MobileView.tsx
+++ b/src/forms/TopComponent/Views/MobileView.tsx
@@ -46,6 +46,7 @@ const MobileView = forwardRef<HTMLDivElement, MobileViewProps>((props: MobileVie
 		buttons,
 		title,
 		onBack,
+		backLabel,
 		description,
 		showActive,
 		tooltipInfo,
@@ -66,6 +67,7 @@ const MobileView = forwardRef<HTMLDivElement, MobileViewProps>((props: MobileVie
 				<TitleWrapper
 					title={title}
 					onBack={onBack}
+					backLabel={backLabel}
 					description={description}
 				/>
 			</TitleRow>


### PR DESCRIPTION
This PR adds a `backLabel` property to all components that support the `onBack` callback, which renders a back button in the relevant header. The components that support it are:

- `DataView`
- `Form`
- `PageHeader`
- `SummaryPageTopComponent`

If the `backLabel` property is omitted, the label will default to "Go back".

Additionally, the following integrated components use the `backLabel` property:

- `DataView`'s column drawer back button will read "Cancel table settings"
- `DataView`'s views drawer back button will read "Cancel saved views"
- `DataView`'s save view drawer back button will read "Cancel save view"
- `FormFieldAdvancedSelection`'s option drawer back button will read "Cancel advanced selection"