### PR TITLE
MOS-1194 v28 visual bugs

### DIFF
--- a/src/components/Field/Label.tsx
+++ b/src/components/Field/Label.tsx
@@ -46,6 +46,7 @@ const StyledInfoOutlinedIcon = styled(InfoOutlinedIcon)`
 `;
 
 const StyledInputLabel = styled(InputLabel)`
+	font-weight: ${theme.fontWeight.semiBold} !important;
   	align-self: center;
 	color: ${theme.newColors.grey4["100"]} !important;
 `;

--- a/src/components/Form/Form.styled.ts
+++ b/src/components/Form/Form.styled.ts
@@ -32,11 +32,7 @@ export const StyledFormContent = styled.div`
 	overflow-y: auto;
 	flex-grow: 1;
 	min-width: 0;
-	padding: 18px 20px;
-
-	${containerQuery("lg", "FORM")} {
-		padding: 32px 40px;
-	}
+	padding: 24px;
 `;
 
 export const StyledFormPrimary = styled.div`

--- a/src/components/Form/Form.styled.ts
+++ b/src/components/Form/Form.styled.ts
@@ -3,13 +3,11 @@ import { CONTAINERS } from "@root/theme/theme";
 import SideNav from "../SideNav/SideNav";
 import { containerQuery } from "@root/utils/css";
 
-export const StyledForm = styled.form`
+export const StyledContainerForm = styled.div<{fullHeight?: boolean}>`
+	position: relative;
 	display: flex;
 	flex-direction: column;
-	height: 100vh;
-`;
 
-export const StyledContainerForm = styled.div`
 	&.disabled {
 		opacity: .5;
 		pointer-events: none;
@@ -17,6 +15,17 @@ export const StyledContainerForm = styled.div`
 
 	container-type: inline-size;
 	container-name: ${CONTAINERS.FORM};
+
+	${({ fullHeight = true }) => fullHeight && `
+		height: 100%;
+	`}
+`;
+
+export const StyledForm = styled.form`
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 0%;
+	min-height: 0;
 `;
 
 export const StyledFormContent = styled.div`

--- a/src/components/Form/Form.styled.ts
+++ b/src/components/Form/Form.styled.ts
@@ -3,7 +3,7 @@ import { CONTAINERS } from "@root/theme/theme";
 import SideNav from "../SideNav/SideNav";
 import { containerQuery } from "@root/utils/css";
 
-export const StyledContainerForm = styled.div<{fullHeight?: boolean}>`
+export const StyledContainerForm = styled.div<{$fullHeight?: boolean}>`
 	position: relative;
 	display: flex;
 	flex-direction: column;
@@ -16,7 +16,7 @@ export const StyledContainerForm = styled.div<{fullHeight?: boolean}>`
 	container-type: inline-size;
 	container-name: ${CONTAINERS.FORM};
 
-	${({ fullHeight = true }) => fullHeight && `
+	${({ $fullHeight = true }) => $fullHeight && `
 		height: 100%;
 	`}
 `;

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -191,7 +191,7 @@ const Form = (props: FormProps) => {
 				aria-busy={isBusy ? "true" : "false"}
 				role="form"
 				aria-label={title}
-				fullHeight={fullHeight}
+				$fullHeight={fullHeight}
 			>
 				<StyledForm autoComplete="off">
 					{title && (

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -47,7 +47,8 @@ const Form = (props: FormProps) => {
 		handleDialogClose,
 		tooltipInfo,
 		showActive,
-		scrollSpyThreshold = 0.15
+		scrollSpyThreshold = 0.15,
+		fullHeight = true
 	} = props;
 
 	const [sectionRefs, setSectionRefs] = useState<HTMLElement[]>([]);
@@ -185,12 +186,12 @@ const Form = (props: FormProps) => {
 		<>
 			<StyledContainerForm
 				data-testid="form-test-id"
-				style={{ position: "relative", height: "100%" }}
 				ref={formContainerRef}
 				className={state.disabled ? "disabled" : ""}
 				aria-busy={isBusy ? "true" : "false"}
 				role="form"
 				aria-label={title}
+				fullHeight={fullHeight}
 			>
 				<StyledForm autoComplete="off">
 					{title && (

--- a/src/components/Form/FormTypes.tsx
+++ b/src/components/Form/FormTypes.tsx
@@ -33,6 +33,7 @@ export interface FormProps {
 	tooltipInfo?: string;
 	showActive?: boolean;
 	scrollSpyThreshold?: number;
+	fullHeight?: boolean
 }
 
 export { FieldDef, FieldDefCustom };

--- a/src/components/Form/Section/SectionStyled.tsx
+++ b/src/components/Form/Section/SectionStyled.tsx
@@ -6,7 +6,6 @@ import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import { StyledProps } from "@root/types";
-import { containerQuery } from "@root/utils/css";
 import { SectionPropTypes } from "./SectionTypes";
 
 export const StyledAccordion = styled(Accordion)<StyledProps<SectionPropTypes, "title">>`
