### PR TITLE
MOS-1147 Amends  "email" typo

### DIFF
--- a/automation_testing/utils/data/formData.ts
+++ b/automation_testing/utils/data/formData.ts
@@ -4,7 +4,7 @@ export const validatorsData = {
 	requireError: "This field is required, please fill it",
 	validEmail: "test@mail.com",
 	invalidEmail: "aaa",
-	emailError: "The value is not a valid e-mail",
+	emailError: "The value is not a valid email",
 	validNumber: 123456,
 	invalidNumber: "sabs",
 	numberError: "The value is not a number",

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -818,7 +818,7 @@ const fields = useMemo(
 ## FormFieldText
 This field implements the [**FieldDef**](#generic-field-props-fielddef) interface.
 
-- Text input fields are used to enter text information, numbers, e-mail addresses, or passwords.
+- Text input fields are used to enter text information, numbers, email addresses, or passwords.
 - A text field consists of a label and a line with variations in width.
 - [**Playground**](/?path=/story/formfields-formfieldtext--playground)
 - Data: `string | number` - Value of the input typed.
@@ -1788,7 +1788,7 @@ All of the following default validators return string (with the error message) o
 
 ### validateEmail
 * Receives: string
-* Error message returned: "The value is not a valid e-mail"
+* Error message returned: "The value is not a valid email"
 * Ways of declaring:
 	* "validateEmail"
 	* { fn: "validateEmail", options: undefined }

--- a/src/components/Form/validators.ts
+++ b/src/components/Form/validators.ts
@@ -22,7 +22,7 @@ export function validateEmail(str: string): string | undefined {
 
 	if (isValidEmail) return;
 
-	return "The value is not a valid e-mail";
+	return "The value is not a valid email";
 }
 
 export function validateSlow(str: string): Promise<void | string> {


### PR DESCRIPTION
Replaces all occurences of the incorrectly typed "e-mail" text to "email".