### PR TITLE
MOS-1259 Tooltip improvements

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.mdx
+++ b/src/components/Tooltip/Tooltip.stories.mdx
@@ -18,6 +18,7 @@ https://github.com/simpleviewinc/sv-mosaic/blob/develop/src/components/Tooltip/T
 | `children`  | `ReactNode`                    | (Required) The content of the tooltip.                                                                                                          |
 | `placement` | `MUITooltipProps["placement"]` | (Optional, default: "bottom-start") How the tooltip should be positioned relative to its anchor.                                                |
 | `id`        | `string`                       | (Optional) The HTML ID to be given to the parent tooltip element. Should be used in conjunction with the anchor's `aria-describedby` attribute. |
+| `maxWidth`  | `number` or `string`           | (Optional) The maximum width for the tooltip. Accepts a number of pixels or any valid CSS max-width unit                                        |
 
 ## Helper Hook
 

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -16,11 +16,17 @@ export default {
 export const Example = (): ReactElement => {
 	const { anchorProps, tooltipProps } = useTooltip();
 	const tooltip = text("Tooltip text","Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec iaculis quam adipiscing elit. Quisque Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec iaculis quam adipiscing elit. Quisque");
+	const maxWidth = text("Max Width", "");
 
 	return (
 		<>
 			<InfoOutlinedIcon style={{margin: "140px 30px"}} {...anchorProps} />
-			<Tooltip {...tooltipProps}>{tooltip}</Tooltip>
+			<Tooltip
+				{...tooltipProps}
+				maxWidth={maxWidth !== "" ? maxWidth : undefined}
+			>
+				{tooltip}
+			</Tooltip>
 		</>
 	)
 };

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ReactElement } from "react";
-import { withKnobs, text } from "@storybook/addon-knobs";
+import { withKnobs, text, select } from "@storybook/addon-knobs";
 import { Meta } from "@storybook/addon-docs/blocks";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
@@ -13,9 +13,13 @@ export default {
 	decorators: [withKnobs],
 } as Meta;
 
