### PR TITLE
MOS-1131 QA Feedback 2

### DIFF
--- a/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
+++ b/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
@@ -52,6 +52,7 @@ const FormFieldTextEditor = (
 
 	const textArea = useRef(null);
 	const jodit = useRef<Jodit>(null);
+	const hasSetValue = useRef(false);
 
 	const config = useMemo(() => ({
 		cleanHTML: {
@@ -86,7 +87,6 @@ const FormFieldTextEditor = (
 		};
 
 		jodit.current = Jodit.make(textArea.current, config);
-		jodit.current.value = value;
 
 		jodit.current.events.on("blur", () => {
 			const value = jodit.current.value === "<p><br></p>" ? "" : jodit.current.value;
@@ -99,7 +99,21 @@ const FormFieldTextEditor = (
 		});
 
 		return () => jodit.current.destruct();
-	}, [onBlur, onChange, config, value]);
+	}, [onBlur, onChange, config]);
+
+
+	/**
+	 * Ridiculous hack because Jodit sucks when trying
+	 * to set a new text editor value
+	 */
+	useEffect(() => {
+		if (!jodit.current || hasSetValue.current || value === undefined) {
+			return;
+		}
+
+		hasSetValue.current = true;
+		jodit.current.value = value;
+	}, [value]);
 
 	return (
 		<EditorWrapper $error={!!error} data-testid="text-editor-testid">

--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -315,6 +315,11 @@ export const formActions: FormActionThunks = {
 				[curr]: mounted[curr] ? data[curr] : undefined
 			}), {});
 
+			extraArgs.hasBlurred = Object.keys(extraArgs.fieldMap).reduce((prev, curr) => ({
+				...prev,
+				[curr]: true
+			}), {});
+
 			return {
 				valid,
 				data: cleanData


### PR DESCRIPTION
- Employs a workaround to prevent Jodit text editor from losing focus when the value changes
- Considers all fields to be blurred after the form is submitted