### PR TITLE
MOS-1215 Skip data items that don't have a valid row/col

### DIFF
--- a/src/components/Field/FormFieldNumberTable/FormFieldNumberTable.tsx
+++ b/src/components/Field/FormFieldNumberTable/FormFieldNumberTable.tsx
@@ -48,11 +48,11 @@ const FormFieldNumberTable = (
 		if (value) {
 			for (const row in value) {
 				if (!isValidRowCol(row, inputSettings.rows)) {
-					throw new Error(`Row ${row} is not defined.`);
+					continue;
 				}
 				for (const column in value[row]) {
 					if (!isValidRowCol(column, inputSettings.columns)) {
-						throw new Error(`Column ${column} is not defined.`);
+						continue;
 					}
 					totals[column] = (totals[column] || 0) + (Number(value[row][column] || 0));
 				}


### PR DESCRIPTION
Rather than throwing errors, the data items that don't correspond to a row or column provided are skipped. The data will not contribute to the row/column totals.