### PR TITLE
MOS-1266 Form submission not prevented by busy fields

### DIFF
--- a/src/components/Form/formActions.ts
+++ b/src/components/Form/formActions.ts
@@ -307,7 +307,7 @@ export const formActions: FormActionThunks = {
 			const state = getState();
 			const { data, mounted } = extraArgs;
 
-			if (!dispatch(formActions.isSubmittable())) {
+			if (!(await dispatch(formActions.isSubmittable()))) {
 				return {
 					valid: false,
 					data: null,


### PR DESCRIPTION
Ensures the form action `submitForm` waits for the result of the asynchronous function `isSubmittable` to correctly return a `{ valid: false }` result.