+const tooltipContentOptions = ["text", "image"];
+
 export const Example = (): ReactElement => {
 	const { anchorProps, tooltipProps } = useTooltip();
-	const tooltip = text("Tooltip text","Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec iaculis quam adipiscing elit. Quisque Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec iaculis quam adipiscing elit. Quisque");
+	const tooltipContent = select("Tooltip content", tooltipContentOptions, "text");
+	const tooltipText = text("Tooltip text","Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec iaculis quam adipiscing elit. Quisque Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec iaculis quam adipiscing elit. Quisque");
+	const tooltipImage = text("Tooltip image", "http://placekitten.com/200/300");
 	const maxWidth = text("Max Width", "");
 
 	return (
@@ -25,7 +29,7 @@ export const Example = (): ReactElement => {
 				{...tooltipProps}
 				maxWidth={maxWidth !== "" ? maxWidth : undefined}
 			>
-				{tooltip}
+				{tooltipContent === "text" ? tooltipText : <img style={{display: "block", maxWidth: "100%"}} alt="Tooltip Image" src={tooltipImage} />}
 			</Tooltip>
 		</>
 	)

--- a/src/components/Tooltip/Tooltip.styled.tsx
+++ b/src/components/Tooltip/Tooltip.styled.tsx
@@ -6,7 +6,7 @@ export const TooltipPopper: any = styled(Popper)`
 	z-index: 1500;
 	background: ${theme.newColors.almostBlack["100"]};
 	color: white;
-	padding: 4px 8px;
+	padding: 8px;
 	border-radius: 4px;
 	color: white;
 	font-family: ${theme.fontFamily};

--- a/src/components/Tooltip/Tooltip.styled.tsx
+++ b/src/components/Tooltip/Tooltip.styled.tsx
@@ -12,6 +12,7 @@ export const TooltipPopper: any = styled(Popper)`
 	font-family: ${theme.fontFamily};
 	font-size: 12px;
 	max-width: 12rem;
+	pointer-events: none;
 
 	&[data-popper-placement="bottom-start"] .arrow,
 	&[data-popper-placement="bottom"] .arrow,
@@ -77,8 +78,6 @@ export const TooltipPopper: any = styled(Popper)`
 		bottom: 5px;
 	}
 `;
-
-//"bottom" | "top" | "left" | "right" | "bottom-end" | "bottom-start" | "left-end" | "left-start" | "right-end" | "right-start" | "top-end" | "top-start"
 
 export const TooltipArrow = styled.div`
 	border: 5px solid transparent;

--- a/src/components/Tooltip/Tooltip.styled.tsx
+++ b/src/components/Tooltip/Tooltip.styled.tsx
@@ -11,7 +11,7 @@ export const TooltipPopper: any = styled(Popper)`
 	color: white;
 	font-family: ${theme.fontFamily};
 	font-size: 12px;
-	max-width: 12rem;
+	max-width: 500px;
 	pointer-events: none;
 
 	&[data-popper-placement="bottom-start"] .arrow,

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ReactElement } from "react";
+import { ReactElement, useMemo } from "react";
 import { TooltipProps } from ".";
 import { TooltipArrow, TooltipPopper } from "./Tooltip.styled";
 
@@ -18,19 +18,22 @@ const Tooltip = (props: TooltipProps): ReactElement => {
 		open,
 		placement = "bottom-start",
 		anchorEl,
-		id
+		id,
+		maxWidth
 	} = props;
+
+	const style = useMemo(() => ({ maxWidth }), [maxWidth]);
 
 	return (
 		<TooltipPopper
 			open={open}
 			anchorEl={anchorEl}
-			style={{ zIndex: 1500, pointerEvents: "none" }}
 			placement={placement}
 			modifiers={tooltipOffset}
 			role="tooltip"
 			id={id}
 			data-testid="tooltip-test-id"
+			style={style}
 		>
 			<TooltipArrow className="arrow" />
 			{children}

--- a/src/components/Tooltip/TooltipTypes.tsx
+++ b/src/components/Tooltip/TooltipTypes.tsx
@@ -8,7 +8,7 @@ export interface TooltipProps {
    * The tooltip anchor. Must be a type of
    * HTML element
    */
-  anchorEl: AnchorElement
+  anchorEl: AnchorElement | null
   /**
    * Whether or not the tooltip is currently
    * visible on screen
@@ -32,7 +32,7 @@ export interface TooltipProps {
 }
 
 export interface AnchorProps {
-	ref: Dispatch<AnchorElement>
+	ref: Dispatch<AnchorElement | null>
 	onMouseEnter: () => void;
 	onMouseLeave: () => void;
 	"aria-describedby": string

--- a/src/components/Tooltip/TooltipTypes.tsx
+++ b/src/components/Tooltip/TooltipTypes.tsx
@@ -29,6 +29,11 @@ export interface TooltipProps {
    * the anchor's aria-describedby attribute
    */
   id?: string
+  /**
+   * The maximum width for the tooltip. Accepts
+   * a number of pixels or any valid CSS max-width unit
+   */
+  maxWidth?: string | number
 }
 
 export interface AnchorProps {

--- a/src/components/Tooltip/useTooltip.ts
+++ b/src/components/Tooltip/useTooltip.ts
@@ -1,5 +1,5 @@
 import { useId, useMemo, useState } from "react";
-import { AnchorProps, TooltipProps } from "./TooltipTypes";
+import { AnchorElement, AnchorProps, TooltipProps } from "./TooltipTypes";
 
 type HookTooltipProps = Required<Pick<TooltipProps, "anchorEl" | "open" | "id">>;
 
@@ -9,7 +9,7 @@ export interface UseTooltipResult {
 }
 
 function useTooltip(): UseTooltipResult {
-	const [ref, setRef] = useState(null);
+	const [ref, setRef] = useState<AnchorElement | null>(null);
 	const [open, setOpen] = useState(false);
 
 	const id = useId();


### PR DESCRIPTION
- Ensures the tooltip hook and component can be used in strict TypeScript environments without throwing errors.
- Adds support for a `maxWidth` property that allows the overriding of the default 12rem maximum width.