### PR TITLE
MOS-1054 Form roles for testing

### DIFF
--- a/src/components/ButtonRow/ButtonRow.tsx
+++ b/src/components/ButtonRow/ButtonRow.tsx
@@ -33,7 +33,7 @@ function ButtonRow(props: ButtonRowProps) {
 	}
 
 	return (
-		<Row className={props.className} $wrap={wrap} data-testid="button-row">
+		<Row className={props.className} $wrap={wrap} data-testid="button-row" role="toolbar">
 			{children.map((elem: React.ReactNode, i: number) => (
 				<Item key={i} separator={props.separator} gap={gap}>
 					{elem}

--- a/src/forms/TopComponent/Views/DesktopView.tsx
+++ b/src/forms/TopComponent/Views/DesktopView.tsx
@@ -49,7 +49,7 @@ const DesktopView = forwardRef((props: DesktopViewProps, ref): ReactElement => {
 	} = props;
 
 	return (
-		<StyledColumn className={view} ref={ref} sections={sections && sections.length > 1}>
+		<StyledColumn className={view} ref={ref} sections={sections && sections.length > 1} data-testid="form-header">
 			<FlexContainer>
 				<TitleRow view={view}>
 					<TitleWrapper

--- a/src/forms/TopComponent/Views/MobileView.tsx
+++ b/src/forms/TopComponent/Views/MobileView.tsx
@@ -55,7 +55,7 @@ const MobileView = forwardRef<HTMLDivElement, MobileViewProps>((props: MobileVie
 	} = props;
 
 	return (
-		<div ref={ref}>
+		<div ref={ref} data-testid="form-header">
 			<MobileActionsRow className={view}>
 				<StyledClearIcon onClick={onBack} />
 				{buttons && (


### PR DESCRIPTION
This PR makes changes to assist with unit and automation tests:

- Adds the `data-testid="form-header"` to the form headers container element on both desktop and mobile layouts
- Adds the `role="toolbar"`