### PR TITLE
Mos 1176 Date filter QA rework

### DIFF
--- a/src/components/DataViewFilterDate/DataViewFilterDate.stories.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.stories.tsx
@@ -66,7 +66,7 @@ const optionLibrary: MosaicLabelValue[] = [
 export const Playground = (): ReactElement => {
 	const [state, setState] = useState({});
 
-	const showOptions = number("Show options", 0, { max: optionLibrary.length });
+	const showOptions = number("Show options", 0, { min: 0, max: optionLibrary.length });
 	const options = optionLibrary.slice(0, showOptions);
 
 	const onChange = function(data) {
@@ -79,7 +79,7 @@ export const Playground = (): ReactElement => {
 		<DataViewFilterDate
 			label="Date filter example"
 			data={state}
-			args={{ options }}
+			args={{ options: showOptions > 0 ? options : undefined }}
 			onRemove={onRemove}
 			onChange={onChange}
 		/>

--- a/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
@@ -66,6 +66,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 
 			onChange({
 				...value,
+				date,
 				validDate: false
 			});
 		}
@@ -81,6 +82,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 
 			onChange({
 				...value,
+				time,
 				validTime: false
 			});
 		} else if (isKeyboardEvent && !validKeyboardInput) {
@@ -90,6 +92,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 
 			onChange({
 				...value,
+				time,
 				validTime: false
 			});
 


### PR DESCRIPTION
- Ensures even invalid dates are stored in internal state, so that when that state is "cleared", the change causes the date's text field to be emptied
- Update the date filter story to prevent negative option counts causing unexpected slicing