### PR TITLE
MOS-1119 Implements new value count validator

### DIFF
--- a/src/components/Form/Col/Col.tsx
+++ b/src/components/Form/Col/Col.tsx
@@ -64,6 +64,8 @@ function sanitizeSize(size: undefined | Sizes | string | number): string {
 	return String(size);
 }
 
+let typingTimer;
+
 const Col = (props: ColPropsTypes) => {
 	const {
 		col,
@@ -77,25 +79,8 @@ const Col = (props: ColPropsTypes) => {
 	} = props;
 
 	const doneTypingInterval = 300;
-	let typingTimer;
 
-	const sendValidateField = useCallback(async (curr, value) => {
-		const { maxCharacters } = curr?.inputSettings || { maxCharacters: 0 };
-		const exceeded = maxCharacters && typeof value === "string" && value.length > maxCharacters;
-
-		if (exceeded) {
-			await dispatch({
-				type: "FIELD_VALIDATE",
-				name: curr.name,
-				value: "You have exceeded the maximum number of characters"
-			})
-		} else {
-			await dispatch({
-				type: "FIELD_UNVALIDATE",
-				name: curr.name
-			})
-		}
-
+	const sendValidateField = useCallback(async (curr) => {
 		await dispatch(formActions.validateField({ name: curr.name }))
 
 		if (curr.pairedFields)
@@ -117,7 +102,7 @@ const Col = (props: ColPropsTypes) => {
 					})
 				);
 				clearTimeout(typingTimer);
-				typingTimer = setTimeout(async () => await sendValidateField(curr, value), doneTypingInterval);
+				typingTimer = setTimeout(async () => await sendValidateField(curr), doneTypingInterval);
 			};
 
 			return prev;

--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -124,6 +124,13 @@ export const formActions = {
 				validators.push(validatePhoneNumber);
 			}
 
+			if (extraArgs?.fieldMap[name]?.inputSettings?.maxCharacters) {
+				validators.push({
+					fn: "validateCharacterCount",
+					options: {max: extraArgs?.fieldMap[name]?.inputSettings?.maxCharacters}
+				});
+			}
+
 			if (validators.length === 0) {
 				return;
 			}

--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -124,7 +124,7 @@ export const formActions = {
 				validators.push(validatePhoneNumber);
 			}
 
-			if (extraArgs?.fieldMap[name]?.inputSettings?.maxCharacters) {
+			if (extraArgs?.fieldMap[name]?.inputSettings?.maxCharacters > 0) {
 				validators.push({
 					fn: "validateCharacterCount",
 					options: {max: extraArgs?.fieldMap[name]?.inputSettings?.maxCharacters}

--- a/src/components/Form/validators.ts
+++ b/src/components/Form/validators.ts
@@ -148,6 +148,20 @@ export function validateDateRange(value: string, data: any, options: { [key: str
 	return undefined;
 }
 
+export function validateCharacterCount(value: string, data: any, options: {max?: number}): string | undefined {
+	if (!options.max) {
+		return;
+	}
+
+	if (typeof value !== "string") {
+		return;
+	}
+
+	if (value.length > options.max) {
+		return "You have exceeded the maximum number of characters";
+	}
+}
+
 /**
  * Validate that the value is a correctly formed phone number
  * it only supports US (+1) phone numbers. Numbers for other countries
@@ -177,6 +191,7 @@ export function mapsValidators(validators): Validator[] {
 		isLatitude: isLatitude,
 		isLongitude: isLongitude,
 		validateDateRange: validateDateRange,
+		validateCharacterCount: validateCharacterCount,
 		validateEmail: validateEmail,
 		validateNumber: validateNumber,
 		validateSlow: validateSlow,


### PR DESCRIPTION
This PR modifies the max character behaviour that the text field uses. Instead of limiting the amount of characters to the `maxCharacter` amount, the user can exceed the amount but the character counter will turn red and the field will have an error. The behaviour is handled by a validator, so the form cannot be submitted whilst the count is exceeded.