### PR TITLE
MOS-1198 Prevents extra form touch dispatch

### DIFF
--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -65,15 +65,8 @@ export const formActions = {
 				type: "FIELD_ON_CHANGE",
 				name,
 				value: isValidValue(value) ? value : undefined,
+				touched
 			});
-
-			if (touched) {
-				await dispatch({
-					type: "FIELD_TOUCHED",
-					name,
-					value: touched,
-				});
-			}
 
 			if (validate) {
 				await dispatch(formActions.validateField({ name }));

--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -40,6 +40,7 @@ type Action = {
 	value: any;
 	name?: string;
 	clearErrors?: boolean
+	touched?: boolean
 }
 
 export function coreReducer(state: State, action: Action): State {
@@ -50,7 +51,12 @@ export function coreReducer(state: State, action: Action): State {
 			data: {
 				...state.data,
 				[action.name]: action.value
-			}
+			},
+			touched: action.touched ? {
+				...state.touched,
+				[action.name]: true
+			} : state.touched
+
 		};
 	case "FIELDS_ON_CHANGE":
 		return {


### PR DESCRIPTION
Avoids dispatching an extraneous action to mark fields as touched, but instead provides the touched flag to the change reducer so that it can handle the touched flag with just one new state.