### PR TITLE
MOS-1253 Import audit

### DIFF
--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import theme from "@root/theme";
-import { Button, IconButton } from "@mui/material";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
 import { TransientProps } from "@root/types";
 import { ButtonProps } from "./ButtonTypes";
 

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -4,7 +4,7 @@ import { boolean, withKnobs, select } from "@storybook/addon-knobs";
 import { Meta } from "@storybook/addon-docs/blocks";
 import styled from "styled-components";
 import theme from "@root/theme";
-import { format } from "date-fns";
+import format from "date-fns/format";
 import { ButtonProps } from "../Button";
 
 // Components

--- a/src/components/CheckboxList/CheckboxList.tsx
+++ b/src/components/CheckboxList/CheckboxList.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useMemo, useCallback, ReactElement, HTMLAttributes } from "react";
-import { xorBy } from "lodash";
+import xorBy from "lodash/xorBy";
 
 import Checkbox from "@root/components/Checkbox";
 import { useStateRef } from "@root/utils/reactTools";

--- a/src/components/Content/Content.stories.tsx
+++ b/src/components/Content/Content.stories.tsx
@@ -17,7 +17,7 @@ import { ChipsWrapper } from "./Content.styled";
 import Chip from "../Chip";
 import EditIcon from "@mui/icons-material/Edit";
 import { ButtonProps } from "@root/components/Button";
