### PR TITLE
MOS-1193 Sets time to midnight if time field is not enabled

### DIFF
--- a/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
@@ -73,27 +73,6 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 
 		setDateChosen(date);
 
-		/**
-		 * -- START --
-		 * To force the user to pick a time if a date is chosen (regardless
-		 * of whether or not it's required), do this:
-		 */
-
-		// if (showTime && !timeChosen) {
-		// 	setError(PROVIDE_TIME);
-		// }
-
-		// if (!showTime || timeChosen) {
-		// 	matchTime(date, showTime && timeChosen ? timeChosen : [0, 0, 0, 0]);
-		// 	onChange(date);
-		// } else {
-		// 	onChange(undefined);
-		// }
-
-		/**
-		 * Otherwise do this
-		 */
-
 		if (showTime) {
 			if (fieldDef.required && !timeChosen) {
 				setError(PROVIDE_TIME);
@@ -101,6 +80,8 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 			}
 
 			matchTime(date, timeChosen ? timeChosen : [0, 0, 0, 0]);
+		} else {
+			matchTime(date, [0, 0, 0, 0]);
 		}
 
 		onChange(date);


### PR DESCRIPTION
When picking a date from the datepicker, this ensures the time is always set to midnight if the time field is not enabled. If the time field is enabled, the existing time will be retained.