### PR TITLE
MOS-1257 DataView action toggle fixes and tests

### DIFF
--- a/src/components/DataView/DataView.stories.tsx
+++ b/src/components/DataView/DataView.stories.tsx
@@ -617,7 +617,8 @@ export const Playground = (): ReactElement => {
 				mIcon: GetAppIcon,
 				onClick: function ({ data }) {
 					alert(`DOWNLOAD ${data.map(val => val.id)}`);
-				}
+				},
+				show: ({ data }) => data.length <= 5
 			},
 			{
 				name: "delete",
@@ -629,7 +630,8 @@ export const Playground = (): ReactElement => {
 				},
 				onAllClick: bulkAllActions ? function () {
 					alert("DELETE ALL");
-				} : undefined
+				} : undefined,
+				show: ({ checkedAllPages }) => !checkedAllPages
 			}
 		] : [],
 		buttons: [

--- a/src/components/DataView/DataView.stories.tsx
+++ b/src/components/DataView/DataView.stories.tsx
@@ -618,7 +618,8 @@ export const Playground = (): ReactElement => {
 				onClick: function ({ data }) {
 					alert(`DOWNLOAD ${data.map(val => val.id)}`);
 				},
-				show: ({ data }) => data.length <= 5
+				show: ({ data }) => data.length <= 5,
+				muiAttrs: { title: "Download checked" }
 			},
 			{
 				name: "delete",
@@ -631,7 +632,8 @@ export const Playground = (): ReactElement => {
 				onAllClick: bulkAllActions ? function () {
 					alert("DELETE ALL");
 				} : undefined,
-				show: ({ checkedAllPages }) => !checkedAllPages
+				show: ({ checkedAllPages }) => !checkedAllPages,
+				muiAttrs: { title: "Delete checked" }
 			}
 		] : [],
 		buttons: [

--- a/src/components/DataView/DataView.test.tsx
+++ b/src/components/DataView/DataView.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { DataViewFilterText } from "../../index";
+import { Playground } from "./DataView.stories";
 
 afterEach(cleanup);
 
@@ -77,4 +78,58 @@ describe("DataViewFilterText component", () => {
 			/>
 		)).toThrow("The selected comparison is not a valid comparison");
 	})
+
+	it("Should not show bulk action download if more than 5 items are checked", async () => {
+		render(
+			<Playground />
+		);
+
+		await waitFor(() => expect(screen.getAllByRole("checkbox").length).toBeGreaterThan(1));
+
+		const checkboxes = screen.getAllByRole("checkbox");
+
+		act(() => {
+			fireEvent.click(checkboxes[1]);
+		});
+
+
+		expect(screen.queryByTitle("Download checked")).not.toBeNull();
+
+		act(() => {
+			fireEvent.click(checkboxes[2]);
+			fireEvent.click(checkboxes[3]);
+			fireEvent.click(checkboxes[4]);
+			fireEvent.click(checkboxes[5]);
+			fireEvent.click(checkboxes[6]);
+		});
+
+		expect(screen.queryByTitle("Download checked")).toBeNull();
+	});
+
+	it("Should not show bulk action delete if items across all pages are checked", async () => {
+		render(
+			<Playground />
+		);
+
+		await waitFor(() => expect(screen.getAllByRole("checkbox").length).toBeGreaterThan(1));
+
+		const checkboxes = screen.getAllByRole("checkbox");
+
+		act(() => {
+			for (let i = 1; i < checkboxes.length; i++) {
+				fireEvent.click(checkboxes[i]);
+			}
+		})
+
+		const selectAllButton = screen.queryByText("Select All 304 Records");
+
+		expect(selectAllButton).not.toBeNull();
+		expect(screen.queryByTitle("Delete checked")).not.toBeNull();
+
+		act(() => {
+			fireEvent.click(selectAllButton);
+		})
+
+		expect(screen.queryByTitle("Delete checked")).toBeNull();
+	});
 });

--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -100,12 +100,18 @@ const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (pr
 		})
 	}, [props.bulkActions, props.checkedAllPages]);
 
+	const bulkActionsToggleCtx = useMemo(() => ({
+		checkedAllPages: props.checkedAllPages,
+		data: props.data.filter((_, i) => props.checked?.length > 0 && props.checked[i] === true)
+	}), [
+		props.checked,
+		props.checkedAllPages,
+		props.data
+	]);
+
 	const shownBulkActions = useWrappedToggle(
 		bulkActions,
-		{
-			checkedAllPages: props.checkedAllPages,
-			data: props.data.filter((_, i) => props.checked?.length > 0 && props.checked[i] === true)
-		},
+		bulkActionsToggleCtx,
 		"show",
 		true
 	)

