### PR TITLE
MOS-1195 Removes touched reset on form submission

### DIFF
--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -235,14 +235,6 @@ export const formActions = {
 				formActions.validateForm({ fields: extraArgs.fields })
 			);
 
-			if (valid) {
-				await dispatch({
-					type: "PROPERTY_RESET",
-					name: "touched",
-					value: {},
-				});
-			}
-
 			const cleanData = Object.keys(data).reduce((acc, curr) => ({
 				...acc,
 				[curr]: mounted[curr] ? data[curr] : undefined


### PR DESCRIPTION
Removed the clearing of the `touched` object when a form with valid data is submitted