### PR TITLE
MOS-1228 Section separator

### DIFF
--- a/src/components/SideNav/SideNav.styled.tsx
+++ b/src/components/SideNav/SideNav.styled.tsx
@@ -38,6 +38,7 @@ export const LinksWrapper = styled.div<{$collapse?: MosaicCSSContainer}>`
 
 	${({$collapse}) => $collapse ? `
 		gap: 40px;
+		border-bottom: 0;
 
 		${containerQuery($collapse.minWidth, $collapse.name)} {
 			flex-direction: column;

--- a/src/components/SideNav/SideNav.styled.tsx
+++ b/src/components/SideNav/SideNav.styled.tsx
@@ -24,13 +24,22 @@ export const StyledSideNav = styled.nav<{$collapse?: MosaicCSSContainer}>`
 	`}
 `;
 
+export const SidebarWrap = styled.div`
+  	font-family: ${theme.fontFamily};
+`;
+
 export const LinksWrapper = styled.div<{$collapse?: MosaicCSSContainer}>`
 	display: flex;
+	border-bottom: 2px solid ${theme.newColors.grey2["100"]};
+
+	&:last-child{
+		border-bottom: 0;
+	}
 
 	${({$collapse}) => $collapse ? `
 		gap: 40px;
 
-		${containerQuery("xl", "FORM")} {
+		${containerQuery($collapse.minWidth, $collapse.name)} {
 			flex-direction: column;
 			gap: 0;
 		}
@@ -68,7 +77,7 @@ export const LinkWrapper = styled.a<{$isActive?: boolean, $collapse?: MosaicCSSC
 	`};
 
 	${({$collapse}) => $collapse && `
-		${containerQuery("xl", "FORM")} {
+		${containerQuery($collapse.minWidth, $collapse.name)} {
 			align-items: center;
 			border-bottom: 0;
 			border-left: 3px solid transparent;
@@ -78,7 +87,7 @@ export const LinkWrapper = styled.a<{$isActive?: boolean, $collapse?: MosaicCSSC
 	`}
 
 	${({$collapse, $isActive}) => $collapse && $isActive && `
-		${containerQuery("xl", "FORM")} {
+		${containerQuery($collapse.minWidth, $collapse.name)} {
 			background-color: ${theme.newColors.grey2["100"]};
 			border-left-color: ${theme.newColors.simplyGold["100"]};
 		}
@@ -94,8 +103,7 @@ export const LinkWrapper = styled.a<{$isActive?: boolean, $collapse?: MosaicCSSC
 		.MuiSvgIcon-root:not(:first-child) {
 			display: block;
 			color: ${theme.newColors.grey3["100"]};
-			margin-right: -12px;
-			margin-left: auto;
+			margin: -2px -12px -2px auto;
 			width: 16px;
 		}
 	}
@@ -103,13 +111,6 @@ export const LinkWrapper = styled.a<{$isActive?: boolean, $collapse?: MosaicCSSC
 	.MuiSvgIcon-root:not(:first-child) {
 		display: none;
 	}
-`;
-
-export const SidebarWrap = styled.div`
-  	font-family: ${theme.fontFamily};
-	div:last-child {
-		border-bottom: 0;
-	};
 `;
 
 export const StyledLink = styled.span`


### PR DESCRIPTION
This reinstates the `SideNav` section separator that was lost in the MOS-1175 refactor