-import { Link } from "@mui/material";
+import Link from "@mui/material/Link";
 
 export default {
 	title: "Components/Content",

--- a/src/components/DataView/DataViewFilters/DataViewFilters.tsx
+++ b/src/components/DataView/DataViewFilters/DataViewFilters.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { useState, useMemo } from "react";
 import styled from "styled-components";
-import { pick, xor } from "lodash";
+import pick from "lodash/pick";
+import xor from "lodash/xor";
 
 import FilterListIcon from "@mui/icons-material/FilterList";
 import DataViewFilterDropdown from "../../DataViewFilterDropdown";

--- a/src/components/DataViewFilterDate/DataViewFilterDate.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import { useState, ReactElement } from "react";
 import styled from "styled-components";
-import { format, isSameDay, isSameMonth, isSameYear } from "date-fns";
+import format from "date-fns/format";
+import isSameDay from "date-fns/isSameDay";
+import isSameMonth from "date-fns/isSameMonth";
+import isSameYear from "date-fns/isSameYear";
 
 import DataViewPrimaryFilter from "../DataViewPrimaryFilter";
 import DataViewFilterDateDropdownContent from "./DataViewFilterDateDropdownContent";

--- a/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectDropdownContent.tsx
+++ b/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectDropdownContent.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { debounce, xor } from "lodash";
+import debounce from "lodash/debounce";
+import xor from "lodash/xor";
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import SearchIcon from "@mui/icons-material/Search";
@@ -15,7 +16,7 @@ import { SubtitleText } from "../Typography";
 import { useMosaicTranslation } from "@root/i18n";
 import { PopoverP, StyledHr, StyledVerticalHr, StyledWrapper, StyledComparisonHeader } from "./DataViewFilterMultiselect.styled";
 import { StyledTextField } from "@root/components/Field/FormFieldText/FormFieldText.styled";
-import { InputAdornment } from "@mui/material";
+import InputAdornment from "@mui/material/InputAdornment";
 import { DataViewFilterMultiselectDropdownContentProps } from "./DataViewFilterMultiselectTypes";
 import CheckboxList from "../CheckboxList";
 

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -5,7 +5,8 @@ import { ReactElement } from "react";
 import Button from "@root/components/Button";
 
 // Material UI
-import { DialogActions, DialogContent } from "@mui/material";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
 
 // Types and styles
 import { DialogProps } from ".";

--- a/src/components/Field/FormFieldAddress/Address.test.tsx
+++ b/src/components/Field/FormFieldAddress/Address.test.tsx
@@ -16,7 +16,7 @@ import Form, { useForm } from "@root/components/Form";
 
 // Utils
 import AddressAutocomplete from "./AddressAutocomplete";
-import { InputAdornment } from "@mui/material";
+import InputAdornment from "@mui/material/InputAdornment";
 import { StyledClearIcon } from "./AddressAutocomplete/AddressAutocomplete.styled";
 
 

--- a/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocomplete.tsx
+++ b/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocomplete.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { memo, ReactElement } from "react";
 import PlacesAutocomplete from "react-places-autocomplete";
 import { AddressAutocompleteProps } from "./AddressAutocompleteTypes";
-import { Popover } from "@mui/material"
+import Popover from "@mui/material/Popover"
 
 // Styles
 import {

--- a/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
+++ b/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
@@ -9,7 +9,7 @@ import Form, { formActions, useForm } from "@root/components/Form";
 // Utils
 import { IAddress } from "@root/components/Field/FormFieldAddress";
 import { AddressDrawerProps } from "../AddressTypes";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import { FormDrawerWrapper } from "@root/forms/shared/styledComponents";
 import AddressAutocomplete from "../AddressAutocomplete";
 import { useLoadScript } from "@react-google-maps/api";
@@ -76,7 +76,7 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 
 	useEffect(() => {
 		if (state.data !== undefined && initialState !== undefined)
-			handleUnsavedChanges(!_.isEqual(initialState, state.data));
+			handleUnsavedChanges(!isEqual(initialState, state.data));
 	}, [state.data, initialState]);
 
 	const getFormValues = useCallback(async () => {

--- a/src/components/Field/FormFieldColorPicker/ColorPicker.styled.tsx
+++ b/src/components/Field/FormFieldColorPicker/ColorPicker.styled.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import theme from "@root/theme";
 import { ColorSelectedProps } from "./ColorPickerTypes";
 import { TransientProps } from "@root/types";
-import { Popover } from "@mui/material"
+import Popover from "@mui/material/Popover"
 
 export const ColorContainer = styled.div<TransientProps<ColorSelectedProps, "displayColorPicker" | "disabled">>`
   background: ${theme.newColors.grey1["100"]};

--- a/src/components/Field/FormFieldDate/DatePicker/DatePicker.styled.tsx
+++ b/src/components/Field/FormFieldDate/DatePicker/DatePicker.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import theme from "@root/theme";
-import { TextField } from "@mui/material";
+import TextField from "@mui/material/TextField";
 
 export const popperSx = {
 	"& .MuiPaper-root": {

--- a/src/components/Field/FormFieldImageUpload/FormFieldImageUpload.tsx
+++ b/src/components/Field/FormFieldImageUpload/FormFieldImageUpload.tsx
@@ -3,7 +3,7 @@ import { memo, ReactElement, useEffect, useRef, useState } from "react";
 
 import { ImageUploadValue, ImageUploadInputSettings } from "./FormFieldImageUploadTypes";
 import { MosaicFieldProps } from "@root/components/Field";
-import { isEmpty } from "lodash";
+import isEmpty from "lodash/isEmpty";
 
 // Components
 import Button from "@root/components/Button";

--- a/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/BrowseOption/BrowseOption.tsx
+++ b/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/BrowseOption/BrowseOption.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { memo, ReactElement } from "react";
 import { BrowseOptionProps } from "..";
-import { startCase } from "lodash";
+import startCase from "lodash/startCase";
 
 // Styles
 import {

--- a/src/components/Field/FormFieldMapCoordinates/Map/Map.tsx
+++ b/src/components/Field/FormFieldMapCoordinates/Map/Map.tsx
@@ -3,7 +3,7 @@ import { GoogleMap } from "@react-google-maps/api";
 import { memo, ReactElement, useEffect, useState } from "react";
 import { MapProps } from "../MapCoordinatesTypes";
 import { geocodeByAddress, getLatLng } from "react-places-autocomplete";
-import { InputAdornment } from "@mui/material";
+import InputAdornment from "@mui/material/InputAdornment";
 
 // Styles
 import { MapContainer } from "../MapCoordinates.styled";

--- a/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
@@ -1,7 +1,8 @@
 import Button from "@root/components/Button";
 import { MosaicFieldProps } from "@root/components/Field";
-import { formActions, Snackbar } from "@root/index";
-import _ from "lodash";
+import { formActions } from "@root/components/Form";
+import Snackbar from "@root/components/Snackbar";
+import uniqueId from "lodash/uniqueId";
 import * as React from "react";
 import { memo, SyntheticEvent, useEffect, useRef, useState, useMemo } from "react";
 import { DragAndDropContainer, DragAndDropSpan, FileInput } from "../../../forms/shared/styledComponents";
@@ -166,7 +167,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 		newFiles.forEach(file => {
 			transformedFiles = {
 				...transformedFiles,
-				[_.uniqueId()]: {
+				[uniqueId()]: {
 					data: {
 						name: file.name,
 						size: file.size,

--- a/src/components/Field/Label.tsx
+++ b/src/components/Field/Label.tsx
@@ -3,7 +3,7 @@ import { ReactElement, ReactNode } from "react";
 import styled from "styled-components";
 
 // Material UI
-import { InputLabel } from "@mui/material";
+import InputLabel from "@mui/material/InputLabel";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
 import theme from "@root/theme";

--- a/src/components/Form/stories/DrawerForm.stories.tsx
+++ b/src/components/Form/stories/DrawerForm.stories.tsx
@@ -14,7 +14,7 @@ import Drawer from "@root/components/Drawer/Drawer";
 import { FieldDef } from "@root/components/Field";
 
 import theme, { BREAKPOINTS } from "@root/theme/theme";
-import _ from "lodash";
+import uniqueId from "lodash/uniqueId";
 import { Sizes } from "@root/theme";
 import { getOptionsCountries, getOptionsStates } from "@root/components/Field/FormFieldAddress/utils/optionGetters";
 import styled from "styled-components";
@@ -170,7 +170,7 @@ export const DrawerForm = (): ReactElement => {
 			type: "upload",
 			inputSettings: {
 				onFileAdd: async ({onUploadComplete, file}) => {
-					onUploadComplete({name: "Test", fileUrl: "https://www.google.com", id: _.uniqueId(), size: 1098})
+					onUploadComplete({name: "Test", fileUrl: "https://www.google.com", id: uniqueId(), size: 1098})
 				},
 				onFileDelete: async () => {
 					// This is fine

--- a/src/components/Form/validators.ts
+++ b/src/components/Form/validators.ts
@@ -1,5 +1,5 @@
 import { DATE_FORMAT_FULL } from "@root/constants";
-import { format } from "date-fns";
+import format from "date-fns/format";
 
 export const VALIDATE_EMAIL_TYPE = "validateEmail";
 export const VALIDATE_SLOW_TYPE = "validateSlow";

--- a/src/components/LeftNav/LeftNavDesktop.tsx
+++ b/src/components/LeftNav/LeftNavDesktop.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { useState, useEffect, useContext, ReactElement } from "react";
 import styled from "styled-components";
-import { debounce, throttle } from "lodash";
+import debounce from "lodash/debounce";
+import throttle from "lodash/throttle";
 
 import SettingsIcon from "@mui/icons-material/Settings";
 

--- a/src/components/LeftNav/LeftNavFlyout.tsx
+++ b/src/components/LeftNav/LeftNavFlyout.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import Popper from "@mui/material/Popper";
 import { PopperProps } from "@mui/material/Popper";
 import Paper from "@mui/material/Paper";
-import { throttle } from "lodash";
+import throttle from "lodash/throttle";
 
 import { LeftNavItemDef, LeftNavContext } from "./LeftNavTypes";
 import LeftNavTitle from "./LeftNavTitle";

--- a/src/components/LeftNav/LeftNavItemDesktop.tsx
+++ b/src/components/LeftNav/LeftNavItemDesktop.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useContext, useEffect, useRef, useCallback, Fragment, ReactElement } from "react";
-import { throttle } from "lodash";
+import throttle from "lodash/throttle";
 
 import { LeftNavBlockProps, LeftNavContext } from "./LeftNavTypes";
 import LeftNavItem from "./LeftNavItem";
@@ -56,7 +56,7 @@ function LeftNavItemDesktop(props: LeftNavBlockProps): ReactElement {
 			onPointerMove.cancel();
 		}
 	}, [onPointerMove]);
-	
+
 	const attrs = {
 		onPointerMove,
 		onPointerLeave,

--- a/src/components/LeftNav/NavWrapper.tsx
+++ b/src/components/LeftNav/NavWrapper.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useState, useEffect, useMemo, useRef, ReactElement, MouseEventHandler } from "react";
 import styled from "styled-components";
 import { LoremIpsum } from "react-lorem-ipsum";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import theme from "@root/theme";
 
 import MenuIcon from "@mui/icons-material/Menu";

--- a/src/components/Tooltip/Tooltip.styled.tsx
+++ b/src/components/Tooltip/Tooltip.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import theme from "@root/theme";
-import { Popper } from "@mui/material";
+import Popper from "@mui/material/Popper";
 
 export const TooltipPopper = styled(Popper)`
 	z-index: 1500;

--- a/src/transforms/column_transforms.tsx
+++ b/src/transforms/column_transforms.tsx
@@ -1,4 +1,5 @@
-import { get, map } from "lodash";
+import get from "lodash/get";
+import map from "lodash/map";
 import { format } from "date-fns";
 import { createElement, ReactNode } from "react";
 import { MosaicLabelValue, MosaicObject } from "../types";

--- a/src/transforms/column_transforms.tsx
+++ b/src/transforms/column_transforms.tsx
@@ -1,6 +1,6 @@
 import get from "lodash/get";
 import map from "lodash/map";
-import { format } from "date-fns";
+import format from "date-fns/format";
 import { createElement, ReactNode } from "react";
 import { MosaicLabelValue, MosaicObject } from "../types";
 import DataView, { DataViewColumn, DataViewColumnTransform } from "../components/DataView";

--- a/src/utils/JSONDB.ts
+++ b/src/utils/JSONDB.ts
@@ -1,4 +1,6 @@
-import { intersection, isEqual, sortBy } from "lodash";
+import intersection from "lodash/intersection";
+import isEqual from "lodash/isEqual";
+import sortBy from "lodash/sortBy";
 
 interface Relationship {
 	api: JSONDB

--- a/src/utils/date/textIsValidDate.ts
+++ b/src/utils/date/textIsValidDate.ts
@@ -1,4 +1,6 @@
-import { format, isValid, parse } from "date-fns";
+import format from "date-fns/format";
+import isValid from "date-fns/isValid";
+import parse from "date-fns/parse";
 
 function textIsValidDate(text: string, dateFormat: string) {
 	const date = parse(text, dateFormat, new Date());

--- a/src/utils/hooks/useScrollSpy/useScrollSpy.ts
+++ b/src/utils/hooks/useScrollSpy/useScrollSpy.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ScrollSpyProps, ScrollSpyResult } from "./ScrollSpyTypes";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import { useAnimate } from "../useAnimate";
 import clamp from "@root/utils/math/clamp";
 


### PR DESCRIPTION
Ensures imports avoid loading entire libraries:

- Material components are loaded using `@mui/material/*`
- Lodash functions are loaded using `lodash/*`
- Mosaic components and utils are loaded using `@root/components/*`
- Date Fns utils are loaded using `date-fns/*`