--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -137,7 +137,7 @@ const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (pr
 	};
 
 	useEffect(() => {
-		if (!viewContainerRef.current) {
+		if (!viewContainerRef.current || !viewContainerRef.current.scrollTo) {
 			return;
 		}
 

--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -7,6 +7,7 @@ import theme from "@root/theme";
 import { DataViewDisplayList, DataViewDisplayGrid } from "./DataViewDisplays";
 import { DataViewProps, StateViewDef } from "./DataViewTypes";
 import DataViewActionsRow from "./DataViewActionsRow";
+import { useWrappedToggle } from "@root/utils/toggle";
 
 const StyledWrapper = styled.div`
 	font-family: ${theme.fontFamily};
@@ -97,7 +98,17 @@ const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (pr
 
 			return action.onClick
 		})
-	}, [props.bulkActions]);
+	}, [props.bulkActions, props.checkedAllPages]);
+
+	const shownBulkActions = useWrappedToggle(
+		bulkActions,
+		{
+			checkedAllPages: props.checkedAllPages,
+			data: props.data.filter((_, i) => props.checked?.length > 0 && props.checked[i] === true)
+		},
+		"show",
+		true
+	)
 
 	const checkboxEnabled =
 		props.checked !== undefined &&
@@ -212,21 +223,20 @@ const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (pr
 
 	const shouldRenderActionsRow: boolean = useMemo(() => {
 		if (
-			bulkActions ??
-			props.limitOptions ??
-			props.onColumnsChange ??
-			props.onSortChange ??
-			props.sort ??
-			displayControlEnabled === true ??
-			props.onLimitChange ??
+			shownBulkActions.length > 0 ||
+			props.limitOptions ||
+			props.onColumnsChange ||
+			props.onSortChange ||
+			props.sort ||
+			displayControlEnabled === true ||
+			props.onLimitChange ||
 			props.onSkipChange
 		)
 			return true;
 
 		return false;
 	}, [
-		props.display,
-		bulkActions,
+		shownBulkActions,
 		props.limitOptions,
 		props.onColumnsChange,
 		props.onSortChange,
@@ -241,10 +251,10 @@ const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (pr
 
 	// To show the bulkAll header we need bulkActions/rowCount/count, more rows than are visible, at least one registered onAllClick, and all checkboxes selected
 	const showBulkAll =
-		bulkActions?.length > 0 &&
+		shownBulkActions?.length > 0 &&
 		props.data.length > 0 &&
 		props.count > props.data.length &&
-		bulkActions.some(action => action.onAllClick !== undefined) &&
+		shownBulkActions.some(action => action.onAllClick !== undefined) &&
 		allChecked &&
 		props.checkedAllPages !== undefined &&
 		props.onCheckAllPagesChange !== undefined
@@ -288,7 +298,7 @@ const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (pr
 						<DataViewActionsRow
 							activeColumnObjs={activeColumnObjs}
 							columns={props.columns}
-							bulkActions={bulkActions}
+							bulkActions={shownBulkActions}
 							checked={props.checked}
 							display={display}
 							displayControlEnabled={displayControlEnabled}
@@ -323,7 +333,7 @@ const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (pr
 					checked={props.checked}
 					checkedAllPages={props.checkedAllPages}
 					columns={props.columns}
-					bulkActions={bulkActions}
+					bulkActions={shownBulkActions}
 					sort={props.sort}
 					data={props.data}
 					additionalActions={props.additionalActions}

--- a/src/components/DataView/DataViewTypes.ts
+++ b/src/components/DataView/DataViewTypes.ts
@@ -96,7 +96,7 @@ export interface DataViewBulkAction extends Omit<DataViewAction, "onClick" | "sh
 	/** A handler function to be invoked when this action is used. */
 	onClick?: DataViewBulkActionOnClick
 	onAllClick?: MosaicCallback,
-	show?: MosaicToggle
+	show?: MosaicToggle<{ checkedAllPages: DataViewProps["checkedAllPages"], data: DataViewProps["data"] }>
 }
 
 export interface DataViewSort {

--- a/src/utils/toggle/useWrappedToggle.ts
+++ b/src/utils/toggle/useWrappedToggle.ts
@@ -38,7 +38,7 @@ function useWrappedToggle<K extends keyof T, T extends { [key in K]?: MosaicTogg
 		}
 
 		return wrappedItems[0];
-	}, [items, params]);
+	}, [defaultToggle, items, key, params]);
 
 	/**
 	 * Removing this redundant statement makes TS throw up.


### PR DESCRIPTION
- Reinstates toggling mechanism at the `DataView` level for bulk actions and provide appropriate context w/ new tests
- Improved condition for showing DataView's action bar