### PR TITLE
MOS-1241 DataView row actions

### DIFF
--- a/src/components/DataView/DataView.stories.tsx
+++ b/src/components/DataView/DataView.stories.tsx
@@ -751,7 +751,7 @@ export const Playground = (): ReactElement => {
 				loading: false
 			});
 		} : undefined,
-		disabled
+		disabled: disabled || undefined
 	};
 
 	return (

--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -250,6 +250,8 @@ const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (pr
 		props.onCheckAllPagesChange !== undefined
 	;
 
+	const actionsHidden = (props.checked || []).some(checked => checked);
+
 	return (
 		<StyledWrapper
 			className={`
@@ -342,6 +344,7 @@ const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (pr
 					showBulkAll={showBulkAll}
 					allChecked={allChecked}
 					anyChecked={anyChecked}
+					actionsHidden={actionsHidden || undefined}
 				/>
 			</div>
 			{!props.loading && !props.data.length && (

--- a/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRow.styled.ts
+++ b/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRow.styled.ts
@@ -1,0 +1,8 @@
+import ButtonRow from "@root/components/ButtonRow";
+import styled from "styled-components";
+
+export const StyledButtonRow = styled(ButtonRow)<{ $hidden?: boolean }>`
+    ${({ $hidden }) => $hidden && `
+        visibility: hidden;
+    `}
+`

--- a/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRow.tsx
+++ b/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRow.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { memo, useMemo } from "react";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import ButtonRow from "../../ButtonRow";
 import Button from "../../Button";
 import { DataViewActionsButtonRowProps } from "./DataViewActionsButtonRowTypes";
 import { useWrappedToggle } from "@root/utils/toggle";
+import { StyledButtonRow } from "./DataViewActionsButtonRow.styled";
 
 function DataViewActionsButtonRow(props: DataViewActionsButtonRowProps) {
 	const showParams = useMemo(() => ({row: props.originalRowData}), [props.originalRowData]);
@@ -28,22 +28,32 @@ function DataViewActionsButtonRow(props: DataViewActionsButtonRowProps) {
 				onClick({ data : props.originalRowData });
 			}
 
+
+			const disabled = [buttonArgs.disabled, props.disabled, props.actionsHidden].some(disabled => disabled);
+
 			return (
 				<Button
 					{ ...buttonArgs }
-					disabled={buttonArgs.disabled === undefined ? props.disabled : buttonArgs.disabled}
+					disabled={disabled}
 					key={`primary_${name}`}
 					attrs={{ "data-mosaic-id" : `action_primary_${name}` }}
 					onClick={newOnClick}
 				/>
 			)
 		});
-	}, [shownPrimaryActions, props.originalRowData, props.disabled]);
+	}, [
+		shownPrimaryActions,
+		props.originalRowData,
+		props.disabled,
+		props.actionsHidden
+	]);
 
 	const additionalActionsButton = useMemo(() => {
 		if (!shownadditionalActions.length) {
 			return [];
 		}
+
+		const disabled = [props.disabled, props.actionsHidden].some(disabled => disabled);
 
 		return [
 			<Button
@@ -53,7 +63,7 @@ function DataViewActionsButtonRow(props: DataViewActionsButtonRowProps) {
 				mIcon={props.activeDisplay && MoreVertIcon}
 				attrs={{ "data-mosaic-id" : "additional_actions_dropdown" }}
 				tooltip="More actions"
-				disabled={props.disabled}
+				disabled={disabled}
 				menuItems={shownadditionalActions.map(action => {
 					const {
 						name,
@@ -74,7 +84,12 @@ function DataViewActionsButtonRow(props: DataViewActionsButtonRowProps) {
 				})}
 			/>
 		]
-	}, [shownadditionalActions, props.originalRowData, props.disabled]);
+	}, [
+		shownadditionalActions,
+		props.originalRowData,
+		props.disabled,
+		props.actionsHidden
+	]);
 
 	// concat the buttons into a single row so that we have a single child allowing caching of the ButtonRow
 	const buttons = useMemo(() => {
@@ -89,9 +104,9 @@ function DataViewActionsButtonRow(props: DataViewActionsButtonRowProps) {
 	}
 
 	return (
-		<ButtonRow>
+		<StyledButtonRow $hidden={props.actionsHidden}>
 			{buttons}
-		</ButtonRow>
+		</StyledButtonRow>
 	)
 }
 

--- a/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRowTypes.ts
+++ b/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRowTypes.ts
@@ -6,6 +6,7 @@ export type DataViewControlViewOption = "list" | "grid";
 export interface DataViewActionsButtonRowProps {
 	primaryActions: DataViewAction[];
 	additionalActions: DataViewAdditionalAction[];
+	actionsHidden?: boolean;
 	disabled?: DataViewProps["disabled"]
 	originalRowData: MosaicObject;
 	activeDisplay?: DataViewControlViewOption;

--- a/src/components/DataView/DataViewActionsRow/DataViewActionsRow.styled.ts
+++ b/src/components/DataView/DataViewActionsRow/DataViewActionsRow.styled.ts
@@ -7,6 +7,8 @@ export const DataViewActionsRowWrapper = styled.div`
 `;
 
 export const LeftControlsContainer = styled.div`
+	display: flex;
+
 	.custom-checkbox {
 		margin-right: 4px;
 	}

--- a/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
+++ b/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
@@ -85,6 +85,7 @@ function DataViewDisplayGrid(props: DataViewDisplayGridProps) {
 										<DataViewActionsButtonRow
 											primaryActions={props.primaryActions}
 											additionalActions={props.additionalActions}
+											actionsHidden={props.actionsHidden}
 											originalRowData={ row }
 											activeDisplay="grid"
 											disabled={props.disabled}

--- a/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGridTypes.ts
+++ b/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGridTypes.ts
@@ -1,7 +1,6 @@
 import { DataViewProps } from "../DataViewTypes";
 
 export interface DataViewDisplayGridProps {
-	additionalActions?: DataViewProps["additionalActions"];
 	bulkActions?: DataViewProps["bulkActions"];
 	checked?: DataViewProps["checked"];
 	checkedAllPages?: DataViewProps["checkedAllPages"];
@@ -14,6 +13,8 @@ export interface DataViewDisplayGridProps {
 	onCheckboxClick?: (i: any) => void;
 	onSortChange?: DataViewProps["onSortChange"];
 	primaryActions?: DataViewProps["primaryActions"];
+	additionalActions?: DataViewProps["additionalActions"];
+	actionsHidden?: boolean;
 	rowCount?: number;
 	sort?: DataViewProps["sort"];
 	anyChecked?: boolean;

--- a/src/components/DataView/DataViewDisplayList/DataViewDisplayList.tsx
+++ b/src/components/DataView/DataViewDisplayList/DataViewDisplayList.tsx
@@ -130,6 +130,7 @@ function DataViewDisplayList(props: DataViewDisplayListProps) {
 						transformedData={transformedData}
 						bulkActions={props.bulkActions}
 						additionalActions={props.additionalActions}
+						actionsHidden={props.actionsHidden}
 						disabled={props.disabled}
 						primaryActions={props.primaryActions}
 						onCheckboxClick={props.onCheckboxClick}

--- a/src/components/DataView/DataViewDisplayList/DataViewDisplayListTypes.ts
+++ b/src/components/DataView/DataViewDisplayList/DataViewDisplayListTypes.ts
@@ -23,4 +23,5 @@ export interface DataViewDisplayListProps {
 	anyChecked?: boolean;
 	allChecked?: boolean;
 	showBulkAll?: boolean;
+	actionsHidden?: boolean;
 }

--- a/src/components/DataView/DataViewTBody/DataViewTBody.tsx
+++ b/src/components/DataView/DataViewTBody/DataViewTBody.tsx
@@ -35,6 +35,7 @@ const DataViewTBody = forwardRef<HTMLTableSectionElement, DataViewTBodyProps>((p
 				originalRowData={props.data[i]}
 				primaryActions={props.primaryActions}
 				additionalActions={props.additionalActions}
+				actionsHidden={props.actionsHidden}
 				disabled={props.disabled}
 				onCheckboxClick={props.onCheckboxClick ? () => props.onCheckboxClick(i) : undefined}
 				checked={props.checked ? props.checked[i] : false}

--- a/src/components/DataView/DataViewTBody/DataViewTBodyTypes.ts
+++ b/src/components/DataView/DataViewTBody/DataViewTBodyTypes.ts
@@ -10,6 +10,7 @@ export interface DataViewTBodyProps {
 	bulkActions?: DataViewProps["bulkActions"];
 	primaryActions?: DataViewProps["primaryActions"];
 	additionalActions?: DataViewProps["additionalActions"];
+	actionsHidden?: boolean;
 	disabled?: DataViewProps["disabled"];
 	checked?: DataViewProps["checked"];
 	columns: DataViewProps["columns"];

--- a/src/components/DataView/DataViewTr/DataViewTr.tsx
+++ b/src/components/DataView/DataViewTr/DataViewTr.tsx
@@ -19,6 +19,7 @@ const DataViewTrStatic = forwardRef<HTMLTableRowElement, DataViewTrProps>(({
 	hasActions,
 	primaryActions,
 	additionalActions,
+	actionsHidden,
 	originalRowData,
 	columns,
 	row,
@@ -59,6 +60,7 @@ const DataViewTrStatic = forwardRef<HTMLTableRowElement, DataViewTrProps>(({
 					<DataViewActionsButtonRow
 						primaryActions={primaryActions}
 						additionalActions={additionalActions}
+						actionsHidden={actionsHidden}
 						disabled={disabled}
 						originalRowData={originalRowData}
 						activeDisplay="list"

--- a/src/components/DataView/DataViewTr/DataViewTrTypes.ts
+++ b/src/components/DataView/DataViewTr/DataViewTrTypes.ts
@@ -10,12 +10,13 @@ export interface DataViewTrProps {
 	onCheckboxClick?: React.MouseEventHandler<HTMLButtonElement>;
 	primaryActions?: DataViewProps["primaryActions"];
 	additionalActions?: DataViewProps["additionalActions"];
+	actionsHidden?: boolean;
 	disabled?: DataViewProps["disabled"]
 	originalRowData: MosaicObject;
 	columns: DataViewProps["columns"];
 	row?: {[x: string]: any};
 	style?: CSSProperties;
-	isDragOverlay?: boolean
+	isDragOverlay?: boolean;
 }
 
 export type DataViewTrDndProps = DataViewTrProps;


### PR DESCRIPTION
With this change, primary and additional row actions will be hidden and disabled (while remaining in the DOM) if any action checkboxes are checked to prevent confusion regarding bulk actions