### PR TITLE
MOS-1279 Map field thrown error

### DIFF
--- a/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocomplete.tsx
+++ b/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocomplete.tsx
@@ -39,7 +39,7 @@ const AddressAutocomplete = (props: AddressAutocompleteProps): ReactElement => {
 
 	const handleBlur = () => {
 		setAnchorEl(null);
-		onBlur();
+		onBlur && onBlur();
 	};
 
 	const inputProps = {

--- a/src/components/Field/FormFieldMapCoordinates/Map/Map.tsx
+++ b/src/components/Field/FormFieldMapCoordinates/Map/Map.tsx
@@ -33,6 +33,7 @@ const Map = (props: MapProps): ReactElement => {
 		focusZoom = 11,
 		onCoordinatesChange,
 		googleMapsApiKey,
+		onBlur,
 	} = props;
 
 	// State variables
@@ -91,6 +92,7 @@ const Map = (props: MapProps): ReactElement => {
 				className="mapCoordinates"
 				value={addressValue}
 				onChange={setAddressValue}
+				onBlur={onBlur}
 				onSelect={onSelect}
 				placeholder="Type a location, address or city…"
 				googleMapsApiKey={googleMapsApiKey}

--- a/src/components/Field/FormFieldMapCoordinates/Map/MapWithMarker.tsx
+++ b/src/components/Field/FormFieldMapCoordinates/Map/MapWithMarker.tsx
@@ -12,6 +12,7 @@ function MapWithMarker({
 	onCoordinatesChange,
 	value,
 	googleMapsApiKey,
+	onBlur,
 }: MapWithMarkerProps) {
 
 	return (
@@ -23,6 +24,7 @@ function MapWithMarker({
 				focusZoom={focusZoom}
 				onCoordinatesChange={onCoordinatesChange}
 				googleMapsApiKey={googleMapsApiKey}
+				onBlur={onBlur}
 			/>
 			<StyledSpan>
 				Click on the map to update the latitude and longitude coordinates

--- a/src/components/Field/FormFieldMapCoordinates/MapCoordinatesDrawer/MapCoordinatesDrawer.tsx
+++ b/src/components/Field/FormFieldMapCoordinates/MapCoordinatesDrawer/MapCoordinatesDrawer.tsx
@@ -174,13 +174,14 @@ const MapCoordinatesDrawer = (props: MapCoordinatesDrawerProps): ReactElement =>
 			[
 				{
 					name: "placesList",
-					type: ({ value }) => (
+					type: ({ value, onBlur }) => (
 						<MapWithMarker
 							zoom={zoom}
 							focusZoom={focusZoom}
 							initialCenter={initialCenter}
 							onCoordinatesChange={onCoordinatesChange}
 							value={value}
+							onBlur={onBlur}
 							googleMapsApiKey={googleMapsApiKey}
 						/>
 					),

--- a/src/components/Field/FormFieldMapCoordinates/MapCoordinatesTypes.ts
+++ b/src/components/Field/FormFieldMapCoordinates/MapCoordinatesTypes.ts
@@ -75,9 +75,11 @@ export interface MapProps {
 	onCoordinatesChange?: (coords: MapPosition) => void;
 
 	googleMapsApiKey: string;
+
+	onBlur?: () => void;
 }
 
-export type MapWithMarkerProps = Pick<MapProps, "zoom" | "focusZoom" | "onCoordinatesChange" | "value" | "initialCenter" | "googleMapsApiKey">;
+export type MapWithMarkerProps = Pick<MapProps, "zoom" | "focusZoom" | "onCoordinatesChange" | "value" | "initialCenter" | "googleMapsApiKey" | "onBlur">;
 
 export type ResetButtonProps = {
 	show?: boolean;


### PR DESCRIPTION
Ensures the `onBlur` handler is passed down from the map coordinate field's draw to the autocomplete field but also only invoke the `onBlur` handler if it is defined.