### PR TITLE
MOS-1194 Minor visual changes

### DIFF
--- a/src/components/ButtonRow/ButtonRow.styled.tsx
+++ b/src/components/ButtonRow/ButtonRow.styled.tsx
@@ -4,11 +4,6 @@ import styled from "styled-components";
 import { ButtonRowProps } from "./ButtonRowTypes";
 import { StyledProps } from "@root/types";
 
-const gapMap: Record<ButtonRowProps["gap"], string> = {
-	small: "10px",
-	large: "16px"
-}
-
 export const Row = styled.div<StyledProps<ButtonRowProps, "wrap">>`
 	display: flex;
 	align-items: center;
@@ -18,13 +13,13 @@ export const Row = styled.div<StyledProps<ButtonRowProps, "wrap">>`
 	`}
 `;
 
-export const Item = styled.div<StyledProps<ButtonRowProps, "separator" | "gap">>`
+export const Item = styled.div<StyledProps<ButtonRowProps, "separator">>`
 	display: flex;
 	align-items: center;
 
-	${({$separator, $gap}) => `
+	${({$separator}) => `
 		& + &{
-			margin-left: ${gapMap[$gap]};
+			margin-left: 8px;
 		}
 
 		${$separator && `
@@ -32,7 +27,7 @@ export const Item = styled.div<StyledProps<ButtonRowProps, "separator" | "gap">>
 				content: ' ';
 				height: 1.4em;
 				border-left: 2px solid ${theme.newColors.grey2["100"]};
-				margin-right: ${gapMap[$gap]};
+				margin-right: 8px;
 			}
 		`}
 	`}

--- a/src/components/ButtonRow/ButtonRow.tsx
+++ b/src/components/ButtonRow/ButtonRow.tsx
@@ -10,7 +10,7 @@ function ButtonRow(props: ButtonRowProps) {
 		throw new Error("ButtonRow cannot receive both children and a buttons prop");
 	}
 
-	const {gap = "large", wrap = false} = props;
+	const { wrap = false } = props;
 
 	const children = useMemo(() => {
 		if (props.children) {
@@ -35,7 +35,7 @@ function ButtonRow(props: ButtonRowProps) {
 	return (
 		<Row className={props.className} $wrap={wrap} data-testid="button-row" role="toolbar">
 			{children.map((elem: React.ReactNode, i: number) => (
-				<Item key={i} $separator={props.separator} $gap={gap}>
+				<Item key={i} $separator={props.separator}>
 					{elem}
 				</Item>
 			))}

--- a/src/components/ButtonRow/ButtonRowTypes.ts
+++ b/src/components/ButtonRow/ButtonRowTypes.ts
@@ -5,6 +5,9 @@ export interface ButtonRowProps {
 	children?: React.ReactNode
 	className?: string
 	separator?: boolean
+	/**
+	 * @deprecated
+	 */
 	gap?: "small" | "large"
 	wrap?: boolean
 }

--- a/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRow.tsx
+++ b/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRow.tsx
@@ -92,7 +92,7 @@ function DataViewActionsButtonRow(props: DataViewActionsButtonRowProps) {
 	}
 
 	return (
-		<ButtonRow gap="small">
+		<ButtonRow>
 			{buttons}
 		</ButtonRow>
 	)

--- a/src/components/DataView/DataViewActionsRow/DataViewActionsRow.tsx
+++ b/src/components/DataView/DataViewActionsRow/DataViewActionsRow.tsx
@@ -75,7 +75,7 @@ const DataViewActionsRow = (props: DataViewActionsRowProps): ReactElement => {
 					allColumns={allColumns}
 				/>
 			)}
-			<ButtonRow separator gap="small">
+			<ButtonRow separator>
 				{
 					hasSortControl && display === "grid" &&
 						<DataViewDisplayGridSortControl

--- a/src/components/Field/FormFieldUpload/FileCard/FileCard.tsx
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCard.tsx
@@ -85,7 +85,7 @@ const FileCard = (props: FileCardProps) => {
 					</Tooltip>
 					<p className='file-size' data-testid="file-size">{sizeHuman ?? "File size"}</p>
 				</div>
-				<ButtonRow separator gap="small">
+				<ButtonRow separator>
 					{(downloadUrl || fileUrl) && (
 						<div className="file-download-btn">
 							{downloadStrategy === "anchor" ? (

--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponent.tsx
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponent.tsx
@@ -76,7 +76,7 @@ const SumaryPageTopComponent = (props: SummaryPageTopComponentTypes): ReactEleme
 								</>
 						}
 					</ContainerTitle>
-					<ButtonRow separator gap="small" wrap>
+					<ButtonRow separator wrap>
 						{
 							filteredMainActions &&
 							filteredMainActions.map((mainAction, i) => (
@@ -112,7 +112,7 @@ const SumaryPageTopComponent = (props: SummaryPageTopComponentTypes): ReactEleme
 				</Row>
 				<Row>
 					{descriptionItems && (
-						<ButtonRow separator gap="small" wrap>
+						<ButtonRow separator wrap>
 							{
 								descriptionItems.map((item, i) => (
 									<Item key={i} data-testid="description-item">


### PR DESCRIPTION
Deprecates the `gap` row that was available on `ButtonRow`. Now all button rows have a gap of 8px