### PR TITLE
MOS-1252 Button mouse events

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -35,8 +35,6 @@ const ButtonBase = forwardRef<HTMLButtonElement, ButtonProps>(function ButtonBas
 		$size: props.size,
 		onClick: props.onClick,
 		onBlur: props.onBlur,
-		onMouseEnter: props.onMouseEnter,
-		onMouseLeave: props.onMouseLeave,
 		href: props.href,
 		name: props.name,
 		ref,
@@ -58,6 +56,8 @@ const ButtonBase = forwardRef<HTMLButtonElement, ButtonProps>(function ButtonBas
 				size_${props.size}
 				variant_${props.variant}
 			`}
+			onMouseEnter={props.onMouseEnter}
+			onMouseLeave={props.onMouseLeave}
 		>
 			{isIconButton ? (
 				<Component {...buttonProps}>


### PR DESCRIPTION
Attaches the `onMouseEnter` and `onMouseLeave` event handlers to the component that wraps the button instead of the button itself, allowing them to be fired even when the button is disabled.