### PR TITLE
MOS-1234 Ref and attrs props for DataView

### DIFF
--- a/src/components/DataView/DataView.stories.tsx
+++ b/src/components/DataView/DataView.stories.tsx
@@ -765,7 +765,8 @@ export const Playground = (): ReactElement => {
 					loading={state.loading}
 					savedView={state.savedView}
 					activeColumns={state.activeColumns}
-				></DataView>
+					attrs={{"data-testid": "My DataView"}}
+				/>
 			</MosaicContext.Provider>
 		</StyledDiv>
 	);

--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useEffect, useMemo, useRef, ReactElement } from "react";
+import { forwardRef, useEffect, useMemo, useRef, ReactElement } from "react";
 import styled from "styled-components";
 
 import DataViewTitleBar from "./DataViewTitleBar";
@@ -55,7 +55,7 @@ const StyledWrapper = styled.div`
 	}
 `;
 
-function DataView (props: DataViewProps): ReactElement  {
+const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (props, ref): ReactElement  {
 	/**
 	 * Checks if a provided active filter is a
 	 * valid filter based on the name.
@@ -243,9 +243,11 @@ function DataView (props: DataViewProps): ReactElement  {
 	return (
 		<StyledWrapper
 			className={`
-			${props.loading ? "loading" : ""}
-			${props.sticky ? "sticky" : ""}
-		`}
+				${props.loading ? "loading" : ""}
+				${props.sticky ? "sticky" : ""}
+			`}
+			ref={ref}
+			{...(props.attrs || {})}
 		>
 			{
 				shouldRenderTitleBar &&
@@ -343,6 +345,6 @@ function DataView (props: DataViewProps): ReactElement  {
 			)}
 		</StyledWrapper>
 	);
-}
+});
 
 export default DataView;

--- a/src/components/DataView/DataViewTypes.ts
+++ b/src/components/DataView/DataViewTypes.ts
@@ -191,6 +191,7 @@ export interface DataViewFilterGetOptionsReturn {
 }
 
 export interface DataViewProps {
+	attrs?: React.HTMLAttributes<HTMLDivElement> & Record<string, unknown>;
 	title?: string
 	loading?: boolean
 	count?: number


### PR DESCRIPTION
Adds support to `DataView` component to allow `ref` and `attr` props to be provided by the consumer. A reference to the top level `div` will be forwarded and the attributes provided will be spread onto the top level `div`.