@@ -50,12 +49,7 @@ export const StyledDescription = styled.p`
 	font-family: ${theme.fontFamily};
 	color: ${theme.newColors.grey3["100"]};
 	margin: 18px 0 0;
-	padding: 0 20px;
-
-	${containerQuery("lg", "FORM")} {
-		margin-top: 32px;
-		padding: 0 40px;
-	}
+	padding: 0 24px;
 `;
 
 export const StyledRows = styled.div<StyledProps<SectionPropTypes, "title">>`
@@ -65,11 +59,7 @@ export const StyledRows = styled.div<StyledProps<SectionPropTypes, "title">>`
 	gap: 24px 0;
 
 	${({ $title }) => $title && `
-		padding: 18px 20px;
-
-		${containerQuery("lg", "FORM")} {
-			padding: 32px 40px;
-		}
+		padding: 18px 24px;
 	`}
 `;
 

--- a/src/components/Form/Top/TopStyled.tsx
+++ b/src/components/Form/Top/TopStyled.tsx
@@ -11,10 +11,10 @@ import { containerQuery } from "@root/utils/css";
 
 export const TopRoot = styled.div<{$bottomBorder?: boolean}>`
 	border-bottom: 2px solid ${theme.newColors.grey2["100"]};
-	padding: 0 20px 20px;
+	padding: 0 24px 24px;
 
 	${containerQuery("sm", "FORM")} {
-		padding-top: 20px;
+		padding-top: 24px;
 	}
 
 	${({$bottomBorder}) => !$bottomBorder && `
@@ -24,7 +24,7 @@ export const TopRoot = styled.div<{$bottomBorder?: boolean}>`
 		}
 
 		${containerQuery("xl", "FORM")} {
-			padding-bottom: 20px;
+			padding-bottom: 24px;
 		}
 	`}
 
@@ -48,8 +48,8 @@ export const TopWrapper = styled.div`
 
 export const PrimaryActions = styled.div`
 	display: flex;
-	margin: 0 -20px 20px;
-	padding: 12px 20px;
+	margin: 0 -24px 24px;
+	padding: 12px 24px;
 	order: -1;
 	justify-content: end;
   	background-color: ${theme.newColors.grey2["100"]};

--- a/src/components/Form/stories/Playground.stories.tsx
+++ b/src/components/Form/stories/Playground.stories.tsx
@@ -666,7 +666,7 @@ export const Playground = (): ReactElement => {
 	}, [prepopulate, showGetFormValues, showDefaultValues]);
 
 	return (
-		<>
+		<div style={{height: "100vh"}}>
 			{
 				showState && <pre>{JSON.stringify(state, null, "  ")}</pre>
 			}
@@ -683,6 +683,6 @@ export const Playground = (): ReactElement => {
 				tooltipInfo={showTooltipInfo && tooltipInfo}
 				showActive={showActive}
 			/>
-		</>
+		</div>
 	);
 };

--- a/src/components/SideNav/SideNav.styled.tsx
+++ b/src/components/SideNav/SideNav.styled.tsx
@@ -15,14 +15,12 @@ export const StyledSideNav = styled.nav<{$collapse?: MosaicCSSContainer}>`
 			min-width: 196px;
 			padding: 0;
 			overflow: auto;
-			height: 100%;
 		}
 	` : `
 		border-right: 2px solid ${theme.newColors.grey2["100"]};
 		width: 196px;
 		min-width: 196px;
 		overflow: auto;
-		height: 100%;
 	`}
 `;
 

--- a/src/components/SideNav/SideNav.styled.tsx
+++ b/src/components/SideNav/SideNav.styled.tsx
@@ -6,7 +6,7 @@ import { containerQuery } from "@root/utils/css";
 export const StyledSideNav = styled.nav<{$collapse?: MosaicCSSContainer}>`
 	${({$collapse}) => $collapse ? `
 		border-bottom: 2px solid ${theme.newColors.grey2["100"]};
-		padding: 0 20px;
+		padding: 0 24px;
 
 		${containerQuery($collapse.minWidth, $collapse.name)}  {
 			border-bottom: 0;


### PR DESCRIPTION
- Adjusts padding around form sections
- Has form stretch 100% of it's container by default, but introduces a `fullHeight` prop that can be `false` to prevent that
- Ensures field labels are semi-bold