### PR TITLE
MOS-1104 Prevent unnecessary Form rerenders

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -234,28 +234,14 @@ const Form = (props: FormProps) => {
 							onSectionSelect={setActiveSection}
 						/>
 						}
-						{isBigDesktopWithSections ? (
-							<Row className={view}>
-								{sections &&
-									<SideNav
-										items={[items]}
-										active={String(activeSection)}
-										onNav={onNav}
-									/>
-								}
-								<FormContent view={view} sections={sections} ref={formContentRef}>
-									<FormLayout
-										// ref={sectionsRef}
-										registerRef={registerRef}
-										state={state}
-										dispatch={dispatch}
-										fields={fields}
-										sections={sections}
-										view={view}
-									/>
-								</FormContent>
-							</Row>
-						) : (
+						<Row className={view} isBigDesktopWithSections={isBigDesktopWithSections}>
+							{sections && isBigDesktopWithSections &&
+								<SideNav
+									items={[items]}
+									active={String(activeSection)}
+									onNav={onNav}
+								/>
+							}
 							<FormContent view={view} sections={sections} ref={formContentRef}>
 								<FormLayout
 									// ref={sectionsRef}
@@ -267,7 +253,7 @@ const Form = (props: FormProps) => {
 									view={view}
 								/>
 							</FormContent>
-						)}
+						</Row>
 					</StyledForm>
 				</StyledContainerForm>
 			</ViewProvider>

--- a/src/forms/TopComponent/TopComponent.styled.ts
+++ b/src/forms/TopComponent/TopComponent.styled.ts
@@ -32,6 +32,10 @@ export const FlexContainer = styled.div`
 `;
 
 export const Row = styled(FlexContainer)`
+  ${({ isBigDesktopWithSections }) => isBigDesktopWithSections && `
+    display: flex;
+  `}
+
   justify-content: space-between;
 
   &.BIG_DESKTOP {


### PR DESCRIPTION
This PR avoids draws closing unexpectedly by not rerendering `Form` every time the view system's breakpoint changes.