### PR TITLE
MOS-1218 DnD handle styling and disabled state

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -42,6 +42,7 @@ function ButtonBase(props: ButtonProps) {
 	}
 
 	const iconPosition = props.iconPosition || "left";
+	const Component = props.component || (isIconButton ? StyledIconButton : StyledButton) as any;
 
 	return (
 		<StyledWrapper
@@ -57,15 +58,15 @@ function ButtonBase(props: ButtonProps) {
 			`}
 		>
 			{isIconButton ? (
-				<StyledIconButton {...buttonProps}>
+				<Component {...buttonProps}>
 					<Icon data-testid="icon-button-test" />
-				</StyledIconButton>
+				</Component>
 			) : (
-				<StyledButton {...buttonProps} $fullWidth={props.fullWidth}>
+				<Component {...buttonProps} $fullWidth={props.fullWidth}>
 					{iconPosition === "left" && adornmentIcon}
 					{props.label}
 					{iconPosition === "right" && adornmentIcon}
-				</StyledButton>
+				</Component>
 			)}
 		</StyledWrapper>
 	);

--- a/src/components/Button/ButtonTypes.tsx
+++ b/src/components/Button/ButtonTypes.tsx
@@ -32,6 +32,7 @@ export interface ButtonProps {
 	/** Attrs for the nested Material UI IconButton or Button */
 	muiAttrs?: MosaicObject
 	show?: MosaicShow;
+	component?: React.ComponentType
 }
 
 export interface ButtonPopoverContextProps {

--- a/src/components/DataView/DataViewTr/DataViewTr.styled.ts
+++ b/src/components/DataView/DataViewTr/DataViewTr.styled.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import theme from "@root/theme";
-import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+import { StyledIconButton } from "@root/components/Button/Button.styled";
 
 export const TableRow = styled.tr<{ $isDragOverlay?: boolean}>`
 	${({ $isDragOverlay }) => $isDragOverlay && `
@@ -17,6 +17,8 @@ export const TableRow = styled.tr<{ $isDragOverlay?: boolean}>`
 	}
 `
 
-export const TableRowDragHandle = styled(DragIndicatorIcon)`
-	cursor: grab;
+export const TableRowDragHandle = styled(StyledIconButton)`
+	&&{
+		cursor: grab;
+	}
 `

--- a/src/components/DataView/DataViewTr/DataViewTr.tsx
+++ b/src/components/DataView/DataViewTr/DataViewTr.tsx
@@ -1,14 +1,15 @@
 import React, { forwardRef } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 
-import theme from "@root/theme";
 import Checkbox from "@root/components/Checkbox";
 
 import DataViewTd from "../DataViewTd";
 import DataViewActionsButtonRow from "../DataViewActionsButtonRow";
 import { TableRow, TableRowDragHandle } from "./DataViewTr.styled";
 import { DataViewTrDndProps, DataViewTrProps } from "./DataViewTrTypes";
+import Button from "@root/components/Button";
 
 const DataViewTrStatic = forwardRef<HTMLTableRowElement, DataViewTrProps>(({
 	checked,
@@ -22,19 +23,26 @@ const DataViewTrStatic = forwardRef<HTMLTableRowElement, DataViewTrProps>(({
 	columns,
 	row,
 	isDragOverlay,
+	style,
 	...props
 }, ref) => {
-
 	return (
 		<TableRow
-			style={props.style}
+			style={style}
 			className={checked && "checked"}
 			ref={ref}
 			$isDragOverlay={isDragOverlay}
 		>
 			{onReorder && (
 				<DataViewTd key="_draggable">
-					<TableRowDragHandle {...props} style={{display: "flex", color: disabled ? theme.colors.blackDisabled : theme.newColors.almostBlack["100"]}}/>
+					<Button
+						disabled={disabled}
+						color="black"
+						variant="icon"
+						mIcon={DragIndicatorIcon}
+						muiAttrs={{...props}}
+						component={TableRowDragHandle}
+					/>
 				</DataViewTd>
 			)}
 			{onCheckboxClick && (


### PR DESCRIPTION
- Modifies the drag handle to use a Mosaic icon button in order to utilise the disabled and focus states
- Allows for a custom component to be passed to the `Button` component that can be used to in place of Materials nested `Button` or `IconButton` components