### PR TITLE
MOS-1226 Tooltip component

### DIFF
--- a/automation_testing/pages/FormFields/FormFieldImageVideoLinkDocumentBrowsing/FormFieldImageVideoLinkDocumentBrowsingPage.ts
+++ b/automation_testing/pages/FormFields/FormFieldImageVideoLinkDocumentBrowsing/FormFieldImageVideoLinkDocumentBrowsingPage.ts
@@ -11,6 +11,7 @@ export class FormFieldImageVideoLinkDocumentBrowsingPage extends BasePage {
 	readonly browseDocumentLocator: string;
 	readonly browseLinkLocator: string;
 
+	readonly formHeading: Locator;
 	readonly browseAllOptionsCardLocator: Locator;
 	readonly browseAllImageWithSrcButton: Locator;
 	readonly browseAllVideoWithSrcButton: Locator;
@@ -41,6 +42,7 @@ export class FormFieldImageVideoLinkDocumentBrowsingPage extends BasePage {
 		this.browseDocumentLocator = "[data-testid='browse-document-test']";
 		this.browseLinkLocator = "[data-testid='browse-link-test']";
 
+		this.formHeading = page.getByRole("heading");
 		this.browseAllOptionsCardLocator = page.locator("#browseAllOptions");
 		this.browseAllImageWithSrcButton = this.browseAllOptionsCardLocator.locator(this.browseImageLocator);
 		this.browseAllVideoWithSrcButton = this.browseAllOptionsCardLocator.locator(this.browseVideoLocator);
@@ -60,7 +62,7 @@ export class FormFieldImageVideoLinkDocumentBrowsingPage extends BasePage {
 		this.browsingWithoutAnyOptionsCard = page.locator("#withoutAnyBrowsingOption div div div").last();
 		this.disabledCard = page.locator("#disabledExample");
 		this.disabledButton = this.disabledCard.locator(this.browseImageLocator);
-		this.moreButton = page.locator("[data-testid='tooltip-test-id']");
+		this.moreButton = page.getByText("More");
 		this.threePointsButton = page.locator(this.iconButtonTestLocator);
 	}
 

--- a/automation_testing/tests/FormFields/FormFieldImageVideoLinkDocumentBrowsing/FormFieldImageVideoLinkDocumentBrowsing.spec.ts
+++ b/automation_testing/tests/FormFields/FormFieldImageVideoLinkDocumentBrowsing/FormFieldImageVideoLinkDocumentBrowsing.spec.ts
@@ -121,11 +121,12 @@ test.describe.parallel("FormFields - FormFieldImageVideoLinkDocumentBrowsing - K
 
 	test("Validate More tooltip options in Card.", async () => {
 		await ffImageVideoLinkDocumentBrowsingPage.browseAllImageWithSrcButton.click();
-		await ffImageVideoLinkDocumentBrowsingPage.moreButton.hover();
+		await ffImageVideoLinkDocumentBrowsingPage.moreButton.click();
 		await expect(ffImageVideoLinkDocumentBrowsingPage.page.locator("[role='tooltip']")).toBeVisible();
 		const titles = await ffImageVideoLinkDocumentBrowsingPage.getInformationTitlesFromTable();
 		expect(titles).toContain("Focus");
 		expect(titles).toContain("Locales");
+		await ffImageVideoLinkDocumentBrowsingPage.formHeading.click();
 	});
 
 	test("Validate removing a selected card.", async () => {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ReactElement, useState } from "react";
-import { boolean, select, withKnobs } from "@storybook/addon-knobs";
+import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
 
 import StoryBookError from "../StoryBookError";
 import Button from "../Button";
@@ -99,6 +99,7 @@ export const Playground = (): ReactElement => {
 		"Undefined",
 	);
 	const label = select("Type of label", ["String", "JSX"], "String")
+	const labelText = text("Label Text", "Text")
 	const showIcon = boolean("Show icon", false);
 	const iconColor = select(
 		"mIconColor",
@@ -156,7 +157,7 @@ export const Playground = (): ReactElement => {
 				{showButton &&
 					<Button
 						attrs={{$smallText: smallText}}
-						label={label === "String" ? "Test" : <FormatListBulletedOutlinedIcon/>}
+						label={label === "String" ? labelText : <FormatListBulletedOutlinedIcon/>}
 						variant={buttonVariant}
 						color={buttonColor}
 						fullWidth={fullWidth}

--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -204,17 +204,3 @@ export const PopoverWrapper = styled.div`
 	font-family: ${theme.fontFamily};
 	padding: 10px;
 `;
-
-export const TooltipContent = styled.div`
-	z-index: 1500;
-	background: ${theme.newColors.almostBlack["100"]};
-	color: white;
-	padding: 4px 8px;
-	margin-top: 4px;
-	border-radius: 4px;
-	color: white;
-	font-family: ${theme.fontFamily};
-	font-size: 12px;
-	margin: 12px 0px;
-	max-width: 200px;
-`;

--- a/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
+++ b/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
@@ -6,9 +6,9 @@ import DataViewActionsButtonRow from "../DataViewActionsButtonRow/DataViewAction
 import { transformRows } from "../../../utils/dataViewTools";
 
 import DataViewBulkAllBar from "../DataViewBulkAllBar";
-import Tooltip from "../../Tooltip";
 import { DataViewDisplayGridProps } from "./DataViewDisplayGridTypes";
 import { StyledDiv } from "./DataViewDisplayGrid.styled";
+import Typography from "@root/components/Typography";
 
 
 function DataViewDisplayGrid(props: DataViewDisplayGridProps) {
@@ -74,16 +74,12 @@ function DataViewDisplayGrid(props: DataViewDisplayGridProps) {
 								}
 								<div className="info">
 									<div className="left">
-										{
-											primary &&
-											<Tooltip text={primary}>
-												<h2>{primary}</h2>
-											</Tooltip>
-										}
-										{
-											secondary &&
-											<h3>{secondary}</h3>
-										}
+										{primary && (
+											<Typography tag="h2">{primary}</Typography>
+										)}
+										{secondary && (
+											<Typography tag="h3">{secondary}</Typography>
+										)}
 									</div>
 									<div className="right">
 										<DataViewActionsButtonRow

--- a/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
+++ b/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
@@ -76,7 +76,7 @@ function DataViewDisplayGrid(props: DataViewDisplayGridProps) {
 									<div className="left">
 										{
 											primary &&
-											<Tooltip type="advanced" text={primary}>
+											<Tooltip text={primary}>
 												<h2>{primary}</h2>
 											</Tooltip>
 										}

--- a/src/components/DataViewPrimaryFilter/DataViewPrimaryFilter.tsx
+++ b/src/components/DataViewPrimaryFilter/DataViewPrimaryFilter.tsx
@@ -1,31 +1,34 @@
 import React from "react";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import Button from "@root/components/Button";
-import Tooltip from "../Tooltip";
+import Tooltip, { useTooltip } from "../Tooltip";
 import { Count, LabelWrapper, MultiselectCounter, Value } from "./DataViewPrimaryFilter.styled";
 import { DataViewPrimaryFilterProps } from "./DataViewPrimaryFilterTypes";
 
 function DataViewPrimaryFilter(props: DataViewPrimaryFilterProps) {
+	const { anchorProps, tooltipProps } = useTooltip();
+
 	const label = (
 		<LabelWrapper>
 			<div className="filter-label">{props.label}</div>
-			{props.value &&
-				<div className="filter-value" color={ props.color ? props.color : "black"}>
+			{props.value && (
+				<div className="filter-value" color={props.color ? props.color : "black"}>
 					<b>|</b>
 					<Value>{props.value}</Value>
-					{
-						props.multiselect?.length > 1 && (
-							<Tooltip text={props.multiselect.slice(1).map(val => val.label).join(", ")}>
-								<MultiselectCounter>
-									<Count>+{props.multiselect.length - 1}</Count>
-								</MultiselectCounter>
+					{props.multiselect?.length > 1 && (
+						<>
+							<MultiselectCounter {...anchorProps}>
+								<Count>+{props.multiselect.length - 1}</Count>
+							</MultiselectCounter>
+							<Tooltip {...tooltipProps}>
+								{props.multiselect.slice(1).map(val => val.label).join(", ")}
 							</Tooltip>
-						)
-					}
+						</>
+					)}
 				</div>
-			}
+			)}
 		</LabelWrapper>
-	)
+	);
 
 	return (
 		<Button

--- a/src/components/DataViewPrimaryFilter/DataViewPrimaryFilter.tsx
+++ b/src/components/DataViewPrimaryFilter/DataViewPrimaryFilter.tsx
@@ -15,7 +15,7 @@ function DataViewPrimaryFilter(props: DataViewPrimaryFilterProps) {
 					<Value>{props.value}</Value>
 					{
 						props.multiselect?.length > 1 && (
-							<Tooltip text={props.multiselect.slice(1).map(val => val.label).join(", ")} type='advanced'>
+							<Tooltip text={props.multiselect.slice(1).map(val => val.label).join(", ")}>
 								<MultiselectCounter>
 									<Count>+{props.multiselect.length - 1}</Count>
 								</MultiselectCounter>

--- a/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/FormFieldImageVideoLinkDocumentBrowsing.tsx
+++ b/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/FormFieldImageVideoLinkDocumentBrowsing.tsx
@@ -25,7 +25,6 @@ import {
 	MoreText,
 	StyledAnchor,
 	AssetImage,
-	StyledTooltip,
 	TableRow,
 	Td,
 	Th
@@ -34,6 +33,7 @@ import {
 // Components
 import MenuFormFieldCard from "@root/forms/MenuFormFieldCard";
 import BrowseOption from "./BrowseOption";
+import Popover from "@root/components/Popover";
 
 const DOCUMENT = "document";
 const IMAGE = "image";
@@ -51,6 +51,9 @@ const FormFieldImageVideoLinkDocumentBrowsing = (
 
 	// State variables
 	const [assetType, setAssetType] = useState("");
+
+	const [moreTextRef, setMoreTextRef] = useState(null);
+	const [moreOpen, setMoreOpen] = useState(false);
 
 	/**
 	 * The Browse button should execute the function
@@ -138,23 +141,25 @@ const FormFieldImageVideoLinkDocumentBrowsing = (
 						{idx === 3 && value.length > 4 && (
 							<>
 								<AssetValue>...</AssetValue>
-								<StyledTooltip
-									placement="top"
-									text={
-										<table>
-											<tbody>{tootltipContent}</tbody>
-										</table>
-									}
-									type="advanced"
+								<Popover
+									anchorEl={moreTextRef}
+									topContent={<table><tbody>{tootltipContent}</tbody></table>}
+									onClose={() => setMoreOpen(false)}
+									open={moreOpen}
+								/>
+								<MoreText
+									ref={setMoreTextRef}
+									onClick={() => setMoreOpen(true)}
+									type="button"
 								>
-									<MoreText>More</MoreText>
-								</StyledTooltip>
+									More
+								</MoreText>
 							</>
 						)}
 					</Td>
 				</TableRow>
 			)),
-		[value]
+		[value, moreTextRef, moreOpen]
 	);
 
 	const hasOptions =

--- a/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsing.styled.tsx
+++ b/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsing.styled.tsx
@@ -160,11 +160,15 @@ export const MenuColumn = styled(Column)`
   margin-left: auto;
 `;
 
-export const MoreText = styled.span`
+export const MoreText = styled.button`
   color: ${theme.newColors.realTeal["100"]};
+  cursor: pointer;
   font-size: 14px;
   font-weight: ${theme.fontWeight.bold};
   margin-left: 12px;
+  font-family: inherit;
+  background: none;
+  border: 0;
 `;
 
 export const StyledTooltip = styled(Tooltip)`

--- a/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsing.test.tsx
+++ b/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsing.test.tsx
@@ -210,9 +210,9 @@ describe("ImageVideoLinkDocumentBrowsing when an image is loaded", () => {
 			browseTestId.dispatchEvent(new MouseEvent("click", {bubbles: true}));
 		});
 
-		const tooltipTestId = await findByTestId("tooltip-test-id");
+		const moreButton = await findByText("More");
 		await act(async () => {
-			fireEvent.mouseOver(tooltipTestId);
+			fireEvent.click(moreButton);
 		});
 
 		expect(await findByText("Focus")).toBeInTheDocument();

--- a/src/components/Field/FormFieldUpload/FileCard/FileCard.tsx
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCard.tsx
@@ -9,10 +9,10 @@ import Spinner from "@root/components/Spinner";
 import { StyledFileCard } from "./FileCard.styled";
 import HelperText from "@root/components/Field/HelperText";
 import InsertDriveFile from "@mui/icons-material/InsertDriveFile";
-import Tooltip from "@root/components/Tooltip";
 import ButtonRow from "@root/components/ButtonRow/ButtonRow";
 import Downloader from "@root/components/Downloader/Downloader";
 import { pretty } from "@root/utils/formatters";
+import Typography from "@root/components/Typography";
 
 const FileCard = (props: FileCardProps) => {
 	const {
@@ -76,13 +76,19 @@ const FileCard = (props: FileCardProps) => {
 					)}
 				</div>
 				<div className='file-data' data-testid="file-data">
-					<Tooltip type="advanced" text={name ?? "File title"}>
-						{fileUrl ? (
-							<a href={fileUrl} rel="noreferrer" target="_blank" className='file-name' data-testid="file-name">{name ?? "File title"}</a>
-						) : (
-							<p className='file-name' data-testid="file-name">{name ?? "File title"}</p>
-						)}
-					</Tooltip>
+					{fileUrl ? (
+						<a href={fileUrl} rel="noreferrer" target="_blank" className='file-name' data-testid="file-name">
+							<Typography maxLines={1} breakAll>
+								{name ?? "File title"}
+							</Typography>
+						</a>
+					) : (
+						<p className='file-name' data-testid="file-name">
+							<Typography maxLines={1} breakAll>
+								{name ?? "File title"}
+							</Typography>
+						</p>
+					)}
 					<p className='file-size' data-testid="file-size">{sizeHuman ?? "File size"}</p>
 				</div>
 				<ButtonRow separator>

--- a/src/components/Field/Label.tsx
+++ b/src/components/Field/Label.tsx
@@ -98,7 +98,7 @@ const Label = (props: LabelProps): ReactElement => {
 			</StyledInputLabel>
 			{instructionText && (
 				<StyledTooltipWrapper $colsInRow={colsInRow}>
-					<Tooltip text={instructionText} type='advanced'>
+					<Tooltip text={instructionText}>
 						<StyledInfoOutlinedIcon />
 					</Tooltip>
 				</StyledTooltipWrapper>

--- a/src/components/Field/Label.tsx
+++ b/src/components/Field/Label.tsx
@@ -7,9 +7,9 @@ import { InputLabel } from "@mui/material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
 import theme from "@root/theme";
-import Tooltip from "../Tooltip";
 import { TransientProps } from "@root/types";
 import { containerQuery } from "@root/utils/css";
+import Tooltip, { useTooltip } from "../Tooltip";
 
 const LabelWrapper = styled.div<TransientProps<LabelProps, "required">>`
 	display: flex;
@@ -90,6 +90,8 @@ const Label = (props: LabelProps): ReactElement => {
 		colsInRow
 	} = props;
 
+	const { anchorProps, tooltipProps } = useTooltip();
+
 	return (
 		<LabelWrapper className={className}>
 			<StyledInputLabel htmlFor={htmlFor}>
@@ -98,8 +100,9 @@ const Label = (props: LabelProps): ReactElement => {
 			</StyledInputLabel>
 			{instructionText && (
 				<StyledTooltipWrapper $colsInRow={colsInRow}>
-					<Tooltip text={instructionText}>
-						<StyledInfoOutlinedIcon />
+					<StyledInfoOutlinedIcon {...anchorProps}/>
+					<Tooltip {...tooltipProps}>
+						{instructionText}
 					</Tooltip>
 				</StyledTooltipWrapper>
 			)}

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -46,7 +46,6 @@ const Form = (props: FormProps) => {
 		description,
 		getFormValues,
 		handleDialogClose,
-		tooltipInfo,
 		showActive,
 		scrollSpyThreshold = 0.15,
 		fullHeight = true,
@@ -211,7 +210,6 @@ const Form = (props: FormProps) => {
 							backLabel={backLabel}
 							description={description}
 							buttons={buttons}
-							tooltipInfo={tooltipInfo}
 							showActive={showActive}
 							bottomBorder={sideNavItems.length < 2}
 							collapse={topCollapseContainer}

--- a/src/components/Form/FormTypes.tsx
+++ b/src/components/Form/FormTypes.tsx
@@ -34,7 +34,6 @@ export interface FormProps {
 	getFormValues?(): Promise<MosaicObject>;
 	handleDialogClose?: (val: boolean) => void;
 	buttons?: ButtonProps[];
-	tooltipInfo?: string;
 	showActive?: boolean;
 	scrollSpyThreshold?: number;
 	fullHeight?: boolean

--- a/src/components/Form/Top/Top.tsx
+++ b/src/components/Form/Top/Top.tsx
@@ -8,7 +8,6 @@ import {
 } from "react";
 
 // Components
-import Tooltip from "@root/components/Tooltip";
 import Checkbox from "@root/components/Checkbox";
 
 // Types and Utils
@@ -23,8 +22,6 @@ import {
 	SmallBack,
 	SmallBackIcon,
 	ActiveCheckboxWrapper,
-	HelpIcon,
-	HelpIconWrapper,
 	TopWrapper,
 	SmallDescription,
 	LargeDescription
@@ -42,14 +39,12 @@ const Top = (props: TopProps): ReactElement => {
 		title,
 		onBack,
 		backLabel,
-		tooltipInfo,
 		bottomBorder,
 		collapse
 	} = props;
 
 	// State variables
 	const [activeChecked, setActiveChecked] = useState(false);
-	const [tooltipIsOpen, setTooltipIsOpen] = useState(false);
 
 	const handleActiveClick = useCallback(() => {
 		setActiveChecked((prev) => !prev);
@@ -68,22 +63,6 @@ const Top = (props: TopProps): ReactElement => {
 		[activeChecked, handleActiveClick]
 	);
 
-	const helpIcon = useMemo(
-		() => (
-			<HelpIconWrapper>
-				<Tooltip
-					open={tooltipIsOpen}
-					onOpen={() => setTooltipIsOpen(true)}
-					onClose={() => setTooltipIsOpen(false)}
-					text={tooltipInfo}
-				>
-					<HelpIcon />
-				</Tooltip>
-			</HelpIconWrapper>
-		),
-		[showActive, tooltipInfo, setTooltipIsOpen, tooltipIsOpen]
-	);
-
 	return (
 		<TopRoot $bottomBorder={bottomBorder}>
 			<TopWrapper>
@@ -100,9 +79,8 @@ const Top = (props: TopProps): ReactElement => {
 					</Title>
 				</Heading>
 				{description && <SmallDescription>{description}</SmallDescription>}
-				{((tooltipInfo && helpIcon) || showActive) && (
+				{showActive && (
 					<SecondaryActions>
-						{tooltipInfo && helpIcon}
 						{showActive && checkbox}
 					</SecondaryActions>
 				)}

--- a/src/components/Form/Top/TopStyled.tsx
+++ b/src/components/Form/Top/TopStyled.tsx
@@ -1,9 +1,6 @@
 import styled from "styled-components";
 import ClearIcon from "@mui/icons-material/Clear";
 
-// Components
-import MUIHelpIcon from "@mui/icons-material/Help";
-
 // Utils
 import theme from "@root/theme/theme";
 import { Description } from "@root/components/Title/TitleWrapper.styled";
@@ -153,19 +150,3 @@ export const ActiveCheckboxWrapper = styled.div`
 		}
 	}
 `
-
-export const HelpIconWrapper = styled.div`
-	order: 1;
-	margin: 2px 0 2px auto;
-
-	${containerQuery("md", "FORM")} {
-		order: 0;
-		margin-left: 16px;
-	}
-`;
-
-export const HelpIcon = styled(MUIHelpIcon)`
-	.MuiSvgIcon-root{
-		display: block;
-	}
-`;

--- a/src/components/Form/Top/TopTypes.ts
+++ b/src/components/Form/Top/TopTypes.ts
@@ -21,11 +21,6 @@ export type TopProps = {
 	onBack?: FormProps["onBack"];
 	backLabel?: FormProps["backLabel"]
 	/**
-	 * If present, the help icon is display with the
-	 * string defined with this prop.
-	 */
-	tooltipInfo?: string;
-	/**
 	 * If present, the active checkbox is displayed.
 	 */
 	showActive?: boolean;

--- a/src/components/Form/stories/DrawerForm.stories.tsx
+++ b/src/components/Form/stories/DrawerForm.stories.tsx
@@ -325,7 +325,6 @@ export const DrawerForm = (): ReactElement => {
 	const showSections = boolean("Show sections", false, "Layout");
 	const drawWidth = select("Draw Width", options, options.default, "Layout");
 	const description = text("Description", "", "Misc");
-	const tooltipInfo = text("Tooltip info", "", "Misc");
 	const showActive = boolean("Show active", false, "Misc");
 
 	const [open, setOpen] = useState(false);
@@ -367,7 +366,6 @@ export const DrawerForm = (): ReactElement => {
 						fields={fields}
 						onBack={onCancel}
 						sections={showSections ? sections : undefined}
-						tooltipInfo={tooltipInfo || undefined}
 						showActive={showActive}
 						description={description || undefined}
 						getFormValues={getFormValues}

--- a/src/components/Form/stories/Playground.stories.tsx
+++ b/src/components/Form/stories/Playground.stories.tsx
@@ -63,8 +63,6 @@ export const Playground = (): ReactElement => {
 	const required = boolean("Required", true);
 	const disabled = boolean("Disabled", false);
 	const showSections = select("Show sections", [0, 1, 2, 3], 0);
-	const tooltipInfo = text("Tooltip info", "Tooltip info");
-	const showTooltipInfo = boolean("Show Tooltip info", false);
 	const showActive = boolean("Show active", false);
 	const collapsed = boolean("Collapse sections", false);
 	const containerHeight = text("Container Height (500px, 50rem, etc..)", "100vh");
@@ -637,7 +635,6 @@ export const Playground = (): ReactElement => {
 				getFormValues={showGetFormValues === "None" ? undefined : (loadReady && getFormValues)}
 				sections={showSections > 0 ? sectionsAmount : undefined}
 				buttons={renderButtons(dispatch, { showCancel, showSave })}
-				tooltipInfo={showTooltipInfo && tooltipInfo}
 				showActive={showActive}
 			/>
 		</div>

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -2,25 +2,25 @@ import * as React from "react";
 import { ReactElement } from "react";
 import { withKnobs, text } from "@storybook/addon-knobs";
 import { Meta } from "@storybook/addon-docs/blocks";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
 // Components
 import Tooltip from "./Tooltip";
+import useTooltip from "./useTooltip";
 
 export default {
 	title: "Components/Tooltip",
 	decorators: [withKnobs],
 } as Meta;
 
-export const AdvancedTooltip = (): ReactElement => (
-	<Tooltip type='advanced' text={text("Tooltip text","Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec iaculis quam adipiscing elit. Quisque Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec iaculis quam adipiscing elit. Quisque")}>
-		<InfoOutlinedIcon style={{margin: "140px 30px"}} />
-	</Tooltip>
-);
+export const Example = (): ReactElement => {
+	const { anchorProps, tooltipProps } = useTooltip();
+	const tooltip = text("Tooltip text","Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec iaculis quam adipiscing elit. Quisque Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec iaculis quam adipiscing elit. Quisque");
 
-export const IconTooltip = (): ReactElement => (
-	<Tooltip text={text("Tooltip text", "More")}>
-		<MoreVertIcon style={{marginLeft: "10px"}} />
-	</Tooltip>
-);
+	return (
+		<>
+			<InfoOutlinedIcon style={{margin: "140px 30px"}} {...anchorProps} />
+			<Tooltip {...tooltipProps}>{tooltip}</Tooltip>
+		</>
+	)
+};

--- a/src/components/Tooltip/Tooltip.styled.tsx
+++ b/src/components/Tooltip/Tooltip.styled.tsx
@@ -1,56 +1,86 @@
-import * as React from "react";
 import styled from "styled-components";
-
-// Material UI
-import { Tooltip } from "@mui/material";
-
 import theme from "@root/theme";
+import { Popper } from "@mui/material";
 
-export const StyledDefaultTooltip = styled(props => (
-	<Tooltip
-		classes={{ popper: props.className, tooltip: "tooltip", arrow: "arrow" }}
-		{...props}
-	/>
-))`
-	& .tooltip {
-		background-color: ${theme.newColors.almostBlack["100"]};
-		color: white;
-		padding: 4px 8px;
-		margin-top: 4px;
-		font-size: 12px;
-		font-family: ${theme.fontFamily};
+export const TooltipPopper = styled(Popper)`
+	z-index: 1500;
+	background: ${theme.newColors.almostBlack["100"]};
+	color: white;
+	padding: 4px 8px;
+	border-radius: 4px;
+	color: white;
+	font-family: ${theme.fontFamily};
+	font-size: 12px;
+	max-width: 12rem;
+
+	&[data-popper-placement="bottom-start"] .arrow,
+	&[data-popper-placement="bottom"] .arrow,
+	&[data-popper-placement="bottom-end"] .arrow {
+		border-bottom-color: ${theme.newColors.almostBlack["100"]};
+		border-top: 0;
+		top: -5px;
 	}
 
-	& .arrow {
-		color: ${theme.newColors.almostBlack["100"]};
+	&[data-popper-placement="top-start"] .arrow,
+	&[data-popper-placement="top"] .arrow,
+	&[data-popper-placement="top-end"] .arrow {
+		border-top-color: ${theme.newColors.almostBlack["100"]};
+		border-bottom: 0;
+		bottom: -5px;
+	}
+
+	&[data-popper-placement="bottom-start"] .arrow,
+	&[data-popper-placement="top-start"] .arrow{
+		left: 5px;
+	}
+
+	&[data-popper-placement="bottom"] .arrow,
+	&[data-popper-placement="top"] .arrow{
+		left: 50%;
+		transform: translateX(-50%);
+	}
+
+	&[data-popper-placement="bottom-end"] .arrow,
+	&[data-popper-placement="top-end"] .arrow{
+		right: 5px;
+	}
+
+	&[data-popper-placement="left-start"] .arrow,
+	&[data-popper-placement="left"] .arrow,
+	&[data-popper-placement="left-end"] .arrow {
+		border-left-color: ${theme.newColors.almostBlack["100"]};
+		border-right: 0;
+		right: -5px;
+	}
+
+	&[data-popper-placement="right-start"] .arrow,
+	&[data-popper-placement="right"] .arrow,
+	&[data-popper-placement="right-end"] .arrow {
+		border-right-color: ${theme.newColors.almostBlack["100"]};
+		border-left: 0;
+		left: -5px;
+	}
+
+	&[data-popper-placement="left-start"] .arrow,
+	&[data-popper-placement="right-start"] .arrow{
+		top: 5px;
+	}
+
+	&[data-popper-placement="left"] .arrow,
+	&[data-popper-placement="right"] .arrow{
+		top: 50%;
+		transform: translateY(-50%);
+	}
+
+	&[data-popper-placement="left-end"] .arrow,
+	&[data-popper-placement="right-end"] .arrow{
+		bottom: 5px;
 	}
 `;
 
-// export const StyledAdvancedTooltip = styled(props => (
-// 	<Tooltip
-// 		classes={{ popper: props.className, tooltip: "tooltip", arrow: "arrow" }}
-// 		{...props}
-// 	/>
-// ))`
-// 	& .tooltip {
-// 		background-color: white;
-// 		color: ${theme.newColors.grey3["100"]};
-// 		padding: 12px;
-// 		margin-bottom: 8px;
-// 		font-size: 12px;
-// 		max-width: 280px;
-// 		box-shadow: 0px 2px 6px #00000029;
-// 		border: 1px solid ${theme.newColors.grey2["100"]};
-// 		left: ${pr => pr.placement !== "top" ? "-30px !important" : ""};
-// 		font-family: ${theme.fontFamily};
-// 		font-weight: ${theme.fontWeight.normal};
-// 		line-height: 14px;
-// 		letter-spacing: normal;
-// 		text-align: left;
-// 	}
+//"bottom" | "top" | "left" | "right" | "bottom-end" | "bottom-start" | "left-end" | "left-start" | "right-end" | "right-start" | "top-end" | "top-start"
 
-// 	& .arrow {
-// 		color: white;
-// 		left: ${pr => pr.placement !== "top" ? "32px !important" : ""};
-// 	}
-// `;
+export const TooltipArrow = styled.div`
+	border: 5px solid transparent;
+	position: absolute;
+`

--- a/src/components/Tooltip/Tooltip.styled.tsx
+++ b/src/components/Tooltip/Tooltip.styled.tsx
@@ -8,7 +8,7 @@ import theme from "@root/theme";
 
 export const StyledDefaultTooltip = styled(props => (
 	<Tooltip
-		classes={{ popper: props.className, tooltip: "tooltip" }}
+		classes={{ popper: props.className, tooltip: "tooltip", arrow: "arrow" }}
 		{...props}
 	/>
 ))`
@@ -20,33 +20,37 @@ export const StyledDefaultTooltip = styled(props => (
 		font-size: 12px;
 		font-family: ${theme.fontFamily};
 	}
-`;
-
-export const StyledAdvancedTooltip = styled(props => (
-	<Tooltip
-		classes={{ popper: props.className, tooltip: "tooltip", arrow: "arrow" }}
-		{...props}
-	/>
-))`
-	& .tooltip {
-		background-color: white;
-		color: ${theme.newColors.grey3["100"]};
-		padding: 12px;
-		margin-bottom: 8px;
-		font-size: 12px;
-		max-width: 280px;
-		box-shadow: 0px 2px 6px #00000029;
-		border: 1px solid ${theme.newColors.grey2["100"]};
-		left: ${pr => pr.placement !== "top" ? "-30px !important" : ""};
-		font-family: ${theme.fontFamily};
-		font-weight: ${theme.fontWeight.normal};
-		line-height: 14px;
-		letter-spacing: normal;
-		text-align: left;
-	}
 
 	& .arrow {
-		color: white;
-		left: ${pr => pr.placement !== "top" ? "32px !important" : ""};
+		color: ${theme.newColors.almostBlack["100"]};
 	}
 `;
+
+// export const StyledAdvancedTooltip = styled(props => (
+// 	<Tooltip
+// 		classes={{ popper: props.className, tooltip: "tooltip", arrow: "arrow" }}
+// 		{...props}
+// 	/>
+// ))`
+// 	& .tooltip {
+// 		background-color: white;
+// 		color: ${theme.newColors.grey3["100"]};
+// 		padding: 12px;
+// 		margin-bottom: 8px;
+// 		font-size: 12px;
+// 		max-width: 280px;
+// 		box-shadow: 0px 2px 6px #00000029;
+// 		border: 1px solid ${theme.newColors.grey2["100"]};
+// 		left: ${pr => pr.placement !== "top" ? "-30px !important" : ""};
+// 		font-family: ${theme.fontFamily};
+// 		font-weight: ${theme.fontWeight.normal};
+// 		line-height: 14px;
+// 		letter-spacing: normal;
+// 		text-align: left;
+// 	}
+
+// 	& .arrow {
+// 		color: white;
+// 		left: ${pr => pr.placement !== "top" ? "32px !important" : ""};
+// 	}
+// `;

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -3,6 +3,18 @@ import { render, cleanup, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import Tooltip from "./Tooltip";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
+import useTooltip from "./useTooltip";
+
+function TooltipTest({ text }: { text: string }) {
+	const { anchorProps, tooltipProps } = useTooltip();
+
+	return (
+		<>
+			<MoreVertIcon {...anchorProps} />
+			<Tooltip {...tooltipProps}>{text}</Tooltip>
+		</>
+	)
+}
 
 beforeEach(() => {
 	document.createRange = () => ({
@@ -24,29 +36,13 @@ afterEach(cleanup);
 describe("Tooltip component", () => {
 	it("should render a regular tooltip", async () => {
 		const tooltip = render(
-			<Tooltip text='Default tooltip test' type='default'>
-				<MoreVertIcon />
-			</Tooltip>
+			<TooltipTest text='Default tooltip test' />
 		);
 
-		fireEvent.mouseOver(tooltip.getByTestId("tooltip-test-id"));
+		fireEvent.mouseOver(tooltip.getByTestId("MoreVertIcon"));
 
 		expect(
 			await tooltip.findByText("Default tooltip test")
-		).toBeInTheDocument();
-	});
-	
-	it("should render an advanced tooltip", async () => {
-		const tooltip = render(
-			<Tooltip text='Advanced tooltip test' type='advanced'>
-				<MoreVertIcon />
-			</Tooltip>
-		);
-
-		fireEvent.mouseOver(tooltip.getByTestId("tooltip-test-id"));
-
-		expect(
-			await tooltip.findByText("Advanced tooltip test")
 		).toBeInTheDocument();
 	});
 });

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,32 +1,40 @@
 import * as React from "react";
 import { ReactElement } from "react";
 import { TooltipProps } from ".";
-import { StyledDefaultTooltip } from "./Tooltip.styled";
+import { TooltipArrow, TooltipPopper } from "./Tooltip.styled";
+
+const tooltipOffset = [
+	{
+		name: "offset",
+		options: {
+			offset: [0, 10],
+		},
+	},
+];
 
 const Tooltip = (props: TooltipProps): ReactElement => {
 	const {
-		className = "",
-		text = "",
 		children,
 		open,
-		onClose,
-		onOpen,
-		placement = "top-start"
+		placement = "bottom-start",
+		anchorEl,
+		id
 	} = props;
 
 	return (
-		<StyledDefaultTooltip
-			className={className}
+		<TooltipPopper
 			open={open}
-			onClose={onClose}
-			onOpen={onOpen}
-			title={text}
-			arrow
+			anchorEl={anchorEl}
+			style={{ zIndex: 1500, pointerEvents: "none" }}
 			placement={placement}
-			data-testid='tooltip-test-id'
+			modifiers={tooltipOffset}
+			role="tooltip"
+			id={id}
+			data-testid="tooltip-test-id"
 		>
+			<TooltipArrow className="arrow" />
 			{children}
-		</StyledDefaultTooltip>
+		</TooltipPopper>
 	);
 }
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ReactElement } from "react";
 import { TooltipProps } from ".";
-import { StyledAdvancedTooltip, StyledDefaultTooltip } from "./Tooltip.styled";
+import { StyledDefaultTooltip } from "./Tooltip.styled";
 
 const Tooltip = (props: TooltipProps): ReactElement => {
 	const {
@@ -11,23 +11,11 @@ const Tooltip = (props: TooltipProps): ReactElement => {
 		open,
 		onClose,
 		onOpen,
-		type,
 		placement = "top-start"
 	} = props;
 
-	return type !== "advanced" ? (
+	return (
 		<StyledDefaultTooltip
-			className={className}
-			open={open}
-			onClose={onClose}
-			onOpen={onOpen}
-			title={text}
-			data-testid='tooltip-test-id'
-		>
-			{children}
-		</StyledDefaultTooltip>
-	) : (
-		<StyledAdvancedTooltip
 			className={className}
 			open={open}
 			onClose={onClose}
@@ -38,7 +26,7 @@ const Tooltip = (props: TooltipProps): ReactElement => {
 			data-testid='tooltip-test-id'
 		>
 			{children}
-		</StyledAdvancedTooltip>
+		</StyledDefaultTooltip>
 	);
 }
 

--- a/src/components/Tooltip/TooltipTypes.tsx
+++ b/src/components/Tooltip/TooltipTypes.tsx
@@ -19,14 +19,6 @@ export interface TooltipProps {
    */
   children: ReactNode;
   /**
-   * Current available types for the tooltip.
-   * Default: Small black tooltip (mostly used
-   * with icon buttons).
-   * Advanced: Large white tooltip (mostly used
-   * with fields).
-   */
-  type?: "default" | "advanced";
-  /**
    * Tooltip placement.
    */
   placement?: MUITooltipProps["placement"];

--- a/src/components/Tooltip/TooltipTypes.tsx
+++ b/src/components/Tooltip/TooltipTypes.tsx
@@ -1,17 +1,19 @@
-import { ReactNode } from "react";
+import { Dispatch, ReactNode } from "react";
 import { TooltipProps as MUITooltipProps } from "@mui/material/Tooltip";
+
+export type AnchorElement = HTMLElement | SVGElement;
 
 export interface TooltipProps {
   /**
-   * Additional custom css class to style the
-   * component.
+   * The tooltip anchor. Must be a type of
+   * HTML element
    */
-  className?: string;
+  anchorEl: AnchorElement
   /**
-   * Text to be displayed once the
-   * tooltip gets rendered on the screen.
+   * Whether or not the tooltip is currently
+   * visible on screen
    */
-  text: string | JSX.Element[] | ReactNode;
+  open: boolean
   /**
    * Element to be wrapped by the tooltip.
    * When hovering over this child the tooltip
@@ -23,15 +25,15 @@ export interface TooltipProps {
    */
   placement?: MUITooltipProps["placement"];
   /**
-   * If true, the tooltip is shown.
+   * The tooltip ID, should to referred to by
+   * the anchor's aria-describedby attribute
    */
-  open?: boolean;
-  /**
-   * Callback fired when the component requests to be open.
-   */
-  onOpen?: () => void;
-  /**
-   * Callback fired when the component requests to be closed.
-   */
-  onClose?: () => void;
+  id?: string
+}
+
+export interface AnchorProps {
+	ref: Dispatch<AnchorElement>
+	onMouseEnter: () => void;
+	onMouseLeave: () => void;
+	"aria-describedby": string
 }

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,3 +1,5 @@
 export { default } from "./Tooltip";
 export * from "./Tooltip";
 export * from "./TooltipTypes";
+export * from "./useTooltip";
+export { default as useTooltip } from "./useTooltip";

--- a/src/components/Tooltip/useTooltip.ts
+++ b/src/components/Tooltip/useTooltip.ts
@@ -1,0 +1,36 @@
+import { useId, useMemo, useState } from "react";
+import { AnchorProps, TooltipProps } from "./TooltipTypes";
+
+type HookTooltipProps = Required<Pick<TooltipProps, "anchorEl" | "open" | "id">>;
+
+export interface UseTooltipResult {
+	tooltipProps: HookTooltipProps,
+	anchorProps: AnchorProps
+}
+
+function useTooltip(): UseTooltipResult {
+	const [ref, setRef] = useState(null);
+	const [open, setOpen] = useState(false);
+
+	const id = useId();
+
+	const tooltipProps = useMemo<HookTooltipProps>(() => ({
+		open,
+		anchorEl: ref,
+		id: `tooltip-${id}`
+	}), [open, ref, id])
+
+	const anchorProps = useMemo<AnchorProps>(() => ({
+		ref: setRef,
+		onMouseEnter: () => setOpen(true),
+		onMouseLeave: () => setOpen(false),
+		"aria-describedby": `tooltip-${id}`
+	}), [id]);
+
+	return {
+		tooltipProps,
+		anchorProps
+	};
+}
+
+export default useTooltip;

--- a/src/components/Typography/Typography.styled.ts
+++ b/src/components/Typography/Typography.styled.ts
@@ -58,7 +58,8 @@ export const variants: Record<TypographyVariant, RuleSet> = {
 	body: css`
         font-family: ${theme.fontFamily};
         font-size: 16px;
-	`
+	`,
+	none: css``
 };
 
 export const Component = styled.div<BaseProps & {$variant: TypographyVariant}>`

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -7,7 +7,8 @@ import { Component } from "./Typography.styled";
 const defaultTagMap: Record<TypographyVariant, TypographyTag> = {
 	title: "h1",
 	subtitle: "h3",
-	body: "div"
+	body: "div",
+	none: "span"
 }
 
 export default function Typography({
@@ -15,11 +16,12 @@ export default function Typography({
 	attrs = {},
 	as,
 	tag: providedTag = as,
-	variant,
+	variant = "none",
 	maxLines,
 	color,
 	breakAll,
-	className
+	className,
+	title
 }: TypographyProps): ReactElement {
 	const tag = providedTag || defaultTagMap[variant];
 
@@ -31,7 +33,7 @@ export default function Typography({
 			$maxLines={maxLines}
 			$color={color}
 			$breakAll={breakAll}
-			title={typeof children === "string" ? children : undefined}
+			title={title !== undefined ? title : typeof children === "string" ? children : undefined}
 			as={tag}
 		>
 			{children}

--- a/src/components/Typography/TypographyTypes.ts
+++ b/src/components/Typography/TypographyTypes.ts
@@ -3,7 +3,7 @@ import { MosaicObject } from "../../types"
 import { ColorTypes } from "../Button";
 import { Properties } from "csstype"
 
-export type TypographyVariant = "title" | "subtitle" | "body";
+export type TypographyVariant = "title" | "subtitle" | "body" | "none";
 
 export type TypographyTag = string;
 
@@ -11,7 +11,7 @@ export interface TypographyProps {
 	/**
 	 * Controls the look of the typography
 	 */
-	variant: TypographyVariant,
+	variant?: TypographyVariant,
 	/**
 	 * @deprecated Use "tag" prop instead
 	 */


### PR DESCRIPTION
(BREAKING CHANGE) Rehauls the `Tooltip` component, dropping the dependency on Material's `Tooltip` and instead using the underlying `Popper` component directly. `Tooltip` **no longer wraps its anchor**, but instead takes the following required properties:

- `anchorEl` the `HTMLElement` or `SVGElement` that the tooltip should point to
- `open` a `boolean` denoting whether or not the tooltip is currently rendered and visible
- `children`, replacing the old `text` property, which can be any `ReactNode` to be rendered within the tooltip.

There is an optional `useTooltip` hook that can be utilised to make using the `Tooltip` component a little cleaner. It returns `anchorProps` and `tooltipProps` which can be spread into their corresponding components, causing the tooltip to appear when the anchor is hovered.

Additionally, the following tooltips have been dropped and replaced with a native title using the `Typography` component:
- The title that appears for each uploaded file within the file upload field
- The primary and secondary title for `DataView` items when using a "grid" display