### PR TITLE
MOS-1115 Drop redundant Typography wrapper

### DIFF
--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -98,12 +98,7 @@ const Heading = styled.h2`
 `
 
 const MyBodyText = styled(BodyText)`
-	color: white;
-	background-color: #444;
-	border-radius: 3px;
-	padding: 10px;
-
-	> * {
+	&& {
 		font-size: 12px;
 		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 	}

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -24,18 +24,17 @@ export default function Typography({
 	const tag = providedTag || defaultTagMap[variant];
 
 	return (
-		<div className={className}>
-			<Component
-				{...attrs}
-				$variant={variant}
-				$maxLines={maxLines}
-				$color={color}
-				$breakAll={breakAll}
-				title={typeof children === "string" ? children : undefined}
-				as={tag}
-			>
-				{children}
-			</Component>
-		</div>
+		<Component
+			{...attrs}
+			className={className}
+			$variant={variant}
+			$maxLines={maxLines}
+			$color={color}
+			$breakAll={breakAll}
+			title={typeof children === "string" ? children : undefined}
+			as={tag}
+		>
+			{children}
+		</Component>
 	);
 }


### PR DESCRIPTION
Removes the unnecessary `div` that wraps Typography components and updates the story that demonstrates adding custom styles to it using `&&` workaround.