### PR TITLE
MOS-1131 form system refactor

### DIFF
--- a/automation_testing/tests/FormFields/FormFieldMapCoordinates/FormFieldMapCoordinates.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldMapCoordinates/FormFieldMapCoordinates.spec.ts
@@ -30,12 +30,14 @@ test.describe.parallel("FormFields - FormFieldMapCoordinates - Kitchen Sink", ()
 		await ffMapCoordinatesPage.mapWithoutAddressAndAutocoordinatesDisabledButton.click();
 		await ffMapCoordinatesPage.longitude.type("10");
 		await ffMapCoordinatesPage.latitude.type("91");
+		await ffMapCoordinatesPage.latitude.blur();
 
 		expect(await ffMapCoordinatesPage.errorMessage.textContent()).toBe("Latitude should be between -90 and 90");
 		await expect(ffMapCoordinatesPage.saveCoordinatesButton).toBeDisabled();
 
 		await ffMapCoordinatesPage.latitude.type("");
 		await ffMapCoordinatesPage.latitude.type("-91");
+		await ffMapCoordinatesPage.latitude.blur();
 		expect(await ffMapCoordinatesPage.errorMessage.textContent()).toBe("Latitude should be between -90 and 90");
 		await expect(ffMapCoordinatesPage.saveCoordinatesButton).toBeDisabled();
 	});
@@ -44,12 +46,14 @@ test.describe.parallel("FormFields - FormFieldMapCoordinates - Kitchen Sink", ()
 		await ffMapCoordinatesPage.mapWithoutAddressAndAutocoordinatesDisabledButton.click();
 		await ffMapCoordinatesPage.latitude.type("10");
 		await ffMapCoordinatesPage.longitude.type("181");
+		await ffMapCoordinatesPage.longitude.blur();
 
 		expect(await ffMapCoordinatesPage.errorMessage.textContent()).toBe("Longitude should be between -180 and 180");
 		await expect(ffMapCoordinatesPage.saveCoordinatesButton).toBeDisabled();
 
 		await ffMapCoordinatesPage.longitude.type("");
 		await ffMapCoordinatesPage.longitude.type("-181");
+		await ffMapCoordinatesPage.longitude.blur();
 		expect(await ffMapCoordinatesPage.errorMessage.textContent()).toBe("Longitude should be between -180 and 180");
 		await expect(ffMapCoordinatesPage.saveCoordinatesButton).toBeDisabled();
 	});

--- a/automation_testing/tests/FormFields/FormFieldMapCoordinates/FormFieldMapCoordinates.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldMapCoordinates/FormFieldMapCoordinates.spec.ts
@@ -30,14 +30,14 @@ test.describe.parallel("FormFields - FormFieldMapCoordinates - Kitchen Sink", ()
 		await ffMapCoordinatesPage.mapWithoutAddressAndAutocoordinatesDisabledButton.click();
 		await ffMapCoordinatesPage.longitude.type("10");
 		await ffMapCoordinatesPage.latitude.type("91");
-		await ffMapCoordinatesPage.latitude.blur();
+		await ffMapCoordinatesPage.latitude.evaluate(e => e.blur());
 
 		expect(await ffMapCoordinatesPage.errorMessage.textContent()).toBe("Latitude should be between -90 and 90");
 		await expect(ffMapCoordinatesPage.saveCoordinatesButton).toBeDisabled();
 
 		await ffMapCoordinatesPage.latitude.type("");
 		await ffMapCoordinatesPage.latitude.type("-91");
-		await ffMapCoordinatesPage.latitude.blur();
+		await ffMapCoordinatesPage.latitude.evaluate(e => e.blur());
 		expect(await ffMapCoordinatesPage.errorMessage.textContent()).toBe("Latitude should be between -90 and 90");
 		await expect(ffMapCoordinatesPage.saveCoordinatesButton).toBeDisabled();
 	});
