### PR TITLE
MOS-1268 Drop menu props validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
 		"@simpleview/react-phone-input-2": "^2.15.3",
 		"date-fns": "^2.29.1",
 		"jodit": "3.19.3",
-		"jsvalidator": "1.2.0",
 		"lodash": "^4.17.15"
 	},
 	"peerDependencies": {

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import jsvalidator from "jsvalidator";
 
 import MenuBase from "../MenuBase";
 import MenuItem, { MenuItemProps } from "../MenuItem";
@@ -12,67 +11,6 @@ export interface MenuProps {
 }
 
 function Menu(props: MenuProps) {
-	jsvalidator.validate(props, {
-		type : "object",
-		schema : [
-			{
-				name : "items",
-				type : "array",
-				schema : {
-					type : "object",
-					schema : [
-						{
-							name : "label",
-							type : "string",
-						},
-						{
-							name : "color",
-							type : "string",
-							enum : ["blue", "red", "black"],
-						},
-						{
-							name : "mIcon",
-							type : "object",
-						},
-						{
-							name : "disabled",
-							type : "boolean",
-						},
-						{
-							name : "selected",
-							type : "boolean",
-						},
-						{
-							name : "onClick",
-							type : "function",
-						},
-						{
-							name : "attrs",
-							type : "object",
-						},
-					],
-					allowExtraKeys : false,
-				},
-			},
-			{
-				name : "anchorEl",
-				type : "object",
-			},
-			{
-				name : "open",
-				type : "boolean",
-				required : true,
-			},
-			{
-				name : "onClose",
-				type : "function",
-				required : true,
-			},
-		],
-		allowExtraKeys : false,
-		throwOnInvalid : true,
-	});
-
 	const menuItems = props.items.map((item, i) => {
 		const onClick = function() {
 			item.onClick();

--- a/src/components/SummaryPageTopComponent/SummaryPageTopComponent.stories.tsx
+++ b/src/components/SummaryPageTopComponent/SummaryPageTopComponent.stories.tsx
@@ -61,27 +61,22 @@ export const Example = (): ReactElement => {
 		},
 	];
 
-	const additionalActions: MenuItemProps[] = [
+	const additionalActions: MenuItemProps[] = useMemo(() => [
 		{
 			label : "Edit",
 			onClick : function() {
 				alert("EDIT CLICK");
 			},
+			show: additionalActionsKnob !== "undefined" && Number(additionalActionsKnob) > 0,
 		},
 		{
 			label : "Download",
 			onClick : function() {
 				alert("DOWNLOAD CLICK");
 			},
+			show: additionalActionsKnob !== "undefined" && Number(additionalActionsKnob) > 1,
 		},
-	];
-
-	const slicedAdditionalActions = useMemo(() => {
-		if (additionalActionsKnob === "undefined") return undefined;
-
-		const amountActions = Number(additionalActionsKnob);
-		return additionalActions.slice(0, amountActions);
-	}, [additionalActionsKnob, additionalActions]);
+	], [additionalActionsKnob]);
 
 	const textLinks = [
 		{
@@ -150,7 +145,7 @@ export const Example = (): ReactElement => {
 			favorite={showFavorite && favorite}
 			img={img && "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1436900668/clients/grandrapids/Covered%20bridge%20in%20Ada_19c2ee0d-a43b-4aab-b102-65a0db32288b.jpg"}
 			mainActions={showMainActions && mainActions}
-			additionalActions={slicedAdditionalActions}
+			additionalActions={additionalActions}
 			descriptionItems={showDescription && descriptionItems}
 		/>
 	);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4818,7 +4818,6 @@ __metadata:
     jest-fail-on-console: 2.4.2
     jodit: 3.19.3
     json-date-parser: 1.0.1
-    jsvalidator: 1.2.0
     lodash: ^4.17.15
     mocha: 5.2.0
     nanoid: 4.0.0
@@ -15871,13 +15870,6 @@ __metadata:
     is-promise: ^2.0.0
     promise: ^7.0.1
   checksum: 1e019fde17a38766a5b96bccf0738156badc60cfa61e2ba8a8bbd3b855e7d5d7e17492b8a66e4aaabc39483e335d23217343ae32d0f7e5a81af42a95c3e075f9
-  languageName: node
-  linkType: hard
-
-"jsvalidator@npm:1.2.0":
-  version: 1.2.0
-  resolution: "jsvalidator@npm:1.2.0"
-  checksum: d661b2ddd4d764465b8a7e7312c2520b696da6cfa81da021c6371d4ae51a8d73445b50d2f69051c534c7d8d863f0b1d1b674f6af3629dd3569a0914afc790268
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removes the runtime validation of `Menu` props and drops `jsvalidator` as a dependency since it is no longer in use.