### PR TITLE
MOS-1194 Spacing adjustments

### DIFF
--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -42,7 +42,7 @@ const StyledWrapper = styled.div`
 
 	& > .viewContainer {
 		overflow: auto;
-		margin: 0 24px;
+		padding: 0 24px;
 	}
 
 	&.loading {

--- a/src/components/PageHeader/PageHeader.styled.tsx
+++ b/src/components/PageHeader/PageHeader.styled.tsx
@@ -7,7 +7,7 @@ export const StyledPageHeader = styled.div`
 	flex-direction: row;
 	justify-content: space-between;
 	align-items: center;
-	padding: 20px;
+	padding: 24px;
 	min-height: 80px;
 	max-height: 80px;
 `;


### PR DESCRIPTION
- Increases the padding around the `PageHeader` from 20px to 24px.
- Swaps out horizontal margin used for `DataView` table for padding for consistency.