### PR TITLE
MOS-1251 File size limits

### DIFF
--- a/src/components/Field/FormFieldUpload/FormFieldUpload.stories.tsx
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.stories.tsx
@@ -67,6 +67,8 @@ export const Playground = (): ReactElement => {
 	const maxFileSize = text("Max file size (KB)", "");
 	const maxTotalSize = text("Max total size (KB)", "");
 
+	// One line change
+
 	const accept = acceptCsv.trim() ? acceptCsv.split(",") : undefined;
 
 	const [loadReady, setLoadReady] = useState(false);

--- a/src/components/Field/FormFieldUpload/FormFieldUpload.stories.tsx
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.stories.tsx
@@ -64,6 +64,8 @@ export const Playground = (): ReactElement => {
 	const downloadUrl = text("Override onUploadComplete download URL", "");
 	const error = boolean("Trigger errors when loading", false);
 	const acceptCsv = text("Comma separated accepted extensions", "");
+	const maxFileSize = text("Max file size (KB)", "");
+	const maxTotalSize = text("Max total size (KB)", "");
 
 	const accept = acceptCsv.trim() ? acceptCsv.split(",") : undefined;
 
@@ -107,7 +109,7 @@ export const Playground = (): ReactElement => {
 	]);
 
 	const onFileDelete = async ({id}) => {
-		alert("DELETED FILE: " + id);
+		await new Promise((resolve) => setTimeout(() => resolve(null), 2000));
 	}
 
 	const getFormValues = useCallback(async () => {
@@ -131,7 +133,9 @@ export const Playground = (): ReactElement => {
 						limit: limit === "No limit" ? undefined : limit,
 						onFileAdd,
 						onFileDelete,
-						accept
+						accept,
+						maxFileSize: maxFileSize ? Number(maxFileSize) * 1000 : undefined,
+						maxTotalSize: maxTotalSize ? Number(maxTotalSize) * 1000 : undefined
 					}
 				},
 			],
@@ -143,7 +147,9 @@ export const Playground = (): ReactElement => {
 			instructionText,
 			limit,
 			onFileAdd,
-			accept
+			accept,
+			maxFileSize,
+			maxTotalSize
 		]
 	);
 

--- a/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
+++ b/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
@@ -1,8 +1,7 @@
 import { FieldDefBase } from "@root/components/Field";
-import { MosaicObject } from "@root/types";
 
 export type TransformedFile = {
-		data: MosaicObject,
+		data: UploadData,
 		percent: number,
 		error: string | undefined,
 		rawData: File,
@@ -16,7 +15,16 @@ export type UploadFieldInputSettings = {
 	onFileDelete: OnFileDelete;
 	onFileAdd: OnFileAdd;
 	limit?: number;
-	accept?: string[]
+	accept?: string[];
+	/**
+	 * Maximum size limit for each file uploaded
+	 */
+	maxFileSize?: number;
+	/**
+	 * Maximum size limit for cumulative total
+	 * of files uploaded
+	 */
+	maxTotalSize?: number;
 };
 
 export type UploadData =  {
@@ -71,6 +79,17 @@ type OnFileAddData = {
 
 type OnFileDeleteData = {
 	id: UploadData["id"];
+}
+
+export interface QueuedFile {
+	id: string;
+	data: {
+		name: string;
+		size: number;
+	};
+	percent: number;
+	error?: string;
+	file: File
 }
 
 export type FieldDefUpload = FieldDefBase<"upload", UploadFieldInputSettings, UploadData[]>;


### PR DESCRIPTION
This adds support for individual and cumulative file size limits by introducing two new available input settings for the file upload field. Both properties take the byte limit in the form of a number:

- `maxFileSize` can be used to limit each file uploaded. The `onFileAdd` function will not fire and an error will be displayed beneath the offending file item
- `maxTotalSize` can be used to limit the total cumulative file size. The file(s) selected will not be added to the queue and a snackbar will be displayed to the user reading "Maximum cumulative file size is x" where x is a formatted amount of bytes.