### PR TITLE
MOS-1188 Chip accessibility

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,11 @@
+const styledComponentArrowFn =
+  "TaggedTemplateExpression > TemplateLiteral > ArrowFunctionExpression";
+
+const ignoredNodes = [
+	styledComponentArrowFn,
+	`${styledComponentArrowFn} > BlockStatement`,
+];
+
 module.exports = {
 	parserOptions: {
 		ecmaVersion: 11,
@@ -24,7 +32,7 @@ module.exports = {
 	rules: {
 		"react-hooks/rules-of-hooks": "error",
 		"react-hooks/exhaustive-deps": "warn",
-		"@stylistic/indent": ["error", "tab", { "flatTernaryExpressions": true }],
+		"@stylistic/indent": ["error", "tab", { "flatTernaryExpressions": true, ignoredNodes }],
 		"@stylistic/quotes": ["error", "double", { "avoidEscape": true }],
 		"@stylistic/semi": ["error", "always"],
 		"@stylistic/no-extra-semi": "error",

--- a/automation_testing/tests/Components/Chip/chip.spec.ts
+++ b/automation_testing/tests/Components/Chip/chip.spec.ts
@@ -14,7 +14,7 @@ test.describe.parallel("Components - Chip - Kitchen Sink", () => {
 
 	test("Validate Chip has simplyGold background.", async () => {
 		const expectedColor = theme.newColors.simplyGold["100"];
-		const expectedDisabledBgColor = theme.newColors.simplyGold["100"];
+		const expectedDisabledBgColor = theme.newColors.simplyGold["60"];
 		expect(await chipPage.getBackgroundColorFromElement(chipPage.basicChipWithOnClickSelected)).toBe(expectedColor);
 		expect(await chipPage.getBackgroundColorFromElement(chipPage.basicChipWithoutOnClickSelected)).toBe(expectedColor);
 		expect(await chipPage.getBackgroundColorFromElement(chipPage.disabledChipSelected)).toBe(expectedDisabledBgColor);

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -24,7 +24,6 @@ const Checkbox = (props: CheckboxProps) => (
 					checked={props.checked}
 					onClick={props.onClick}
 					indeterminate={props.indeterminate}
-					disableRipple
 				/>
 			}
 		/>

--- a/src/components/Chip/Chip.styled.ts
+++ b/src/components/Chip/Chip.styled.ts
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import theme from "@root/theme";
 import { TransientProps } from "@root/types";
 import { ChipsProps } from "./ChipTypes";
+import { ComponentProps } from "react";
 
 const chipFont = `
 	font-size: 14px;
@@ -40,31 +41,57 @@ export const StyledDeletableChip = styled(Chip)`
 	}
 `;
 
-export const StyledChip = styled(Chip)<TransientProps<ChipsProps, "disabled" | "selected">>`
-	&.MuiChip-root {
-		background-color: ${({ $selected, $disabled }) => {
-		if ($selected && !$disabled) {
-			return theme.newColors.simplyGold["100"];
-		} else if ($selected && $disabled) {
-			return theme.newColors.simplyGold["60"];
+function getChipBackground({ $selected, disabled, onClick }: Pick<ComponentProps<typeof StyledChip>, "$selected" | "disabled" | "onClick">) {
+	if ($selected) {
+		if (disabled) {
+			return { base: theme.newColors.simplyGold["60"] };
 		}
-		return theme.newColors.grey2["100"];
-	}};
-	max-width: 186px;
 
+		return {
+			base: theme.newColors.simplyGold["100"],
+			focus: onClick && theme.newColors.darkerSimplyGold["100"],
+			hover: onClick && theme.newColors.darkerSimplyGold["100"],
+		};
+	}
+
+	return {
+		base: theme.newColors.grey2["100"],
+		focus: onClick && theme.newColors.simplyGrey["100"],
+		hover: onClick && theme.newColors.simplyGrey["100"],
+	};
+}
+
+export const StyledChip = styled(Chip)<TransientProps<ChipsProps, "selected">>`
+	&.MuiChip-root {
+		max-width: 186px;
 		color: ${theme.newColors.almostBlack["100"]};
-
-		${({ $selected, onClick }) => onClick ?
-		`	&:hover {
-				background-color: ${$selected	? theme.newColors.darkerSimplyGold["100"] : theme.newColors.simplyGrey["100"]};
-			}
-
-			&:focus {
-				background-color: ${$selected ? theme.newColors.simplyGold["100"] : theme.newColors.grey2["100"]};
-			}
-			` : ""};
-
 		padding: 8px 16px;
+
+		&:focus{
+			box-shadow: none;
+			outline: 1px solid white;
+			outline-offset: -2px;
+		}
+
+		${({ $selected, disabled, onClick }) => {
+			const { base, focus, hover } = getChipBackground({ $selected, disabled, onClick });
+
+			return `
+				background-color: ${base};
+
+				${focus && `
+					&:focus{
+						background-color: ${focus}
+					}
+				`}
+
+				${hover && `
+					&:hover{
+						background-color: ${hover}
+					}
+				`}
+			`;
+		}}
 	}
 
 	& .MuiChip-label {


### PR DESCRIPTION
Makes the following changes in order to improve form accessibility:

- Reinstates the `Checkbox` ripple to indicate focus.
- Amends `Chip` styling to show visual cues indicating focus where appropriate.
- Adjust eslint to prevent false reports within template strings