### PR TITLE
MOS-1231 Field disabled toggle

### DIFF
--- a/src/components/Field/FieldTypes.tsx
+++ b/src/components/Field/FieldTypes.tsx
@@ -66,6 +66,10 @@ export interface MosaicFieldProps<T = any, U = any, V = any> {
 	 * Spacing type
 	 */
 	spacing?: FormSpacing
+	/**
+	 * Whether or not the field is disabled
+	 */
+	disabled?: boolean
 }
 
 // SHARED FIELD DEFINITION - DEVELOPER GENERIC CONTRACT
@@ -97,7 +101,7 @@ export interface FieldDefBase<Type, T = any, U = any> {
 	/**
 	 * Indicates whether the field can be written on or readonly.
 	 */
-	disabled?: boolean;
+	disabled?: MosaicToggle<FormState>;
 	/**
 	 * Settings that belong to a specific field.
 	 * They are defined within each field implementation.

--- a/src/components/Field/FormFieldAddress/FormFieldAddress.tsx
+++ b/src/components/Field/FormFieldAddress/FormFieldAddress.tsx
@@ -15,6 +15,7 @@ import Dialog from "@root/components/Dialog/Dialog";
 
 const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSettings, AddressData>): ReactElement => {
 	const {
+		disabled,
 		value,
 		onBlur,
 		onChange,
@@ -208,7 +209,7 @@ const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSe
 			{addressTypes?.length > 0 && (
 				<Footer>
 					<Button
-						disabled={fieldDef?.disabled}
+						disabled={disabled}
 						color="gray"
 						variant="outlined"
 						label="ADD ADDRESS"
@@ -224,7 +225,7 @@ const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSe
 							address={address}
 							addressIndex={idx}
 							onEdit={showEditModal}
-							disabled={fieldDef?.disabled}
+							disabled={disabled}
 							onRemoveAddress={setRemoveDialog}
 						/>
 					))}

--- a/src/components/Field/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
+++ b/src/components/Field/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
@@ -30,6 +30,7 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 		value,
 		onBlur,
 		onChange,
+		disabled,
 		fieldDef,
 	} = props;
 
@@ -87,7 +88,7 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 							onClick={handleOpenModal}
 							mIcon={AddIcon}
 							attrs={{ style: { marginBottom: "16px" } }}
-							disabled={fieldDef?.disabled}
+							disabled={disabled}
 						/>
 					)}
 					<ChipList
@@ -98,7 +99,7 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 								isMobileView,
 								deleteSelectedOption,
 							},
-							disabled: fieldDef?.disabled,
+							disabled,
 						}}
 					/>
 				</AdvancedSelectionWrapper>
@@ -108,7 +109,7 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 					variant="outlined"
 					label="ADD"
 					onClick={handleOpenModal}
-					disabled={fieldDef?.disabled}
+					disabled={disabled}
 				/>
 			)}
 			<Drawer

--- a/src/components/Field/FormFieldCheckbox/FormFieldCheckbox.tsx
+++ b/src/components/Field/FormFieldCheckbox/FormFieldCheckbox.tsx
@@ -14,7 +14,8 @@ const FormFieldCheckbox = (
 		fieldDef,
 		onChange,
 		onBlur,
-		value
+		value,
+		disabled
 	} = props;
 
 	const [internalOptions, setInternalOptions] = useState<MosaicLabelValue[]>([]);
@@ -58,7 +59,7 @@ const FormFieldCheckbox = (
 
 	return (
 		<StyledCheckboxList
-			disabled={fieldDef?.disabled}
+			disabled={disabled}
 			checked={checked}
 			options={internalOptions}
 			onChange={(val) => internalOnChange(val, onChange)}

--- a/src/components/Field/FormFieldChipSingleSelect/FormFieldChipSingleSelect.tsx
+++ b/src/components/Field/FormFieldChipSingleSelect/FormFieldChipSingleSelect.tsx
@@ -20,6 +20,7 @@ const FormFieldChipSingleSelect = (props: MosaicFieldProps<"chip", FormFieldChip
 		onChange,
 		onBlur,
 		value,
+		disabled,
 	} = props;
 
 	const { required } = fieldDef || null;
@@ -97,7 +98,7 @@ const FormFieldChipSingleSelect = (props: MosaicFieldProps<"chip", FormFieldChip
 				<Chip
 					key={option.value}
 					label={option.label}
-					disabled={fieldDef?.disabled}
+					disabled={disabled}
 					selected={option.selected}
 					onClick={() => updateSelectedOption(option)}
 				/>

--- a/src/components/Field/FormFieldColorPicker/ColorPicker.test.tsx
+++ b/src/components/Field/FormFieldColorPicker/ColorPicker.test.tsx
@@ -16,8 +16,8 @@ describe("ColorPicker component", () => {
 		render(
 			<FormFieldColorPicker
 				value={value}
-				fieldDef={{ name: "colorPicker", label: "", disabled: true, type: "color", }}
-
+				fieldDef={{ name: "colorPicker", label: "", type: "color", }}
+				disabled
 			/>
 		);
 

--- a/src/components/Field/FormFieldColorPicker/FormFieldColorPicker.tsx
+++ b/src/components/Field/FormFieldColorPicker/FormFieldColorPicker.tsx
@@ -40,7 +40,13 @@ const FormFieldColorPicker = (
 	props: MosaicFieldProps<"color", unknown, ColorData>
 ): ReactElement => {
 	const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
-	const { fieldDef, value, onChange, onBlur } = props;
+	const {
+		fieldDef,
+		value,
+		onChange,
+		onBlur,
+		disabled,
+	} = props;
 
 	// State variables
 	const [displayColorPicker, setDisplayColorPicker] = useState(false);
@@ -67,11 +73,11 @@ const FormFieldColorPicker = (
 	return (
 		<>
 			<ColorSelected
-				disabled={fieldDef?.disabled}
+				disabled={disabled}
 				color={color?.rgb || value || { r: 0, g: 141, b: 168, a: 1 }}
 				onClick={handleClick}
 			/>
-			{!fieldDef?.disabled && (
+			{!disabled && (
 				<PopOver
 					id={id}
 					open={displayColorPicker}

--- a/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
@@ -23,6 +23,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 			validTime: false
 		},
 		onBlur,
+		disabled,
 		error,
 		dispatch
 	} = props;
@@ -135,7 +136,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 							maxDate: fieldDef?.inputSettings?.maxDate
 						},
 						required: fieldDef?.required,
-						disabled: fieldDef?.disabled
+						disabled,
 					}}
 					value={value?.date}
 					onBlur={onBlurProxy("date")}
@@ -154,7 +155,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 							inputSettings: {
 								placeholder: TIME_FORMAT_FULL_PLACEHOLDER
 							},
-							disabled: fieldDef?.disabled
+							disabled,
 						}}
 						value={value?.time}
 						onBlur={onBlurProxy("time")}

--- a/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
@@ -14,7 +14,7 @@ import {
 import { DATE_FORMAT_FULL } from "@root/constants";
 
 const DateFieldPicker = (props: DatePickerProps): ReactElement => {
-	const { fieldDef, onChange, value = null, onBlur } = props;
+	const { fieldDef, onChange, value = null, onBlur, disabled } = props;
 
 	const [isPickerOpen, setIsPickerOpen] = useState(false);
 
@@ -31,7 +31,7 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 			{...params}
 			onBlur={onBlur}
 			required={fieldDef.required}
-			disabled={fieldDef?.disabled}
+			disabled={disabled}
 			inputProps={{
 				...params.inputProps,
 				placeholder: fieldDef?.inputSettings?.placeholder,
@@ -41,7 +41,7 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 
 	return (
 		<LocalizationProvider dateAdapter={AdapterDateFns}>
-			<DatePickerWrapper data-testid="date-picker-test-id" $isPickerOpen={isPickerOpen} $disabled={fieldDef?.disabled}>
+			<DatePickerWrapper data-testid="date-picker-test-id" $isPickerOpen={isPickerOpen} $disabled={disabled}>
 				<DatePicker
 					renderInput={renderInput}
 					inputFormat={DATE_FORMAT_FULL}
@@ -54,7 +54,7 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 					}}
 					minDate={fieldDef?.inputSettings?.minDate}
 					maxDate={fieldDef?.inputSettings?.maxDate}
-					disabled={fieldDef?.disabled}
+					disabled={disabled}
 				/>
 			</DatePickerWrapper>
 		</LocalizationProvider>

--- a/src/components/Field/FormFieldDate/TimePicker/TimePicker.tsx
+++ b/src/components/Field/FormFieldDate/TimePicker/TimePicker.tsx
@@ -14,7 +14,7 @@ import { TimePickerDef, TimePickerData  } from "./TimePickerTypes";
 import { ThemeProvider } from "@mui/material/styles";
 
 const TimeFieldPicker = (props: MosaicFieldProps<"timePicker", TimePickerDef, TimePickerData>): ReactElement => {
-	const { fieldDef, onChange, value = null, onBlur } = props;
+	const { fieldDef, onChange, value = null, onBlur, disabled } = props;
 
 	const [isPickerOpen, setIsPickerOpen] = useState(false);
 
@@ -28,7 +28,7 @@ const TimeFieldPicker = (props: MosaicFieldProps<"timePicker", TimePickerDef, Ti
 			{...params}
 			onBlur={onBlur}
 			required={fieldDef.required}
-			disabled={fieldDef?.disabled}
+			disabled={disabled}
 			inputProps={{
 				...params.inputProps,
 				placeholder: fieldDef?.inputSettings?.placeholder,
@@ -39,14 +39,14 @@ const TimeFieldPicker = (props: MosaicFieldProps<"timePicker", TimePickerDef, Ti
 	return (
 		<LocalizationProvider dateAdapter={AdapterDateFns}>
 			<ThemeProvider theme={customTheme}>
-				<DatePickerWrapper $isPickerOpen={isPickerOpen} $disabled={fieldDef?.disabled}>
+				<DatePickerWrapper $isPickerOpen={isPickerOpen} $disabled={disabled}>
 					<TimePicker
 						value={value}
 						onChange={onChange}
 						renderInput={renderInput}
 						onOpen={handleOpenState}
 						onClose={handleOpenState}
-						disabled={fieldDef?.disabled}
+						disabled={disabled}
 					/>
 				</DatePickerWrapper>
 			</ThemeProvider>

--- a/src/components/Field/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
+++ b/src/components/Field/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
@@ -20,7 +20,8 @@ const DropdownSingleSelection = (props: MosaicFieldProps<"dropdown", DropdownSin
 		error,
 		onChange,
 		onBlur,
-		value
+		value,
+		disabled
 	} = props;
 
 	const [isOpen, setIsOpen] = useState(false);
@@ -99,7 +100,7 @@ const DropdownSingleSelection = (props: MosaicFieldProps<"dropdown", DropdownSin
 				popupIcon={<ExpandMoreIcon />}
 				onBlur={(e) => onBlur && onBlur((e.target as HTMLInputElement).value)}
 				open={isOpen}
-				disabled={fieldDef?.disabled}
+				disabled={disabled}
 			/>
 		</SingleDropdownWrapper>
 	);

--- a/src/components/Field/FormFieldImageUpload/FormFieldImageUpload.test.tsx
+++ b/src/components/Field/FormFieldImageUpload/FormFieldImageUpload.test.tsx
@@ -84,8 +84,8 @@ describe("FormFieldImageUpload disabled state", () => {
 					name: "imageUpload",
 					type: "imageUpload",
 					label: "",
-					disabled: true,
 				}}
+				disabled
 			/>
 		);
 

--- a/src/components/Field/FormFieldImageUpload/FormFieldImageUpload.tsx
+++ b/src/components/Field/FormFieldImageUpload/FormFieldImageUpload.tsx
@@ -30,7 +30,7 @@ import { AssetCard, AssetButtons, AssetCardTop, AssetInfo } from "../FormFieldIm
 const FormFieldImageUpload = (
 	props: MosaicFieldProps<"imageUpload", ImageUploadInputSettings, ImageUploadValue>
 ): ReactElement => {
-	const { fieldDef, onChange, value } = props;
+	const { fieldDef, onChange, value, disabled } = props;
 
 	// State variables
 	const [isOver, setIsOver] = useState(false);
@@ -239,7 +239,7 @@ const FormFieldImageUpload = (
 						</DragAndDropSpan>
 					) : (
 						<>
-							{!fieldDef?.disabled && (
+							{!disabled && (
 								<DragAndDropSpan $isOver={isOver}>
 									Drag & Drop files here or
 								</DragAndDropSpan>
@@ -247,7 +247,7 @@ const FormFieldImageUpload = (
 							<UploadButton
 								color="gray"
 								variant="outlined"
-								disabled={fieldDef?.disabled}
+								disabled={disabled}
 								label="UPLOAD FILES"
 								onClick={uploadFiles}
 								muiAttrs={{disableRipple: true}}
@@ -262,7 +262,7 @@ const FormFieldImageUpload = (
 						title=""
 						type="file"
 						value=""
-						disabled={fieldDef?.disabled}
+						disabled={disabled}
 					/>
 				</DragAndDropContainer>
 			) : (
@@ -307,7 +307,7 @@ const FormFieldImageUpload = (
 									<MenuColumn data-testid="menu-container-test">
 										<MenuFormFieldCard
 											options={fieldDef?.inputSettings?.options}
-											disabled={fieldDef?.disabled}
+											disabled={disabled}
 										/>
 									</MenuColumn>
 								)}
@@ -320,7 +320,7 @@ const FormFieldImageUpload = (
 									variant="text"
 									label="Set Focus"
 									onClick={setFocus}
-									disabled={fieldDef?.disabled}
+									disabled={disabled}
 								/>
 							) : (
 								fieldDef?.inputSettings?.handleSetFocus && (
@@ -329,7 +329,7 @@ const FormFieldImageUpload = (
 										variant="text"
 										label="View"
 										onClick={handleView}
-										disabled={fieldDef?.disabled}
+										disabled={disabled}
 									/>
 								)
 							)}
@@ -338,7 +338,7 @@ const FormFieldImageUpload = (
 								variant="text"
 								label="Remove"
 								onClick={removeFile}
-								disabled={fieldDef?.disabled}
+								disabled={disabled}
 							/>
 						</AssetButtons>
 					</AssetCard>

--- a/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/FormFieldImageVideoLinkDocumentBrowsing.tsx
+++ b/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/FormFieldImageVideoLinkDocumentBrowsing.tsx
@@ -47,7 +47,7 @@ const FormFieldImageVideoLinkDocumentBrowsing = (
 		ImageVideoDocumentLinkData
 	>
 ): ReactElement => {
-	const { fieldDef, value } = props;
+	const { fieldDef, value, disabled } = props;
 
 	// State variables
 	const [assetType, setAssetType] = useState("");
@@ -175,28 +175,28 @@ const FormFieldImageVideoLinkDocumentBrowsing = (
 							<BrowseOptionsContainer>
 								{fieldDef?.inputSettings?.handleSetImage && (
 									<BrowseOption
-										disabled={fieldDef?.disabled}
+										disabled={disabled}
 										handleBrowse={handleBrowse}
 										assetType={IMAGE}
 									/>
 								)}
 								{fieldDef?.inputSettings?.handleSetVideo && (
 									<BrowseOption
-										disabled={fieldDef?.disabled}
+										disabled={disabled}
 										handleBrowse={handleBrowse}
 										assetType={VIDEO}
 									/>
 								)}
 								{fieldDef?.inputSettings?.handleSetDocument && (
 									<BrowseOption
-										disabled={fieldDef?.disabled}
+										disabled={disabled}
 										handleBrowse={handleBrowse}
 										assetType={DOCUMENT}
 									/>
 								)}
 								{fieldDef?.inputSettings?.handleSetLink && (
 									<BrowseOption
-										disabled={fieldDef?.disabled}
+										disabled={disabled}
 										handleBrowse={handleBrowse}
 										assetType={LINK}
 									/>
@@ -228,7 +228,7 @@ const FormFieldImageVideoLinkDocumentBrowsing = (
 							{fieldDef?.inputSettings?.options && (
 								<MenuColumn>
 									<MenuFormFieldCard
-										disabled={fieldDef?.disabled}
+										disabled={disabled}
 										options={fieldDef?.inputSettings?.options}
 									/>
 								</MenuColumn>
@@ -242,7 +242,7 @@ const FormFieldImageVideoLinkDocumentBrowsing = (
 							variant="text"
 							label="Browse"
 							muiAttrs={{ disableRipple: true }}
-							disabled={fieldDef?.disabled}
+							disabled={disabled}
 							onClick={async (e) => await handleBrowse(e, assetType)}
 						></Button>
 						<Button
@@ -250,7 +250,7 @@ const FormFieldImageVideoLinkDocumentBrowsing = (
 							variant="text"
 							label="Remove"
 							muiAttrs={{ disableRipple: true }}
-							disabled={fieldDef?.disabled}
+							disabled={disabled}
 							onClick={(e) => handleRemove(e)}
 						></Button>
 					</AssetButtons>

--- a/src/components/Field/FormFieldMapCoordinates/FormFieldMapCoordinates.tsx
+++ b/src/components/Field/FormFieldMapCoordinates/FormFieldMapCoordinates.tsx
@@ -44,6 +44,7 @@ const FormFieldMapCoordinates = (props: MosaicFieldProps<"mapCoordinates", MapCo
 		value,
 		onBlur,
 		onChange,
+		disabled,
 		fieldDef,
 	} = props;
 
@@ -159,12 +160,12 @@ const FormFieldMapCoordinates = (props: MosaicFieldProps<"mapCoordinates", MapCo
 								color="teal"
 								variant="text"
 								label="Edit"
-								disabled={fieldDef?.disabled}
+								disabled={disabled}
 								onClick={handleAddCoordinates}
 							/>
 							<Button
 								color="red"
-								disabled={fieldDef?.disabled}
+								disabled={disabled}
 								variant="text"
 								label="Remove"
 								onClick={() => setRemoveDialog(true)}
@@ -174,7 +175,7 @@ const FormFieldMapCoordinates = (props: MosaicFieldProps<"mapCoordinates", MapCo
 				</div>
 			) : (
 				<Button
-					disabled={fieldDef?.disabled}
+					disabled={disabled}
 					onClick={handleAddCoordinates}
 					color="gray"
 					variant="outlined"

--- a/src/components/Field/FormFieldMatrix/FormFieldMatrix.tsx
+++ b/src/components/Field/FormFieldMatrix/FormFieldMatrix.tsx
@@ -13,6 +13,7 @@ const FormFieldMatrix = (
 ): ReactElement => {
 	const {
 		value,
+		disabled,
 		fieldDef,
 	} = props;
 
@@ -28,7 +29,7 @@ const FormFieldMatrix = (
 						<Button
 							key={`${button.label}-${idx}`}
 							{...button}
-							disabled={button.disabled === undefined ? fieldDef?.disabled : button.disabled}
+							disabled={button.disabled === undefined ? disabled : button.disabled}
 						/>
 					))}
 				</ButtonRow>
@@ -36,7 +37,7 @@ const FormFieldMatrix = (
 			{hasValue && (
 				<DataView
 					data={[]}
-					{...{...dataView, disabled: fieldDef?.disabled, data}}
+					{...{...dataView, disabled, data}}
 				/>
 			)}
 		</MatrixWrapper>

--- a/src/components/Field/FormFieldNumberTable/FormFieldNumberTable.tsx
+++ b/src/components/Field/FormFieldNumberTable/FormFieldNumberTable.tsx
@@ -29,7 +29,7 @@ const FormFieldNumberTable = (
     NumberTableData
   >
 ): ReactElement => {
-	const { fieldDef, onChange, value } = props;
+	const { fieldDef, onChange, value, disabled } = props;
 
 	const { inputSettings } = fieldDef;
 	const { displaySumColumn = true, displaySumRow = true } = inputSettings;
@@ -191,7 +191,7 @@ const FormFieldNumberTable = (
 										value={strValue}
 										onChange={(e) => onChangeCell(e, row.name, column.name)}
 										fieldSize={"90px"}
-										disabled={fieldDef?.disabled}
+										disabled={disabled}
 										inputRef={(el) => {
 											if (cellRefs?.current) {
 												cellRefs.current[rowIdx] = cellRefs.current[rowIdx] || [];

--- a/src/components/Field/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
+++ b/src/components/Field/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
@@ -20,7 +20,8 @@ const FormFieldPhoneSelectionDropdown = (
 		error,
 		onChange,
 		onBlur,
-		value
+		value,
+		disabled,
 	} = props;
 
 	const [dialCode, setDialCode] = useState("");
@@ -38,12 +39,12 @@ const FormFieldPhoneSelectionDropdown = (
 		<PhoneInputWrapper
 			$error={!!(fieldDef?.required && error)}
 			onBlur={(e) => onBlur && onBlur((e.target as HTMLInputElement).value)}
-			$disabled={fieldDef?.disabled}
+			$disabled={disabled}
 		>
 			<PhoneInput
 				autoFormat={!!fieldDef?.inputSettings?.autoFormat}
 				country={fieldDef?.inputSettings?.country ? fieldDef?.inputSettings.country : "us"}
-				disabled={fieldDef?.disabled}
+				disabled={disabled}
 				onChange={onPhoneChange}
 				value={value || dialCode}
 				countryCodeEditable={false}

--- a/src/components/Field/FormFieldRadio/FormFieldRadio.tsx
+++ b/src/components/Field/FormFieldRadio/FormFieldRadio.tsx
@@ -16,6 +16,7 @@ const FormFieldRadio = (props: MosaicFieldProps<"radio", RadioInputSettings, Rad
 		onChange,
 		value,
 		onBlur,
+		disabled,
 	} = props;
 
 	const [internalOptions, setInternalOptions] = useState([]);
@@ -48,7 +49,7 @@ const FormFieldRadio = (props: MosaicFieldProps<"radio", RadioInputSettings, Rad
 		<>
 			{internalOptions.map((option) => (
 				<RadioButton
-					disabled={fieldDef?.disabled}
+					disabled={disabled}
 					key={option.label}
 					label={option.label}
 					value={option.value}

--- a/src/components/Field/FormFieldText/FormFieldText.tsx
+++ b/src/components/Field/FormFieldText/FormFieldText.tsx
@@ -18,6 +18,7 @@ const TextField = (
 		onChange,
 		onBlur,
 		value,
+		disabled,
 	} = props;
 
 	const leadingElement = fieldDef?.inputSettings?.prefixElement
@@ -61,7 +62,7 @@ const TextField = (
 			type={fieldDef?.inputSettings?.type === "number" ? "text" : fieldDef?.inputSettings?.type}
 			minRows={fieldDef?.inputSettings?.minRows}
 			maxRows={fieldDef?.inputSettings?.maxRows}
-			disabled={fieldDef?.disabled}
+			disabled={disabled}
 		/>
 	);
 };

--- a/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
+++ b/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
@@ -36,10 +36,9 @@ const buttonList = [
 const FormFieldTextEditor = (
 	props: MosaicFieldProps<"textEditor", TextEditorInputSettings, TextEditorData>
 ): ReactElement => {
-	const { fieldDef, onBlur, onChange, value, error } = props;
+	const { fieldDef, onBlur, onChange, value, disabled, error } = props;
 
 	const {
-		disabled = false,
 		inputSettings = {}
 	} = fieldDef;
 

--- a/src/components/Field/FormFieldToggleSwitch/FormFieldToggleSwitch.test.tsx
+++ b/src/components/Field/FormFieldToggleSwitch/FormFieldToggleSwitch.test.tsx
@@ -20,11 +20,11 @@ const FormFieldToggleSwitchExample = ({ disabled }: { disabled: boolean }) => {
 				label: "Field label",
 				type: "toggleSwitch",
 				name: "toggleSwitch",
-				disabled: disabled,
 				inputSettings: {
 					toggleLabel: "Toggle switch label"
 				}
 			}}
+			disabled
 			onChange={handleChange}
 			value={isChecked}
 		/>

--- a/src/components/Field/FormFieldToggleSwitch/FormFieldToggleSwitch.tsx
+++ b/src/components/Field/FormFieldToggleSwitch/FormFieldToggleSwitch.tsx
@@ -16,11 +16,12 @@ const FormFieldToggleSwitch = (
 		onBlur,
 		onChange,
 		value,
+		disabled
 	} = props;
 
 	return (
 		<ToggleSwitch
-			disabled={fieldDef?.disabled}
+			disabled={disabled}
 			checked={value}
 			label={fieldDef?.inputSettings?.toggleLabel}
 			onChange={onChange}

--- a/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
@@ -15,7 +15,8 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 		fieldDef,
 		value,
 		onChange,
-		dispatch
+		disabled,
+		dispatch,
 	} = props;
 
 	const {
@@ -247,7 +248,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 						</DragAndDropSpan>
 					) : (
 						<>
-							{!fieldDef?.disabled && (
+							{!disabled && (
 								<DragAndDropSpan $isOver={isOver}>
 								Drag & Drop files here or
 								</DragAndDropSpan>
@@ -257,7 +258,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 								variant="outlined"
 								label="UPLOAD FILES"
 								onClick={uploadFiles}
-								disabled={fieldDef?.disabled}
+								disabled={disabled}
 							/>
 						</>
 					)}
@@ -268,7 +269,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 						title=""
 						type="file"
 						value=""
-						disabled={fieldDef?.disabled}
+						disabled={disabled}
 						multiple={limit < 0 || (limit > 1 && limit - currentLength > 1)}
 						accept={fileExtensions.acceptAttr}
 					/>

--- a/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
@@ -291,12 +291,12 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 							fileUrl={file.fileUrl}
 							downloadUrl={file.downloadUrl}
 							onFileDelete={handleFileDelete}
-							disabled={fieldDef.disabled}
+							disabled={disabled}
 						/>
 					))}
 				</StyledFileGrid>
 			}
-			{pendingFiles && Object.keys(pendingFiles).length > 0 && !fieldDef.disabled &&
+			{pendingFiles && Object.keys(pendingFiles).length > 0 && !disabled &&
 				<StyledFileGrid>
 					{Object.entries(pendingFiles).map(([key, file]: [key: string, file: {data: UploadData, error: string, percent: number}]) => {
 						return (

--- a/src/components/Form/Col/ColField.tsx
+++ b/src/components/Form/Col/ColField.tsx
@@ -30,6 +30,8 @@ const ColField = ({
 		throw new Error(`Invalid type ${field.type}`);
 	}
 
+	const disabled = useWrappedToggle(field, state, "disabled", false);
+
 	const onChange = useCallback((value: any) => {
 		field.onChangeCb && field.onChangeCb();
 
@@ -49,7 +51,7 @@ const ColField = ({
 	}, [field.name]);
 
 	const value = state?.internalData[field.name];
-	const error = !field.disabled ? state.errors[field.name] : "";
+	const error = !disabled ? state.errors[field.name] : "";
 
 	const size = sanitizeFieldSize(
 		field.size,
@@ -70,6 +72,7 @@ const ColField = ({
 			onBlur={onBlur}
 			ref={sanitizedFieldDef.ref}
 			dispatch={dispatch}
+			disabled={disabled}
 		/>
 	), [sanitizedFieldDef, value, error, onChange, onBlur, dispatch]);
 

--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -2,6 +2,7 @@ import { mapsValidators, required, validatePhoneNumber, Validator } from "./vali
 import { FormActionThunks, FormExtraArgs } from "./state/types";
 import { getFieldConfig } from "./Col/fieldConfigMap";
 import { FieldDefSanitized } from "../Field";
+import { getToggle, wrapToggle } from "@root/utils/toggle";
 
 async function runValidators(
 	validators: Validator[],
@@ -158,7 +159,8 @@ export const formActions: FormActionThunks = {
 	},
 	validateField({ name, validateLinkedFields }) {
 		return async function (dispatch, getState, extraArgs) {
-			const { data } = getState();
+			const state = getState();
+			const { data } = state;
 			const { mounted, internalValidators } = extraArgs;
 			const field = getFieldFromExtra(extraArgs, name);
 
@@ -179,12 +181,15 @@ export const formActions: FormActionThunks = {
 				});
 			}
 
+			const disabledWrapped = wrapToggle(extraArgs?.fieldMap[name]?.disabled, state, false);
+			const disabled = getToggle(disabledWrapped);
+
 			/**
 			 * We dispatch an undefined so that way, if by any reason
 			 * the field had an error message and then became disabled,
 			 * the error would get removed from the state.
 			 */
-			if (extraArgs?.fieldMap[name]?.disabled) {
+			if (disabled) {
 				await dispatch({
 					type: "FIELD_UNVALIDATE",
 					name

--- a/src/components/Form/stories/RuntimeBehaviours.stories.tsx
+++ b/src/components/Form/stories/RuntimeBehaviours.stories.tsx
@@ -59,7 +59,24 @@ export const RuntimeBehaviours = (): ReactElement => {
 					name: "text4",
 					label: "Text that receives copy",
 					type: "text"
-				}
+				},
+				{
+					name: "text5",
+					label: "Text that enables another field",
+					type: "text"
+				},
+				{
+					name: "text6",
+					label: "Text that is initially disabled",
+					type: "text",
+					instructionText: "Type \"ENABLE\" into the previous field to enable this field",
+					disabled: [
+						({data}) => data?.text5 !== "ENABLE",
+						true,
+						() => true
+					],
+					required: true
+				},
 			],
 		[]
 	);

--- a/src/utils/toggle/getToggle.ts
+++ b/src/utils/toggle/getToggle.ts
@@ -1,0 +1,16 @@
+import { MosaicToggle } from "@root/types";
+
+function getToggle(toggle?: MosaicToggle, defaultToggle = true): boolean {
+	const toggleDefined = toggle !== undefined ? toggle : defaultToggle;
+	const conditions = Array.isArray(toggleDefined) ? toggleDefined : [toggleDefined];
+
+	return conditions.every(condition => {
+		if (typeof condition === "function") {
+			return condition();
+		} else {
+			return condition;
+		}
+	});
+}
+
+export default getToggle;

--- a/src/utils/toggle/index.ts
+++ b/src/utils/toggle/index.ts
@@ -1,3 +1,4 @@
 export { default as wrapToggle } from "./wrapToggle"
+export { default as getToggle } from "./getToggle"
 export { default as useWrappedToggle } from "./useWrappedToggle"
 export { default as useToggle } from "./useToggle"

--- a/src/utils/toggle/useToggle.ts
+++ b/src/utils/toggle/useToggle.ts
@@ -1,4 +1,5 @@
 import { MosaicToggle } from "@root/types";
+import getToggle from "./getToggle";
 
 /**
  * A way of conditionally rendering an item or items based on their
@@ -10,24 +11,14 @@ import { MosaicToggle } from "@root/types";
  *
  * @param items The item or items containing the show property
  */
-function useToggle<K extends keyof T, T extends { [key in K]?: MosaicToggle }>(items: T[], key: K): T[]
-function useToggle<K extends keyof T, T extends { [key in K]?: MosaicToggle }>(items: T, key: K): boolean
-function useToggle<K extends keyof T, T extends { [key in K]?: MosaicToggle }>(items: T | T[], key: K): boolean | T[] {
+function useToggle<K extends keyof T, T extends { [key in K]?: MosaicToggle }>(items: T[], key: K, defaultToggle?: boolean): T[]
+function useToggle<K extends keyof T, T extends { [key in K]?: MosaicToggle }>(items: T, key: K, defaultToggle?: boolean): boolean
+function useToggle<K extends keyof T, T extends { [key in K]?: MosaicToggle }>(items: T | T[], key: K, defaultToggle = true): boolean | T[] {
 	const isArray = Array.isArray(items);
 	const itemsAsArray = isArray ? items : [items];
 
 	const filteredItems = itemsAsArray.filter((item) => {
-		const toggle = item[key] !== undefined ? item[key] : true;
-		const conditions = Array.isArray(toggle) ? toggle : [toggle];
-
-		return conditions.every(condition => {
-			if (typeof condition === "function") {
-				return condition();
-			} else {
-				return condition;
-			}
-		});
-
+		return getToggle(item[key], defaultToggle);
 	});
 
 	if (isArray) {

--- a/src/utils/toggle/useWrappedToggle.ts
+++ b/src/utils/toggle/useWrappedToggle.ts
@@ -7,17 +7,20 @@ import useToggle from "./useToggle";
 function useWrappedToggle<K extends keyof T, T extends { [key in K]?: MosaicToggle<P> }, P>(
 	items: T[],
 	params: P,
-	key: K
+	key: K,
+	defaultToggle?: boolean
 ): (Omit<T, K> & { [key in K]?: MosaicToggle })[]
 function useWrappedToggle<K extends keyof T, T extends { [key in K]?: MosaicToggle<P> }, P>(
 	items: T,
 	params: P,
-	key: K
+	key: K,
+	defaultToggle?: boolean
 ): boolean
 function useWrappedToggle<K extends keyof T, T extends { [key in K]?: MosaicToggle<P> }, P>(
 	items: T | T[],
 	params: P,
-	key: K
+	key: K,
+	defaultToggle = true
 ): (Omit<T, K> & { [key in K]?: MosaicToggle })[] | boolean {
 	const result = useMemo(() => {
 		const isArray = Array.isArray(items);
@@ -26,7 +29,7 @@ function useWrappedToggle<K extends keyof T, T extends { [key in K]?: MosaicTogg
 		const wrappedItems = itemsAsArray.map((item) => {
 			return {
 				...item,
-				[key]: wrapToggle(item[key], params),
+				[key]: wrapToggle(item[key], params, defaultToggle),
 			};
 		});
 

--- a/src/utils/toggle/wrapToggle.ts
+++ b/src/utils/toggle/wrapToggle.ts
@@ -1,10 +1,10 @@
 import { MosaicToggle } from "@root/types";
 
-function wrapToggle<T>(show: MosaicToggle<T> = true, params: T): MosaicToggle {
-	const arr = Array.isArray(show) ? show : [show];
+function wrapToggle<T>(toggle: MosaicToggle<T>, params: T, defaultToggle = true): MosaicToggle {
+	const toggleDefined = toggle !== undefined ? toggle : defaultToggle;
+	const arr = Array.isArray(toggleDefined) ? toggleDefined : [toggleDefined];
 
 	return arr.map((item) => {
-
 		if (item instanceof Function) {
 			return item(params);
 		} else {


### PR DESCRIPTION
Brings the toggle (previously show) mechanic to form fields. The `disabled` property provided to the field definition still defaults to `false`, but can now also accept:
- `boolean`
- `(state: FormState) => boolean`
- An array of any combination of the former two