@@ -46,14 +46,14 @@ test.describe.parallel("FormFields - FormFieldMapCoordinates - Kitchen Sink", ()
 		await ffMapCoordinatesPage.mapWithoutAddressAndAutocoordinatesDisabledButton.click();
 		await ffMapCoordinatesPage.latitude.type("10");
 		await ffMapCoordinatesPage.longitude.type("181");
-		await ffMapCoordinatesPage.longitude.blur();
+		await ffMapCoordinatesPage.longitude.evaluate(e => e.blur());
 
 		expect(await ffMapCoordinatesPage.errorMessage.textContent()).toBe("Longitude should be between -180 and 180");
 		await expect(ffMapCoordinatesPage.saveCoordinatesButton).toBeDisabled();
 
 		await ffMapCoordinatesPage.longitude.type("");
 		await ffMapCoordinatesPage.longitude.type("-181");
-		await ffMapCoordinatesPage.longitude.blur();
+		await ffMapCoordinatesPage.longitude.evaluate(e => e.blur());
 		expect(await ffMapCoordinatesPage.errorMessage.textContent()).toBe("Longitude should be between -180 and 180");
 		await expect(ffMapCoordinatesPage.saveCoordinatesButton).toBeDisabled();
 	});

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -30,8 +30,8 @@ const Field = ({
 			return;
 		}
 
-		dispatch(formActions.mountField({name: fieldDef?.name}));
-		return () => dispatch(formActions.unmountField({name: fieldDef?.name}))
+		dispatch(formActions.mountField({ name: fieldDef?.name }));
+		return () => dispatch(formActions.unmountField({ name: fieldDef?.name }))
 	}, [dispatch, fieldDef?.name]);
 
 	return (

--- a/src/components/Field/FieldTypes.tsx
+++ b/src/components/Field/FieldTypes.tsx
@@ -144,10 +144,6 @@ export interface FieldDefBase<Type, T = any, U = any> {
 	 */
 	defaultValue?: U;
 	/**
-	 * Array of fields linked to a specific field.
-	 */
-	pairedFields?: string[];
-	/**
 	 * Callback executed when the current fields has changed
 	 */
 	onBlurCb?: (value?: any) => void;

--- a/src/components/Field/FieldTypes.tsx
+++ b/src/components/Field/FieldTypes.tsx
@@ -19,7 +19,7 @@ import { FieldDefTextEditor } from "@root/components/Field/FormFieldTextEditor/F
 import { FieldDefToggleSwitch } from "@root/components/Field/FormFieldToggleSwitch";
 import { FieldDefUpload } from "@root/components/Field/FormFieldUpload";
 import { MosaicShow } from "@root/types";
-import { HTMLAttributes,  MutableRefObject,  ReactNode } from "react";
+import { ElementType, HTMLAttributes,  MutableRefObject,  ReactNode } from "react";
 
 // MOSAIC GENERIC CONTRACT
 export interface MosaicFieldProps<T = any, U = any, V = any> {
@@ -118,6 +118,8 @@ export interface FieldDefBase<Type, T = any, U = any> {
 	/**
 	 * Object that defines the position of the current field in the
 	 * form layout.
+	 *
+	 * @deprecated
 	 */
 	layout?: {
 		section?: number,
@@ -129,6 +131,10 @@ export interface FieldDefBase<Type, T = any, U = any> {
 	 * when submitted.
 	 */
 	validators?: (((args?: any) => string | undefined | JSX.Element | Promise<void | string>) | string | { fn: string; options: any })[];
+	/**
+	 * When to validate the field
+	 */
+	validateOn?: FieldValidateOn
 	/**
 	 * Identifier passed by the developer
 	 */
@@ -179,4 +185,11 @@ export type FieldDef =
 	| FieldDefCustom
 	| FieldDefNumberTable
 	| FieldDefRaw;
+
+export type FieldValidateOn = "onBlur" | "onChange" | "onBlurChange";
+
+export type FieldConfig = {
+	Component: ElementType,
+	validate: FieldValidateOn
+}
 

--- a/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
@@ -12,10 +12,8 @@ import { DateFieldInputSettings, DateData } from "./DateFieldTypes";
 import { isEqual } from "date-fns";
 import { matchTime, textIsValidDate } from "@root/utils/date";
 import { DATE_FORMAT_FULL, DATE_FORMAT_FULL_PLACEHOLDER, TIME_FORMAT_FULL, TIME_FORMAT_FULL_PLACEHOLDER } from "@root/constants";
-
-const ENTER_VALID_DATE = `Please enter a valid ${DATE_FORMAT_FULL_PLACEHOLDER} date`;
-const ENTER_VALID_TIME = `Please enter a valid ${TIME_FORMAT_FULL_PLACEHOLDER} time`;
-const PROVIDE_TIME = "Please also provide a time";
+import { INVALID_DATE, INVALID_TIME, TIME_REQUIRED } from "@root/components/Form/fieldErrors";
+import { useFieldErrors } from "@root/utils/hooks";
 
 const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, DateData>): ReactElement => {
 	const {
@@ -35,6 +33,11 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 	const [dateChosen, setDateChosen] = useState<null | Date>(value);
 	const [timeChosen, setTimeChosen] = useState<null | Date>(value);
 
+	const { addError, removeError } = useFieldErrors({
+		dispatch,
+		name: fieldDef.name
+	});
+
 	useEffect(() => {
 		if (!value) {
 			return;
@@ -44,38 +47,23 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		setTimeChosen((time) => isEqual(time, value) ? time : value);
 	}, [value]);
 
-	const setError = (msg: string) => dispatch && dispatch((d) => {
-		d({
-			type: "FIELD_VALIDATE",
-			name: fieldDef.name,
-			value: msg,
-		})
-	});
-
-	const clearError = () => dispatch && dispatch((d) => {
-		d({
-			type: "FIELD_UNVALIDATE",
-			name: fieldDef.name
-		})
-	});
-
 	const handleDateChange = async (date: Date, keyboardInputValue?: string) => {
 		const isKeyboardEvent = keyboardInputValue !== undefined;
 		const validKeyboardInput = textIsValidDate(keyboardInputValue, DATE_FORMAT_FULL);
 
-		clearError();
-
 		if (isKeyboardEvent && !validKeyboardInput) {
 			// This handler was caused by keyboard input, but it's not a valid date
-			setError(ENTER_VALID_DATE);
+			addError(INVALID_DATE);
 			return onChange(undefined);
+		} else {
+			removeError(INVALID_DATE);
 		}
 
 		setDateChosen(date);
 
 		if (showTime) {
 			if (fieldDef.required && !timeChosen) {
-				setError(PROVIDE_TIME);
+				addError(TIME_REQUIRED);
 				return onChange(undefined);
 			}
 
@@ -92,12 +80,12 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		const isKeyboardEvent = keyboardInputValue !== undefined;
 		const validKeyboardInput = textIsValidDate(keyboardInputValue, TIME_FORMAT_FULL);
 
-		clearError();
-
 		if (!time || (isKeyboardEvent && !validKeyboardInput)) {
 			// This handler was caused by keyboard input, but it's not a valid date
-			setError(ENTER_VALID_TIME);
+			addError(INVALID_TIME);
 			return onChange(undefined);
+		} else {
+			removeError([TIME_REQUIRED, INVALID_TIME]);
 		}
 
 		setTimeChosen(time);

--- a/src/components/Field/FormFieldMapCoordinates/MapCoordinatesDrawer/MapCoordinatesDrawer.tsx
+++ b/src/components/Field/FormFieldMapCoordinates/MapCoordinatesDrawer/MapCoordinatesDrawer.tsx
@@ -69,7 +69,7 @@ const MapCoordinatesDrawer = (props: MapCoordinatesDrawerProps): ReactElement =>
 			return;
 		}
 
-		dispatch(formActions._setFieldValues({
+		dispatch(formActions.setFormValues({
 			values: {
 				lat: parts[0].trim(),
 				lng: parts[1].trim()
@@ -155,7 +155,7 @@ const MapCoordinatesDrawer = (props: MapCoordinatesDrawerProps): ReactElement =>
 		const lng = coords ? coords.lng : undefined;
 
 		dispatch(
-			formActions._setFieldValues({
+			formActions.setFormValues({
 				values: {
 					placesList: { lat, lng },
 					lat: String(lat),
@@ -201,7 +201,7 @@ const MapCoordinatesDrawer = (props: MapCoordinatesDrawerProps): ReactElement =>
 					type: ({value}) => (
 						<ResetButton
 							show={value}
-							onClick={() => dispatch(formActions._setFieldValues({
+							onClick={() => dispatch(formActions.setFormValues({
 								values: {
 									lat: undefined,
 									lng: undefined,

--- a/src/components/Field/FormFieldMatrix/FormFieldMatrix.stories.tsx
+++ b/src/components/Field/FormFieldMatrix/FormFieldMatrix.stories.tsx
@@ -28,6 +28,46 @@ export default {
 	decorators: [withKnobs],
 };
 
+const DrawerEditForm = ({
+	onClose,
+	onSave,
+	title,
+	fields
+}: {
+	onClose: () => void,
+	onSave: (data: any) => void,
+	title: string,
+	fields: FieldDef[]
+}): ReactElement => {
+	const { state, dispatch } = useForm();
+
+	const onSaveClick = () => onSave(state.data);
+
+	return (
+		<Form
+			buttons={[
+				{
+					label: "Cancel",
+					onClick: onClose,
+					color: "gray",
+					variant: "outlined",
+				},
+				{
+					label: "Save",
+					onClick: onSaveClick,
+					color: "yellow",
+					variant: "contained"
+				},
+			]}
+			title={title}
+			state={state}
+			fields={fields}
+			dispatch={dispatch}
+			onBack={onClose}
+		/>
+	)
+}
+
 export const FormVariant = (): ReactElement => {
 	const disabled = boolean("Disabled", false);
 	const required = boolean("Required", false);
@@ -43,24 +83,6 @@ export const FormVariant = (): ReactElement => {
 	});
 
 	const addDrawer = useCallback(async (drawerDef, edit?) => {
-		if (!edit) {
-			await dispatch(
-				formActions.setFieldValue({
-					name: "title",
-					value: "",
-					touched: true
-				})
-			);
-
-			await dispatch(
-				formActions.setFieldValue({
-					name: "description",
-					value: "",
-					touched: true
-				})
-			);
-		}
-
 		setDrawerState((state) => ({
 			...state,
 			drawers: [...state.drawers, drawerDef],
@@ -75,13 +97,13 @@ export const FormVariant = (): ReactElement => {
 		}));
 	}, []);
 
-	const addOrEdit = async () => {
+	const addOrEdit = async (data) => {
 		if (!isEditing) {
 			const id = "id" + Math.random().toString(16).slice(2)
 			const newRow = {
 				id: id,
-				title: state.data.title,
-				description: state.data.description
+				title: data.title,
+				description: data.description
 			};
 
 			if (state.data?.formMatrix?.length > 0) {
@@ -104,8 +126,8 @@ export const FormVariant = (): ReactElement => {
 		} else {
 			const editedRow = {
 				id: state.data.formMatrix[indexEdit].id,
-				title: state.data.title,
-				description: state.data.description,
+				title: data.title,
+				description: data.description,
 			};
 			const currentRows = [...state.data.formMatrix];
 			currentRows.splice(indexEdit, 1, editedRow);
@@ -265,26 +287,11 @@ export const FormVariant = (): ReactElement => {
 			<Drawers drawers={drawerState.drawers}>
 				{(drawerDef) => {
 					return (
-						<Form
-							buttons={[
-								{
-									label: "Cancel",
-									onClick: removeDrawer,
-									color: "gray",
-									variant: "outlined",
-								},
-								{
-									label: "Save",
-									onClick: () => addOrEdit(),
-									color: "yellow",
-									variant: "contained"
-								},
-							]}
-							title={drawerDef.config.title}
-							state={state}
+						<DrawerEditForm
 							fields={drawerDef.config.fields}
-							dispatch={dispatch}
-							onBack={removeDrawer}
+							onClose={removeDrawer}
+							onSave={addOrEdit}
+							title={drawerDef.config.title}
 						/>
 					);
 				}}
@@ -321,24 +328,6 @@ export const Browse = (): ReactElement => {
 	}, [mappedData]);
 
 	const addDrawer = useCallback(async (drawerDef) => {
-		if (drawerDef.config.type === "form") {
-			await dispatch(
-				formActions.setFieldValue({
-					name: "title",
-					value: "",
-					touched: true
-				})
-			);
-
-			await dispatch(
-				formActions.setFieldValue({
-					name: "description",
-					value: "",
-					touched: true
-				})
-			);
-		}
-
 		setDrawerState((state) => ({
 			...state,
 			drawers: [...state.drawers, drawerDef],
@@ -542,11 +531,11 @@ export const Browse = (): ReactElement => {
 		]
 	);
 
-	const edit = async () => {
+	const edit = async (data) => {
 		const editedRow = {
 			id: state.data.formMatrix[indexEdit].id,
-			title: state.data.title,
-			description: state.data.description,
+			title: data.title,
+			description: data.description,
 		};
 		const currentRows = [...state.data.formMatrix];
 		currentRows.splice(indexEdit, 1, editedRow);
@@ -589,25 +578,11 @@ export const Browse = (): ReactElement => {
 						);
 					} else {
 						return (
-							<Form
-								buttons={[
-									{
-										label: "Cancel",
-										onClick: removeDrawer,
-										color: "gray",
-										variant: "outlined",
-									},
-									{
-										label: "Save",
-										onClick: edit,
-										color: "yellow",
-										variant: "contained"
-									},
-								]}
-								title={drawerDef.config.title}
-								state={state}
+							<DrawerEditForm
+								onClose={removeDrawer}
+								onSave={edit}
 								fields={drawerDef.config.fields}
-								dispatch={dispatch}
+								title={drawerDef.config.title}
 							/>
 						);
 					}

--- a/src/components/Form/Col/Col.tsx
+++ b/src/components/Form/Col/Col.tsx
@@ -1,56 +1,9 @@
 import * as React from "react";
-import { ElementType, memo, useCallback, useMemo } from "react";
-import { formActions } from "../formActions";
+import { memo } from "react";
 
-import FormFieldText from "@root/components/Field/FormFieldText";
-import FormFieldCheckbox from "@root/components/Field/FormFieldCheckbox";
-import FormFieldChipSingleSelect from "@root/components/Field/FormFieldChipSingleSelect";
-import FormFieldDropdownSingleSelection from "@root/components/Field/FormFieldDropdownSingleSelection";
-import FormFieldPhoneSelectionDropdown from "@root/components/Field/FormFieldPhoneSelectionDropdown";
-import FormFieldRadio from "@root/components/Field/FormFieldRadio";
-import FormFieldRaw from "@root/components/Field/FormFieldRaw";
-import FormFieldToggleSwitch from "@root/components/Field/FormFieldToggleSwitch";
-import Field, { FieldDef, sanitizeFieldSize } from "@root/components/Field";
-import FormFieldImageVideoLinkDocumentBrowsing from "@root/components/Field/FormFieldImageVideoLinkDocumentBrowsing";
-import FormFieldColorPicker from "@root/components/Field/FormFieldColorPicker";
-import FormFieldDate from "@root/components/Field/FormFieldDate/DateField";
-import FormFieldAddress from "@root/components/Field/FormFieldAddress";
-import FormFieldTable from "@root/components/Field/FormFieldTable";
-import FormFieldTextEditor from "@root/components/Field/FormFieldTextEditor";
-import FormFieldAdvancedSelection from "@root/components/Field/FormFieldAdvancedSelection";
-import FormFieldMapCoordinates from "@root/components/Field/FormFieldMapCoordinates";
-import FormFieldImageUpload from "@root/components/Field/FormFieldImageUpload";
-import FormFieldMatrix from "@root/components/Field/FormFieldMatrix";
-import FormFieldUpload from "@root/components/Field/FormFieldUpload";
-import FormFieldNumberTable from "@root/components/Field/FormFieldNumberTable";
-import evaluateShow from "@root/utils/show/evaluateShow";
 import { ColPropsTypes } from "./ColTypes";
 import { StyledCol } from "./ColStyled";
-
-const fieldComponentMap = {
-	text: FormFieldText,
-	checkbox: FormFieldCheckbox,
-	chip: FormFieldChipSingleSelect,
-	dropdown: FormFieldDropdownSingleSelection,
-	phone: FormFieldPhoneSelectionDropdown,
-	radio: FormFieldRadio,
-	toggleSwitch: FormFieldToggleSwitch,
-	imageVideoDocumentLink: FormFieldImageVideoLinkDocumentBrowsing,
-	color: FormFieldColorPicker,
-	date: FormFieldDate,
-	address: FormFieldAddress,
-	table: FormFieldTable,
-	textEditor: FormFieldTextEditor,
-	advancedSelection: FormFieldAdvancedSelection,
-	mapCoordinates: FormFieldMapCoordinates,
-	imageUpload: FormFieldImageUpload,
-	matrix: FormFieldMatrix,
-	upload: FormFieldUpload,
-	numberTable: FormFieldNumberTable,
-	raw: FormFieldRaw
-};
-
-let typingTimer;
+import ColField from "./ColField";
 
 const Col = (props: ColPropsTypes) => {
 	const {
@@ -64,103 +17,21 @@ const Col = (props: ColPropsTypes) => {
 		sectionIdx
 	} = props;
 
-	const doneTypingInterval = 300;
-
-	const sendValidateField = useCallback(async (curr) => {
-		await dispatch(formActions.validateField({ name: curr.name }))
-
-		if (curr.pairedFields)
-			curr.pairedFields.forEach(async pairedField => {
-				await dispatch(
-					formActions.validateField({ name: pairedField })
-				);
-			});
-	}, [dispatch]);
-
-	const onChangeMap = useMemo(() => {
-		return fieldsDef.reduce((prev, curr) => {
-			prev[curr.name] = async function (value) {
-				await dispatch(
-					formActions.setFieldValue({
-						name: curr.name,
-						value,
-						touched: true
-					})
-				);
-				clearTimeout(typingTimer);
-				typingTimer = setTimeout(async () => await sendValidateField(curr), doneTypingInterval);
-			};
-
-			return prev;
-		}, {});
-	}, [fieldsDef, state.pairedFields, sendValidateField]);
-
 	return (
 		<StyledCol data-layout="column" $colsInRow={colsInRow}>
-			{col.map((field, i) => {
-				const currentField: FieldDef = fieldsDef?.find(
-					(fieldDef) => {
-						return field === fieldDef.name;
-					}
-				);
-
-				if (!currentField) {
-					throw new Error(`No field declared for field name '${field}' in section ${sectionIdx}, row ${rowIdx}, column ${colIdx}.`);
-				}
-
-				const { type, ...fieldProps } = currentField;
-
-				const Component: ElementType = typeof type === "string" ? fieldComponentMap[type] : type;
-
-				if (!Component) {
-					throw new Error(`Invalid type ${type}`);
-				}
-
-				const onChange = onChangeMap[fieldProps.name];
-
-				const name = fieldProps.name;
-				const ref = fieldProps.ref;
-				const value = state?.data[fieldProps.name];
-				const error = (state?.errors[fieldProps.name] && !currentField.disabled) ? state.errors[fieldProps.name] : "";
-
-				const size = sanitizeFieldSize(
-					currentField.size,
-					currentField.type
-				);
-
-				const children = useMemo(() => (
-					<Component
-						fieldDef={{ ...currentField, size, }}
-						name={name}
-						value={value}
-						error={error}
-						onChange={onChange}
-						ref={ref}
-						key={`${name}_${i}`}
-						dispatch={dispatch}
-					/>
-				), [value, error, onChange, currentField]);
-
-				const shouldShow = useMemo(() => evaluateShow(currentField.show, {data: state?.data}), [currentField.show, state?.data]);
-
-				return shouldShow ? (
-					(typeof type === "string" && fieldComponentMap[type]) ? (
-						<Field
-							key={`${name}_${i}`}
-							fieldDef={{ ...currentField, size }}
-							value={value}
-							error={error}
-							colsInRow={colsInRow}
-							id={name}
-							dispatch={dispatch}
-						>
-							{children}
-						</Field>
-					) : (
-						children
-					)
-				) : null;
-			})}
+			{col.map((field) => (
+				<ColField
+					key={field}
+					dispatch={dispatch}
+					fieldName={field}
+					fieldsDef={fieldsDef}
+					state={state}
+					colIdx={colIdx}
+					colsInRow={colsInRow}
+					rowIdx={rowIdx}
+					sectionIdx={sectionIdx}
+				/>
+			))}
 		</StyledCol>
 	);
 };

--- a/src/components/Form/Col/ColField.tsx
+++ b/src/components/Form/Col/ColField.tsx
@@ -1,0 +1,97 @@
+import React, { memo, useCallback, useMemo } from "react";
+import { FieldDef } from "../FormTypes";
+import fieldConfigMap from "./fieldConfigMap";
+import { ColFieldProps } from "./ColTypes";
+import formActions from "../formActions";
+import Field, { FieldConfig, sanitizeFieldSize } from "@root/components/Field";
+import evaluateShow from "@root/utils/show/evaluateShow";
+
+const ColField = ({
+	fieldsDef,
+	fieldName,
+	colsInRow,
+	colIdx,
+	rowIdx,
+	sectionIdx,
+	dispatch,
+	state
+}: ColFieldProps) => {
+	const field: FieldDef = useMemo(() => fieldsDef.find(({ name }) => name === fieldName), [fieldsDef, fieldName]);
+
+	if (!field) {
+		throw new Error(`No field declared for field name '${fieldName}' in section ${sectionIdx}, row ${rowIdx}, column ${colIdx}.`);
+	}
+
+	const isCustomField = typeof field.type !== "string";
+	const { Component }: FieldConfig = typeof field.type === "string" ? fieldConfigMap[field.type] : {
+		Component: field.type,
+		validate: "onBlur"
+	}
+
+	if (!Component) {
+		throw new Error(`Invalid type ${field.type}`);
+	}
+
+	const onChange = useCallback((value: any) => {
+		field.onChangeCb && field.onChangeCb();
+
+		dispatch(formActions.setFieldValue({
+			name: field.name,
+			value,
+			touched: true
+		}));
+	}, [field.name]);
+
+	const onBlur = useCallback(() => {
+		field.onBlurCb && field.onBlurCb();
+
+		dispatch(formActions.setFieldBlur({
+			name: field.name
+		}))
+	}, [field.name]);
+
+	const value = state?.data[field.name];
+	const error = !field.disabled ? state.errors[field.name] : "";
+
+	const size = sanitizeFieldSize(
+		field.size,
+		field.type
+	);
+
+	const shouldShow = useMemo(() => evaluateShow(field.show, { data: state?.data }), [field.show, state?.data]);
+	const sanitizedFieldDef = useMemo(() => ({ ...field, size, }), [field, size])
+
+	const children = useMemo(() => (
+		<Component
+			fieldDef={sanitizedFieldDef}
+			name={sanitizedFieldDef.name}
+			value={value}
+			error={error}
+			onChange={onChange}
+			onBlur={onBlur}
+			ref={sanitizedFieldDef.ref}
+			dispatch={dispatch}
+		/>
+	), [sanitizedFieldDef, value, error, onChange, onBlur, dispatch]);
+
+	if (!shouldShow) {
+		return null;
+	}
+
+	return isCustomField ? (
+		children
+	) : (
+		<Field
+			fieldDef={sanitizedFieldDef}
+			value={value}
+			error={error}
+			colsInRow={colsInRow}
+			id={field.name}
+			dispatch={dispatch}
+		>
+			{children}
+		</Field>
+	);
+}
+
+export default memo(ColField);

--- a/src/components/Form/Col/ColTypes.ts
+++ b/src/components/Form/Col/ColTypes.ts
@@ -1,10 +1,21 @@
 import { FieldDef } from "../FormTypes";
 
 export interface ColPropsTypes {
-	col: (string | FieldDef)[];
+	col: string[];
 	// TODO Use something other than any
 	state: any;
 	fieldsDef: FieldDef[];
+	dispatch: any;
+	colsInRow?: number;
+	colIdx?: number;
+	rowIdx?: number;
+	sectionIdx?: number;
+}
+
+export interface ColFieldProps {
+	fieldName: string;
+	fieldsDef: FieldDef[];
+	state: any;
 	dispatch: any;
 	colsInRow?: number;
 	colIdx?: number;

--- a/src/components/Form/Col/fieldConfigMap.ts
+++ b/src/components/Form/Col/fieldConfigMap.ts
@@ -1,0 +1,108 @@
+import { FieldDef, FieldDefCustom } from "../FormTypes";
+import { FieldConfig } from "@root/components/Field";
+
+import FormFieldText from "@root/components/Field/FormFieldText";
+import FormFieldCheckbox from "@root/components/Field/FormFieldCheckbox";
+import FormFieldChipSingleSelect from "@root/components/Field/FormFieldChipSingleSelect";
+import FormFieldDropdownSingleSelection from "@root/components/Field/FormFieldDropdownSingleSelection";
+import FormFieldPhoneSelectionDropdown from "@root/components/Field/FormFieldPhoneSelectionDropdown";
+import FormFieldRadio from "@root/components/Field/FormFieldRadio";
+import FormFieldRaw from "@root/components/Field/FormFieldRaw";
+import FormFieldToggleSwitch from "@root/components/Field/FormFieldToggleSwitch";
+import FormFieldImageVideoLinkDocumentBrowsing from "@root/components/Field/FormFieldImageVideoLinkDocumentBrowsing";
+import FormFieldColorPicker from "@root/components/Field/FormFieldColorPicker";
+import FormFieldDate from "@root/components/Field/FormFieldDate/DateField";
+import FormFieldAddress from "@root/components/Field/FormFieldAddress";
+import FormFieldTable from "@root/components/Field/FormFieldTable";
+import FormFieldTextEditor from "@root/components/Field/FormFieldTextEditor";
+import FormFieldAdvancedSelection from "@root/components/Field/FormFieldAdvancedSelection";
+import FormFieldMapCoordinates from "@root/components/Field/FormFieldMapCoordinates";
+import FormFieldImageUpload from "@root/components/Field/FormFieldImageUpload";
+import FormFieldMatrix from "@root/components/Field/FormFieldMatrix";
+import FormFieldUpload from "@root/components/Field/FormFieldUpload";
+import FormFieldNumberTable from "@root/components/Field/FormFieldNumberTable";
+
+const fieldConfigMap: Partial<Record<Exclude<FieldDef["type"], FieldDefCustom["type"]>, FieldConfig>> = {
+	text: {
+		Component: FormFieldText,
+		validate: "onBlurChange"
+	},
+	checkbox: {
+		Component: FormFieldCheckbox,
+		validate: "onChange"
+	},
+	chip: {
+		Component: FormFieldChipSingleSelect,
+		validate: "onBlur"
+	},
+	dropdown: {
+		Component: FormFieldDropdownSingleSelection,
+		validate: "onBlur"
+	},
+	phone: {
+		Component: FormFieldPhoneSelectionDropdown,
+		validate: "onBlur"
+	},
+	radio: {
+		Component: FormFieldRadio,
+		validate: "onBlur"
+	},
+	toggleSwitch: {
+		Component: FormFieldToggleSwitch,
+		validate: "onBlur"
+	},
+	imageVideoDocumentLink: {
+		Component: FormFieldImageVideoLinkDocumentBrowsing,
+		validate: "onBlur"
+	},
+	color: {
+		Component: FormFieldColorPicker,
+		validate: "onBlur"
+	},
+	date: {
+		Component: FormFieldDate,
+		validate: "onBlur"
+	},
+	address: {
+		Component: FormFieldAddress,
+		validate: "onChange"
+	},
+	table: {
+		Component: FormFieldTable,
+		validate: "onBlur"
+	},
+	textEditor: {
+		Component: FormFieldTextEditor,
+		validate: "onBlur"
+	},
+	advancedSelection: {
+		Component: FormFieldAdvancedSelection,
+		validate: "onBlur"
+	},
+	mapCoordinates: {
+		Component: FormFieldMapCoordinates,
+		validate: "onBlur"
+	},
+	imageUpload: {
+		Component: FormFieldImageUpload,
+		validate: "onBlur"
+	},
+	matrix: {
+		Component: FormFieldMatrix,
+		validate: "onBlur"
+	},
+	upload: {
+		Component: FormFieldUpload,
+		validate: "onBlur"
+	},
+	numberTable: {
+		Component: FormFieldNumberTable,
+		validate: "onBlur"
+	},
+	raw: {
+		Component: FormFieldRaw,
+		validate: "onBlur"
+	}
+};
+
+export default fieldConfigMap;

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -292,7 +292,6 @@ const fields = useMemo(
 * **validators** - `array` of `string | { fn: string; options: any } | (() => string | undefined | JSX Element))` optional - Validators to be executed when an onBlur occurs on the Field or when an onSubmit occurs on the Form (see the [Validators section](#validators) for more information about default and custom validators).
 * **id** - `string` optional - Follows the same rules as any other html element id.
 * **defaultValue** - `<U>` optional - Value to be used in case no initial value is loaded from a data base. This value should be of the same type as from its corresponding field (see data of each specific field).
-* **pairedFields** - `array` of `string` optional - Array of field names to be linked to this field. When a field is being validated, it will check if it has any associated paired field. If there's one, the validators defined for each paired field will be executed. For a practical example check the [date range validator example](#validatedaterange).
 * **onChangeCb** - `(value?: any) => void` optional - Callback that will be executed when the field triggers an onChange event.
 * **show** - [`MosaicShow`](#mosaicshow-t-type) optional - Show callbacks will be called with `{data: data}`
 
@@ -318,7 +317,6 @@ const fields = useMemo(
 				validators: ["validateNumber"], //Please see validators section on ways of adding validators.
 				id: "myId",
 				defaultValue: "42", //Plase see data of each field and data section to better understand how fields interact with values.
-				pairedFields: ["myCheckbox"],
 			},
 			{
 				name: "myCheckbox",
@@ -1784,7 +1782,6 @@ const fields = useMemo(
 					type: "date",
 					label: "Start date",
 					validators: [{ fn: "validateDateRange", options: { endDateName: "endDate" } }],
-					pairedFields: ["endDate"],
 					inputSettings: {
 						showTime: false,
 					},
@@ -1794,7 +1791,6 @@ const fields = useMemo(
 					type: "date",
 					label: "End date",
 					validators: [{ fn: "validateDateRange", options: { startDateName: "startDate" } }],
-					pairedFields: ["startDate"],
 					inputSettings: {
 						showTime: false,
 					},

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -61,12 +61,6 @@ The dispatch function allows developers to update the state through the followin
 		* **arguments** - `object`
 			* **name** - `string` - Name of the field.
 		* **return** - `Promise<void>`
-* **copyFieldToField** - `({from, to}) => Promise<void>` - This action copies the value from one field into another.
-	* **name** - copyFieldToField
-	* **arguments** - `object`
-		* **from** - `string` - Name of the field where the value will be copied from.
-		* **to** - `string` - Name of the field where the value will be copied to.
-	* **return** - `Promise<void>`
 * **validateForm** - `({fields}) => Promise<void>` - This action validates the entire form.
 	* **name** - validateForm
 	* **arguments** - `object`
@@ -130,7 +124,6 @@ const buttons: ButtonProps[] = [
 Sections follow the next set of rules:
 * Can have a title and a description.
 * Each section can have multiple rows.
-* Each row must have 1 column min and 3 columns max.
 * Each column can have as many fields as needed.
 
 #### SectionDef
@@ -141,51 +134,6 @@ Sections follow the next set of rules:
 | **`fields`** | `MosaicGridConfig` | required - Structure that serves as a map to position fields across rows and columns. Each section can have multiple rows, each row multiple columns, and each column multiple fields ([rows][columns][fields]) |
 | **`collapsed`** | `boolean` | optional - Allows developers to decide whether the section will be first rendered collapsed or expanded. It defaults to false when no value is provided. |
 | **`show`** | [`MosaicShow`](#mosaicshow-t-type) | optional - Show callbacks will be called with `{data: formState.data}` |
-
-The Form component is smart enough to delete blank spaces in the layout, for example if a row has 3 columns (A, B, C) but only A, and C have columns then the row will render as a 2 column layout instead of 3.
-This same rule applies for empty rows.
-
-There are two ways for positioning components inside of a Form:
-1. By defining the position of the component with the layout prop. For more details about this prop refer to the [Generic Field Props subsection](#generic-field-props-fielddef).
-```ts
-		const fields: FieldDef[] = useMemo(
-		() =>
-			[
-				{
-					name: "textField",
-					type: "text",
-					layout: { section: 0, row: 1, col: 0 },
-				},
-				// ...all other fields
-			],
-		[]
-	);
-```
-
-2. Create a layout with an array of sections.
-When done through this method, the array must be passed down as a prop to the Form component.
-```ts
-	const sections = [
-		{
-			title: "Section 1",
-			description: "This will be a short section",
-			fields: [
-				[ //Row 1
-					["myTextField"] // Row 1 Col 1
-				],
-				[ // Row 2
-					["myCheckboxField"] // Row 2 Col 1
-				]
-			]
-		}
-		//...all other sections
-	];
-
-	<Form
-		//...all other props
-		sections={sections}
-	/>
-```
 
 ## How to create a form?
 ```ts

--- a/src/components/Form/Form.test.tsx
+++ b/src/components/Form/Form.test.tsx
@@ -1,7 +1,8 @@
 import testArray from "../../utils/testArray";
 import * as assert from "assert";
-import { generateLayout } from "./formUtils";
 import { FieldDef } from "../../components/Field";
+import { generateLayout } from "./Layout/layoutUtils";
+import { SectionDef } from "./FormTypes";
 
 describe("Layout logic", () => {
 	const fields: FieldDef[] = [
@@ -131,7 +132,7 @@ describe("Layout logic", () => {
 		test.type === "fields" ?
 			result = generateLayout({ fields })
 			:
-			result = generateLayout({ fields, sections: test.data })
+			result = generateLayout({ fields, sections: test.data as SectionDef[] })
 
 		assert.deepStrictEqual(result, test.result);
 	});

--- a/src/components/Form/Form.test.tsx
+++ b/src/components/Form/Form.test.tsx
@@ -57,17 +57,8 @@ describe("Layout logic", () => {
 				data: fields,
 				result: [
 					{
-						fields: [[["text1"]]]
-					},
-					{
-						fields: [[["text2"]]]
-					},
-					{
-						fields: [[["text3"]]]
-					},
-					{
-						fields: [[["text4"]]]
-					},
+						"fields": [[["text1"]], [["text2"]], [["text3"]], [["text4"]]]
+					}
 				]
 			}
 		},
@@ -85,7 +76,7 @@ describe("Layout logic", () => {
 					},
 					{
 						fields: [
-							[["text2"], ["text3"]],
+							[[], ["text2"], ["text3"]],
 						]
 					},
 				]
@@ -99,7 +90,7 @@ describe("Layout logic", () => {
 					{
 						fields: [
 							// row 1
-							[[], [], []],
+							[[], ["text1"], []],
 							// row 2
 							[[], [], []],
 							[[]],
@@ -117,7 +108,9 @@ describe("Layout logic", () => {
 				],
 				result: [
 					{
-						fields: []
+						fields: [
+							[[], ["text1"], []]
+						]
 					},
 					{
 						fields: []

--- a/src/components/Form/FormTypes.tsx
+++ b/src/components/Form/FormTypes.tsx
@@ -36,4 +36,8 @@ export interface FormProps {
 	fullHeight?: boolean
 }
 
+export interface FieldError {
+	message: string
+}
+
 export { FieldDef, FieldDefCustom };

--- a/src/components/Form/Layout/Layout.tsx
+++ b/src/components/Form/Layout/Layout.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { useMemo, memo } from "react";
-import { generateLayout } from "../formUtils";
 
 // Components
 import Section from "../Section";
@@ -9,6 +8,7 @@ import Section from "../Section";
 import evaluateShow from "@root/utils/show/evaluateShow";
 import { LayoutProps } from "./LayoutTypes";
 import { StyledLayout } from "./LayoutStyles";
+import { generateLayout } from "./layoutUtils";
 
 const Layout = (props: LayoutProps): React.ReactElement => {
 	const { state, dispatch, fields, sections, registerRef } = props;

--- a/src/components/Form/Layout/layoutUtils.ts
+++ b/src/components/Form/Layout/layoutUtils.ts
@@ -5,5 +5,18 @@ export const generateLayout = ({ sections, fields }: { sections?: SectionDef[], 
 		return [{ fields: fields.map(field => [[field.name]]) }];
 	}
 
-	return sections;
+	return sections.map(section => {
+		/**
+		 * Filters out rows that have all-empty columns
+		 */
+		const rows = section.fields.filter(row => {
+			const columnsWithFields = row.filter(column => column.length);
+			return columnsWithFields.length;
+		});
+
+		return {
+			...section,
+			fields: rows
+		};
+	});
 };

--- a/src/components/Form/Layout/layoutUtils.ts
+++ b/src/components/Form/Layout/layoutUtils.ts
@@ -1,0 +1,9 @@
+import { FieldDef, SectionDef } from "../FormTypes";
+
+export const generateLayout = ({ sections, fields }: { sections?: SectionDef[], fields: FieldDef[] }): SectionDef[] => {
+	if (!sections) {
+		return [{ fields: fields.map(field => [[field.name]]) }];
+	}
+
+	return sections;
+};

--- a/src/components/Form/fieldErrors.ts
+++ b/src/components/Form/fieldErrors.ts
@@ -1,0 +1,14 @@
+import { DATE_FORMAT_FULL_PLACEHOLDER, TIME_FORMAT_FULL_PLACEHOLDER } from "@root/constants";
+import { FieldError } from "./FormTypes";
+
+export const INVALID_DATE: FieldError = {
+	message: `Please enter a valid ${DATE_FORMAT_FULL_PLACEHOLDER} date`
+}
+
+export const INVALID_TIME: FieldError = {
+	message: `Please enter a valid ${TIME_FORMAT_FULL_PLACEHOLDER} time`
+}
+
+export const TIME_REQUIRED: FieldError = {
+	message: "Please also provide a time"
+}

--- a/src/components/Form/state/types.ts
+++ b/src/components/Form/state/types.ts
@@ -1,0 +1,128 @@
+import { MosaicObject } from "@root/types";
+import { Dispatch } from "react";
+import { FieldDef } from "../FormTypes";
+
+export type FormState = {
+    data: MosaicObject<any>;
+    errors: MosaicObject<string>;
+    validating: MosaicObject;
+    custom: unknown;
+    validForm: boolean;
+    disabled: boolean;
+    touched: MosaicObject<boolean>;
+    mounted: MosaicObject<boolean>;
+    busyFields: MosaicObject<boolean>;
+    submitWarning: string;
+}
+
+export type ActionTypes =
+    | "FIELD_ON_CHANGE"
+    | "FIELDS_ON_CHANGE"
+    | "FIELD_TOUCHED"
+    | "FIELD_VALIDATE"
+    | "FIELD_UNVALIDATE"
+    | "FORM_START_DISABLE"
+    | "FORM_END_DISABLE"
+    | "FORM_VALIDATE"
+    | "FORM_START_DISABLE"
+    | "FORM_END_DISABLE"
+    | "FORM_VALIDATE"
+    | "FORM_RESET"
+    | "PROPERTY_RESET"
+    | "MOUNT_FIELD"
+    | "UNMOUNT_FIELD"
+    | "FORM_START_BUSY"
+    | "FORM_END_BUSY"
+    | "SET_SUBMIT_WARNING"
+
+export type LegacyFormAction = {
+    type: ActionTypes;
+    value: any;
+    name?: string;
+    clearErrors?: boolean
+    touched?: boolean
+}
+
+export type FormAction =
+    | LegacyFormAction;
+
+type OptionalUndefinedParam<P, R> = P extends undefined ? (params?: P) => R : (params: P) => R;
+
+export type FormActionThunk<P = undefined, R = void> = OptionalUndefinedParam<
+    P,
+    (dispatch: FormDispatch, getState: FormGetState, extraArgs: FormExtraArgs) => Promise<R>
+>
+
+export type FormActionThunks = {
+    init: FormActionThunk<{
+        fields: FieldDef[]
+    }>;
+    setSubmitWarning: FormActionThunk<{
+        value: string
+    }>;
+    setFieldValue: FormActionThunk<{
+        name: string;
+        value: unknown;
+        validate?: boolean;
+        touched?: boolean;
+    }>;
+    setFieldBlur: FormActionThunk<{
+        name: string;
+        validate?: boolean;
+    }>
+    validateField: FormActionThunk<{
+        name: string
+    }>;
+    validateForm: FormActionThunk<undefined, boolean>;
+    submitForm: FormActionThunk<undefined, {
+        valid: boolean;
+        data: any;
+    }>;
+    resetForm: FormActionThunk;
+    setFormValues: FormActionThunk<MosaicObject>;
+    disableForm: FormActionThunk<{
+        disabled?: boolean
+    }>;
+    startBusy: FormActionThunk<{
+        name: string,
+        value: string
+    }>;
+    endBusy: FormActionThunk<{
+        name: string
+    }>;
+    mountField: FormActionThunk<{
+        name: string
+    }>;
+    unmountField: FormActionThunk<{
+        name: string
+    }>;
+    isSubmittable: FormActionThunk<undefined, boolean>
+    addValidator: FormActionThunk<{
+        name: string;
+        validator: any
+    }>
+    removeValidator: FormActionThunk<{
+        name: string;
+        validator: any
+    }>
+}
+
+export type FormDispatch = (action: any) => any | Dispatch<FormAction>;
+
+export type FormGetState = () => FormState;
+
+export type UseFormReturn = {
+    state: FormState;
+    dispatch: FormDispatch;
+}
+
+export type FormExtraArgs = {
+    fields: FieldDef[];
+    fieldMap: Record<string, FieldDef>;
+    onSubmit: () => void;
+    mounted: Record<string, boolean | undefined>;
+    internalValidators: Record<string, ((value: any) => string | undefined)[]>
+    hasBlurred: Record<string, boolean>
+}
+
+export type FormReducer = (state: FormState, action: FormAction) => FormState;

--- a/src/components/Form/stories/DrawerForm.stories.tsx
+++ b/src/components/Form/stories/DrawerForm.stories.tsx
@@ -16,10 +16,10 @@ import { FieldDef } from "@root/components/Field";
 import theme, { BREAKPOINTS } from "@root/theme/theme";
 import _ from "lodash";
 import { Sizes } from "@root/theme";
-import { useTable } from "@root/components/Field/FormFieldTable/tableUtils";
 import { getOptionsCountries, getOptionsStates } from "@root/components/Field/FormFieldAddress/utils/optionGetters";
 import styled from "styled-components";
 import AddCircleOutline from "@mui/icons-material/AddCircleOutline";
+import { validateEmail } from "../validators";
 
 export default {
 	title: "Components/Form",
@@ -109,7 +109,7 @@ const sections: SectionDef[] = [
 		title: "Fields with grid layout",
 		fields: [
 			[["firstName"], ["lastName"], ["dob"]],
-			[["profilePicture"], ["biography"]],
+			[["profilePicture"], ["biography"], []],
 			[["homeAddress"], ["workAddress"], ["altAddress"]],
 			[["petsHeading"]],
 			[["pets"], ["favouritePet", "firstPet", "desiredPet"]],
@@ -133,12 +133,6 @@ const options = {
 export const DrawerForm = (): ReactElement => {
 	const { state, dispatch } = useForm();
 
-	const { addTableRow, editAction } = useTable(
-		state.data,
-		"table",
-		dispatch
-	);
-
 	const fields  = useMemo<FieldDef[]>(() => [
 		{
 			...baseTextField,
@@ -161,8 +155,9 @@ export const DrawerForm = (): ReactElement => {
 		{
 			...baseTextField,
 			name: "text-lg",
-			label: "Large text",
+			label: "Email address",
 			size: Sizes.lg,
+			validators: [validateEmail]
 		},
 		{
 			...baseTextField,
@@ -207,19 +202,6 @@ export const DrawerForm = (): ReactElement => {
 			name: "petsHeading",
 			type: "raw"
 		} as any),
-		{
-			inputSettings: {
-				handleAddElement: addTableRow,
-				handleEdit: editAction,
-				extraActions: [],
-				headers: ["Species", "Colour"],
-			},
-			label: "Pets",
-			name: "pets",
-			required: true,
-			type: "table",
-			size: Sizes.lg,
-		},
 		{
 			label: "Favourite Pet",
 			name: "favouritePet",
@@ -348,7 +330,7 @@ export const DrawerForm = (): ReactElement => {
 				initialCenter: { lat: 48.858348895100555, lng: 2.294492026111051 }
 			}
 		}
-	], [addTableRow, editAction]);
+	], []);
 
 	const showSections = boolean("Show sections", false, "Layout");
 	const drawWidth = select("Draw Width", options, options.default, "Layout");

--- a/src/components/Form/stories/Validators.stories.tsx
+++ b/src/components/Form/stories/Validators.stories.tsx
@@ -75,7 +75,6 @@ export const Validators = (): ReactElement => {
 					helperText: "Helper text",
 					instructionText: "Instruction text",
 					validators: [{ fn: "validateDateRange", options: { endDateName: "endDate" } }],
-					pairedFields: ["endDate"],
 					inputSettings: {
 						showTime: false,
 					},
@@ -89,7 +88,6 @@ export const Validators = (): ReactElement => {
 					helperText: "Helper text",
 					instructionText: "Instruction text",
 					validators: [{ fn: "validateDateRange", options: { startDateName: "startDate" } }],
-					pairedFields: ["startDate"],
 					inputSettings: {
 						showTime: false,
 					},

--- a/src/utils/array/arrayDifference.ts
+++ b/src/utils/array/arrayDifference.ts
@@ -1,0 +1,20 @@
+/**
+ * Constructs an array containing all of the items that exist in the left array but not in the right array.
+ *
+ * @param left The source array
+ * @param right The comparison array
+ * @returns An array containg the items that exist in the left array but not in the right array
+ */
+function arrayDifference<T>(left: T[], right: T[]): T[] {
+	const difference: T[] = [];
+
+	for (const item of left) {
+		if (!right.includes(item)) {
+			difference.push(item);
+		}
+	}
+
+	return difference;
+}
+
+export default arrayDifference;

--- a/src/utils/array/arrayIntersect.ts
+++ b/src/utils/array/arrayIntersect.ts
@@ -1,0 +1,21 @@
+/**
+ *
+ * Creates an array returning items that are common between two arrays
+ *
+ * @param left The left array
+ * @param right The right array
+ * @returns The array containing common items
+ */
+function arrayIntersect<T>(left: T[], right: T[]): T[] {
+	const intersection: T[] = [];
+
+	for (const item of left) {
+		if (right.includes(item)) {
+			intersection.push(item);
+		}
+	}
+
+	return intersection;
+}
+
+export default arrayIntersect;

--- a/src/utils/array/index.ts
+++ b/src/utils/array/index.ts
@@ -1,0 +1,2 @@
+export { default as arrayIntersect } from "./arrayIntersect";
+export { default as arrayDifference } from "./arrayDifference";

--- a/src/utils/hooks/index.ts
+++ b/src/utils/hooks/index.ts
@@ -1,2 +1,4 @@
 export * from "./useScrollSpy"
 export { default as useScrollSpy } from "./useScrollSpy"
+
+export { default as useFieldErrors } from "./useFieldErrors";

--- a/src/utils/hooks/useFieldErrors/index.ts
+++ b/src/utils/hooks/useFieldErrors/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./useFieldErrors"

--- a/src/utils/hooks/useFieldErrors/useFieldErrors.ts
+++ b/src/utils/hooks/useFieldErrors/useFieldErrors.ts
@@ -1,0 +1,114 @@
+import { useReducer, useEffect, useCallback } from "react";
+import { FieldError, formActions } from "@root/components/Form";
+import { arrayIntersect, arrayDifference } from "@root/utils/array";
+
+type AddError = {
+	type: "ADD_ERROR",
+	error: FieldError | FieldError[]
+}
+
+type RemoveError = {
+	type: "REMOVE_ERROR",
+	error: FieldError | FieldError[]
+}
+
+type Action = AddError | RemoveError;
+
+function reducer(state: FieldError[], action: Action) {
+	switch (action.type) {
+
+	case "ADD_ERROR": {
+		const incomingErrors: FieldError[] = Array.isArray(action.error) ? action.error : [action.error];
+		const errorsToAdd = arrayDifference(incomingErrors, state);
+
+		/**
+		 * Don't needlessly return new state if there are no new
+		 * errors to add
+		 */
+		if (!errorsToAdd.length) {
+			return state;
+		}
+
+		return [
+			...state,
+			...errorsToAdd
+		];
+	}
+	case "REMOVE_ERROR": {
+		const incomingErrors: FieldError[] = Array.isArray(action.error) ? action.error : [action.error];
+		const errorsToRemove = arrayIntersect(incomingErrors, state);
+
+		/**
+		 * Don't needlessly return new state if there are
+		 * no errors to remove
+		 */
+		if (!errorsToRemove.length) {
+			return state;
+		}
+
+		return state.filter(error => !errorsToRemove.includes(error));
+	}
+	default: {
+		throw new Error("useFieldErrors action is not valid");
+	}
+
+	}
+}
+
+type UseFieldErrorState = FieldError[]
+
+interface UseFieldErrorParams {
+	dispatch: any;
+	name: string
+}
+
+interface UseFieldErrorsResult {
+	addError: (error: FieldError | FieldError[]) => void;
+	removeError: (error: FieldError | FieldError[]) => void;
+}
+
+function useFieldErrors({ dispatch: formDispatch, name }: UseFieldErrorParams): UseFieldErrorsResult {
+	const [state, dispatch] = useReducer<(prevState: UseFieldErrorState, action: Action) => UseFieldErrorState>(reducer, []);
+	const error = state[0];
+
+	const addError = useCallback((error: FieldError | FieldError[]) => {
+		dispatch({
+			type: "ADD_ERROR",
+			error
+		});
+	}, [dispatch]);
+
+	const removeError = useCallback((error: FieldError | FieldError[]) => {
+		dispatch({
+			type: "REMOVE_ERROR",
+			error
+		});
+	}, [dispatch]);
+
+	useEffect(() => {
+		if (!formDispatch) {
+			return;
+		}
+
+		const validator = () => {
+			return error && error.message;
+		}
+
+		formDispatch(formActions.addValidator({
+			name,
+			validator
+		}));
+
+		return () => formDispatch(formActions.removeValidator({
+			name,
+			validator
+		}));
+	}, [error]);
+
+	return {
+		addError,
+		removeError
+	}
+}
+
+export default useFieldErrors;


### PR DESCRIPTION
- Introduction of `useFieldErrors` takes a form's dispatch and enables fields to add their own "internal" validators that can throw errors based on their own local state. This function is currently only being consumed by the date field.
- Refactored `Col` into `ColField`.
- Moved form's state.mounted out of state and into a stable reference instead.
- Introduces multiple validation strategies. Each field has a sensible default `validateOn`, but field definitions can take a `validateOn` to specify when strategy to use instead:
  - `onChange` validates a field on every change in value
  - `onBlur` validates a field when the field loses focus
  - `onBlurChange` validates a field when the field loses focus, but then resets the validation when it is next changed
- Improve initial form load performance by dispatching all initial values at once instead of dispatching for each field
- Drops support for field.layout property. Use Form's props.sections instead.
- (**BREAKING CHANGE**) Drops `copyFieldToField` form action
- (**BREAKING CHANGE**) Drops redundant `joinReducers` function
- (**BREAKING CHANGE**) Replaces `pairedFields` property with `validates`