### PR TITLE
MOS-1196 touched bug

### DIFF
--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -61,7 +61,12 @@ export function coreReducer(state: State, action: Action): State {
 			},
 			errors: action.clearErrors ? {} : state.errors
 		}
-	case "FIELD_TOUCHED":
+	case "FIELD_TOUCHED": {
+		// Don't return new state if the field touched value is already the incoming one
+		if (Boolean(state.touched[action.name]) === action.value) {
+			return state;
+		}
+
 		return {
 			...state,
 			touched: {
@@ -69,6 +74,7 @@ export function coreReducer(state: State, action: Action): State {
 				[action.name]: action.value
 			}
 		};
+	}
 	case "FIELD_VALIDATE":
 		// TODO this is bad there's no support for multiple errors, but will be refactored in
 		// https://simpleviewtools.atlassian.net/browse/MOS-1131

--- a/src/components/Form/stories/CopyField.stories.tsx
+++ b/src/components/Form/stories/CopyField.stories.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { ReactElement, useEffect, useMemo } from "react";
+import { boolean, withKnobs } from "@storybook/addon-knobs";
+
+// Utils
+import { formActions, useForm } from "@root/components/Form";
+import { renderButtons } from "@root/utils/storyUtils";
+
+// Components
+import Form from "../Form";
+
+// Types
+import { FieldDef } from "@root/components/Field";
+
+export default {
+	title: "Components/Form",
+	decorators: [withKnobs],
+};
+
+const ORIGINAL_BODY_MARGIN = document.body.style.margin;
+
+export const CopyField = (): ReactElement => {
+	const { state, dispatch } = useForm();
+
+	useEffect(() => {
+		document.body.style.margin = "0px";
+
+		return () => {
+			document.body.style.margin = ORIGINAL_BODY_MARGIN;
+		}
+	}, []);
+
+	const showState = boolean("Show state", false);
+
+	const fields = useMemo(
+		() : FieldDef[] =>
+			[
+				{
+					name: "name",
+					label: "Name",
+					type: "text",
+					required: true,
+				},
+				{
+					name: "slug",
+					label: "Slug",
+					type: "text",
+					required: true,
+					helperText: "The text for this field will be populated with a slugified version the name field, but only if this field hasn't been touched"
+				},
+			],
+		[]
+	);
+
+	useEffect(() => {
+		if (!state.touched.slug) {
+			const transformedLabel = state.data.name?.trim().toLowerCase().replace(/ {1,}/g, "_").replace(/[^a-z_]/g, "");
+			dispatch(formActions.setFieldValue({ name: "slug", value: transformedLabel }))
+		}
+	}, [state.data.name, state.touched]);
+
+	return (
+		<>
+			{
+				showState && <pre>{JSON.stringify(state, null, "  ")}</pre>
+			}
+			<div style={{height: "100vh"}}>
+				<Form
+					buttons={renderButtons(dispatch)}
+					title='Validators story'
+					state={state}
+					fields={fields}
+					dispatch={dispatch}
+				/>
+			</div>
+		</>
+	);
+};


### PR DESCRIPTION
Prevents returning a new state if the field's touched property matches the incoming boolean when setting field value.