### PR TITLE
MOS-1254 Button disabled toggle

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -51,6 +51,34 @@ const menuContent = (
 	</div>
 );
 
+const commonToggleMap = {
+	"Undefined": undefined,
+	"True": true,
+	"False": false,
+	"Function that returns true": () => true,
+	"Function that returns false": () => false,
+};
+
+const showMap = {
+	...commonToggleMap,
+	"Array of true values": [true, true, true],
+	"Array with one falsy value": [true, false, true],
+	"Array of functions that return true": [() => true, () => true],
+	"Array of functions, one returns false": [() => false, () => true],
+};
+
+const showOptions = Object.keys(showMap);
+
+const disabledMap = {
+	...commonToggleMap,
+	"Array of false values": [false, false, false],
+	"Array with one truthy value": [false, true, false],
+	"Array of functions that return false": [() => false, () => false],
+	"Array of functions, one returns true": [() => true, () => false],
+};
+
+const disabledOptions = Object.keys(disabledMap);
+
 export const Playground = (): ReactElement => {
 	const buttonVariant = select(
 		"Variant",
@@ -83,19 +111,14 @@ export const Playground = (): ReactElement => {
 		],
 		"medium",
 	);
-	const showOptions = select(
+	const show = select(
 		"Show",
-		[
-			"Undefined",
-			"True",
-			"False",
-			"Function that returns true",
-			"Function that returns false",
-			"Array of true values",
-			"Array with one falsy value",
-			"Array of functions that return true",
-			"Array of functions, one returns false",
-		],
+		showOptions,
+		"Undefined",
+	);
+	const disabled = select(
+		"Disabled",
+		disabledOptions,
 		"Undefined",
 	);
 	const label = select("Type of label", ["String", "JSX"], "String");
@@ -117,7 +140,6 @@ export const Playground = (): ReactElement => {
 	);
 	const iconPosition = select("Icon position", ["left", "right"], "left");
 	const fullWidth = boolean("Full Width", false);
-	const disabled = boolean("Disabled", false);
 	const tooltip = select("Tooltip", ["string", "JSX", null], null);
 	const popover = boolean("Popover", false);
 	const popoverEvent = select("Popover event", ["onClick", "onHover"], "onClick");
@@ -127,22 +149,11 @@ export const Playground = (): ReactElement => {
 	const showMenuContent = boolean("Menu content", false);
 	const useIcon = buttonVariant === "icon" || showIcon;
 	const tooltipType = tooltip ? tooltip === "string" ? "Tooltip string" : <h2>Tooltip as an H2</h2> : undefined;
-	const show = {
-		"Undefined": undefined,
-		"True": true,
-		"False": false,
-		"Function that returns true": () => true,
-		"Function that returns false": () => false,
-		"Array of true values": [true, true, true],
-		"Array with one falsy value": [true, false, true],
-		"Array of functions that return true": [() => true, () => true],
-		"Array of functions, one returns false": [() => false, () => true],
-	};
 
 	const action = {
 		name: "show",
 		onClick: () => alert("Clicked"),
-		show: show[showOptions],
+		show: showMap[show],
 		color: buttonColor,
 		variant: buttonVariant,
 	};
@@ -161,7 +172,7 @@ export const Playground = (): ReactElement => {
 						variant={buttonVariant}
 						color={buttonColor}
 						fullWidth={fullWidth}
-						disabled={disabled}
+						disabled={disabledMap[disabled]}
 						tooltip={tooltipType}
 						size={size}
 						mIcon={useIcon && AddIcon}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -27,10 +27,12 @@ const ButtonBase = forwardRef<HTMLButtonElement, ButtonProps>(function ButtonBas
 	const isIconButton = props.variant === "icon";
 	const adornmentIcon = Icon && <Icon className="adornment-icon" style={{ color: props.mIconColor }} />;
 
+	const shouldDisable = useToggle(props, "disabled", false);
+
 	const buttonProps = {
 		$variant: props.variant,
 		$color: props.color || "gray",
-		disabled: props.disabled,
+		disabled: shouldDisable,
 		size: props.size,
 		$size: props.size,
 		onClick: props.onClick,

--- a/src/components/Button/ButtonTypes.tsx
+++ b/src/components/Button/ButtonTypes.tsx
@@ -12,7 +12,7 @@ export interface ButtonProps {
 	variant: "icon" | "outlined" | "contained" | "text";
 	size?: "small" | "medium";
 	iconPosition?: "left" | "right";
-	disabled?: boolean;
+	disabled?: MosaicToggle;
 	/** Button will occupy 100% of the width provided to it */
 	fullWidth?: boolean;
 	/** Display a tooltip on hover of the button */

--- a/src/utils/toggle/getToggle.ts
+++ b/src/utils/toggle/getToggle.ts
@@ -4,13 +4,19 @@ function getToggle(toggle?: MosaicToggle, defaultToggle = true): boolean {
 	const toggleDefined = toggle !== undefined ? toggle : defaultToggle;
 	const conditions = Array.isArray(toggleDefined) ? toggleDefined : [toggleDefined];
 
-	return conditions.every(condition => {
+	const callback: (condition: boolean | (() => boolean)) => boolean = condition => {
 		if (typeof condition === "function") {
 			return condition();
 		} else {
 			return condition;
 		}
-	});
+	};
+
+	if (defaultToggle) {
+		return conditions.every(callback);
+	}
+
+	return conditions.some(callback);
 }
 
 export default getToggle;

--- a/src/utils/toggle/useToggle.ts
+++ b/src/utils/toggle/useToggle.ts
@@ -3,13 +3,21 @@ import getToggle from "./getToggle";
 
 /**
  * A way of conditionally rendering an item or items based on their
- * "show" condition.
+ * toggle condition.
  *
- * Takes a single item or array of items containing a show property that
- * is of type MosaicToggle. It returns either true or false if a single item
+ * Takes a single item or array of items containing a toggle property that
+ * is of type `MosaicToggle`. It returns either true or false if a single item
  * is provided, or the filtered array if an array is provided.
  *
+ * If an array MosaicToggle is provided, the resulting toggle is based on whether
+ * or not the `defaultToggle` property is true or false. If `true`, the resulting
+ * toggle will be `true` if **all** of the evaluated array items are true. If `false`,
+ * that will be inverted and the resulting toggle will be `true` if **at least one**
+ * of the evaluated array items are true.
+ *
  * @param items The item or items containing the show property
+ * @param key The property that holds a valid toggle boolean/callback/array
+ * @param defaultToggle What the result should fall back to when the toggle property is undefined. Default `true`.
  */
 function useToggle<K extends keyof T, T extends { [key in K]?: MosaicToggle }>(items: T[], key: K, defaultToggle?: boolean): T[];
 function useToggle<K extends keyof T, T extends { [key in K]?: MosaicToggle }>(items: T, key: K, defaultToggle?: boolean): boolean;

--- a/src/utils/toggle/useWrappedToggle.ts
+++ b/src/utils/toggle/useWrappedToggle.ts
@@ -4,6 +4,16 @@ import { MosaicToggle } from "@root/types";
 import wrapToggle from "./wrapToggle";
 import useToggle from "./useToggle";
 
+/**
+ * The same as `useToggle` but also accepts a context against which
+ * to test any toggle callbacks. The context will be provided as the
+ * first parameter to the toggle callbacks at the time of each test.
+ *
+ * @param items The item or items containing the show property
+ * @param params The context to be provided to any toggle callbacks
+ * @param key The property that holds a valid toggle boolean/callback/array
+ * @param defaultToggle What the result should fall back to when the toggle property is undefined. Default `true`.
+ */
 function useWrappedToggle<K extends keyof T, T extends { [key in K]?: MosaicToggle<P> }, P>(
 	items: T[],
 	params: P,


### PR DESCRIPTION
This employs the toggle mechanic for the `Button` disabled property. It also inverts toggle's behaviour when dealing with arrays of conditions, evaluating in an inverse nature (_some_ instead of _every_) if the `defaultToggle` parameter is `false` instead of `true`.