### PR TITLE
MOS-1187 Adds support for default href behaviour

### DIFF
--- a/src/components/SideNav/SideNav.stories.tsx
+++ b/src/components/SideNav/SideNav.stories.tsx
@@ -65,7 +65,7 @@ export const Example = (): ReactElement => {
 				},
 			},
 			{
-				label: "Link - Standard",
+				label: "SV Link - Standard",
 				name: "sv_link",
 				icon: Link,
 				attrs: {
@@ -73,7 +73,7 @@ export const Example = (): ReactElement => {
 				}
 			},
 			{
-				label: "Link - Custom",
+				label: "SV Link - Custom",
 				name: "sv_link-custom",
 				icon: Link,
 				attrs: {

--- a/src/components/SideNav/SideNav.stories.tsx
+++ b/src/components/SideNav/SideNav.stories.tsx
@@ -18,8 +18,10 @@ export default {
 	decorators: [withKnobs],
 } as Meta;
 
+const homeContent = <h1>Welcome home!</h1>;
+
 export const Example = (): ReactElement => {
-	const [content, setContent] = useState<JSX.Element>(<h1>Home</h1>);
+	const [content, setContent] = useState<JSX.Element>(homeContent);
 	const [active, setActive] = useState("home");
 
 	const onNav = (args: SideNavArgs) => {
@@ -35,7 +37,7 @@ export const Example = (): ReactElement => {
 				icon: HomeIcon,
 				onNav: (args) => {
 					setActive(args.item.name);
-					setContent(<h1>Home</h1>);
+					setContent(homeContent);
 				},
 			},
 			{

--- a/src/components/SideNav/SideNav.stories.tsx
+++ b/src/components/SideNav/SideNav.stories.tsx
@@ -12,6 +12,8 @@ import EventNoteIcon from "@mui/icons-material/EventNote";
 import FolderIcon from "@mui/icons-material/Folder";
 import TaskAltIcon from "@mui/icons-material/TaskAlt";
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
+import OpenInNew from "@mui/icons-material/OpenInNew";
+import Link from "@mui/icons-material/Link";
 
 export default {
 	title: "Components/SideNav",
@@ -63,16 +65,44 @@ export const Example = (): ReactElement => {
 				},
 			},
 			{
-				label: "Simple View link",
+				label: "Link - Standard",
 				name: "sv_link",
+				icon: Link,
+				attrs: {
+					href: "https://www.simpleviewinc.com/"
+				}
+			},
+			{
+				label: "Link - Custom",
+				name: "sv_link-custom",
+				icon: Link,
 				attrs: {
 					href: "https://www.simpleviewinc.com/"
 				},
 				onNav: (args) => {
 					setActive(args.item.name);
-					setContent(<h1>Redirecting...</h1>)
-				}
-			}
+					setContent(<h1 style={{background: "#444", color: "white", padding: 10}}>This is the custom link page. It uses its own onNav handler instead of the one provided to the SideNav</h1>);
+				},
+			},
+			{
+				label: "Google",
+				name: "google",
+				icon: Link,
+				attrs: {
+					href: "https://www.google.co.uk"
+				},
+				onNav: false
+			},
+			{
+				label: "Google (New Tab)",
+				name: "google-new",
+				icon: OpenInNew,
+				attrs: {
+					href: "https://www.google.co.uk",
+					target: "_blank"
+				},
+				onNav: false
+			},
 		],
 		[
 			{

--- a/src/components/SideNav/SideNav.styled.tsx
+++ b/src/components/SideNav/SideNav.styled.tsx
@@ -45,6 +45,7 @@ export const LinkWrapper = styled.a<{$isActive?: boolean, $collapse?: MosaicCSSC
 	display: flex;
 	align-items: center;
 	gap: 8px;
+	text-decoration: none;
 
 	${({$isActive}) => $isActive && `
 		font-weight: ${theme.fontWeight.semiBold};

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -22,9 +22,15 @@ const SideNav = (props: SideNavProps): ReactElement => {
 	 */
 	const onLinkClicked = (args: { item: Item, event?: MouseEvent }) => {
 		const { item, event } = args;
+		const hasModifier = event.ctrlKey || event.shiftKey || event.altKey;
+
+		if (hasModifier) {
+			return;
+		}
+
 		const itemOnNav = item.onNav !== undefined ? item.onNav : onNav;
 
-		if (itemOnNav !== false && !event.ctrlKey && !event.shiftKey && !event.altKey) {
+		if (itemOnNav !== false) {
 			event.preventDefault();
 		}
 

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -24,7 +24,7 @@ const SideNav = (props: SideNavProps): ReactElement => {
 		const { item, event } = args;
 		const itemOnNav = item.onNav !== undefined ? item.onNav : onNav;
 
-		if (itemOnNav !== false && !event.ctrlKey && !event.shiftKey) {
+		if (itemOnNav !== false && !event.ctrlKey && !event.shiftKey && !event.altKey) {
 			event.preventDefault();
 		}
 

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -22,12 +22,14 @@ const SideNav = (props: SideNavProps): ReactElement => {
 	 */
 	const onLinkClicked = (args: { item: Item, event?: MouseEvent }) => {
 		const { item, event } = args;
-		if (typeof item?.onNav === "function") {
-			// if the nav item has it's own onNav function
-			item.onNav({ item, event });
-		} else {
-			// else if onNav exists, we use the main onNav to navigate
-			onNav && onNav({ item, event });
+		const itemOnNav = item.onNav !== undefined ? item.onNav : onNav;
+
+		if (itemOnNav !== false && !event.ctrlKey && !event.shiftKey) {
+			event.preventDefault();
+		}
+
+		if (typeof itemOnNav === "function") {
+			itemOnNav({ item, event });
 		}
 	};
 

--- a/src/components/SideNav/SideNavTypes.ts
+++ b/src/components/SideNav/SideNavTypes.ts
@@ -59,5 +59,5 @@ export type Item = {
 	/**
 	 * Callback that each link will execute on an onClick event.
 	 */
-	onNav?: SideNavOnNav;
+	onNav?: false | SideNavOnNav;
 };


### PR DESCRIPTION
Enables the `SideNav` link on click handler to prevent the default browser action if no modifier key is used. Also adds support to pass false as an item's `onNav`, which will bypass any `onNav` functionality that may come from `SideNav`