### PR TITLE
MOS-1281 Native form submit

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -39,6 +39,7 @@ const ButtonBase = forwardRef<HTMLButtonElement, ButtonProps>(function ButtonBas
 		onBlur: props.onBlur,
 		href: props.href,
 		name: props.name,
+		type: props.type || "button",
 		ref,
 		...props.muiAttrs,
 	};

--- a/src/components/Button/ButtonTypes.tsx
+++ b/src/components/Button/ButtonTypes.tsx
@@ -33,6 +33,7 @@ export interface ButtonProps {
 	muiAttrs?: MosaicObject;
 	show?: MosaicToggle;
 	component?: React.ComponentType;
+	type?: "button" | "submit";
 }
 
 export interface ButtonPopoverContextProps {

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -51,6 +51,7 @@ const Form = (props: FormProps) => {
 		fullHeight = true,
 		spacing = "normal",
 		useSectionHash = "section",
+		onSubmit,
 	} = props;
 
 	/**
@@ -229,6 +230,11 @@ const Form = (props: FormProps) => {
 		loadFormValues();
 	}, [getFormValues]);
 
+	const onSubmitProxy = useCallback<React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>["onSubmit"]>((e) => {
+		e.preventDefault();
+		onSubmit(e);
+	}, [onSubmit]);
+
 	return (
 		<>
 			<StyledContainerForm
@@ -240,7 +246,7 @@ const Form = (props: FormProps) => {
 				aria-label={title}
 				$fullHeight={fullHeight}
 			>
-				<StyledForm autoComplete="off">
+				<StyledForm autoComplete="off" onSubmit={onSubmitProxy}>
 					{title && (
 						<Top
 							title={title}

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -232,7 +232,7 @@ const Form = (props: FormProps) => {
 
 	const onSubmitProxy = useCallback<React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>["onSubmit"]>((e) => {
 		e.preventDefault();
-		onSubmit(e);
+		onSubmit && onSubmit(e);
 	}, [onSubmit]);
 
 	return (

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -230,7 +230,7 @@ const Form = (props: FormProps) => {
 		loadFormValues();
 	}, [getFormValues]);
 
-	const onSubmitProxy = useCallback<React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>["onSubmit"]>((e) => {
+	const onSubmitProxy = useCallback<FormProps["onSubmit"]>((e) => {
 		e.preventDefault();
 		onSubmit && onSubmit(e);
 	}, [onSubmit]);

--- a/src/components/Form/FormTypes.tsx
+++ b/src/components/Form/FormTypes.tsx
@@ -38,7 +38,8 @@ export interface FormProps {
 	scrollSpyThreshold?: number;
 	fullHeight?: boolean;
 	spacing?: FormSpacing;
-	useSectionHash?: string | false
+	useSectionHash?: string | false;
+	onSubmit?: React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>["onSubmit"];
 }
 
 export interface FieldError {

--- a/src/components/Form/stories/QuickSubmitForm.stories.tsx
+++ b/src/components/Form/stories/QuickSubmitForm.stories.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { ReactElement, useEffect, useMemo } from "react";
+
+// Utils
+import { formActions, useForm } from "@root/components/Form";
+
+// Components
+import Form from "../Form";
+
+// Types
+import { FieldDef } from "@root/components/Field";
+
+import { ORIGINAL_BODY_MARGIN } from "./utils";
+import { ButtonProps } from "@root/components/Button";
+
+export default {
+	title: "Components/Form",
+};
+
+export const QuickSubmit = (): ReactElement => {
+	const { state, dispatch } = useForm();
+
+	useEffect(() => {
+		document.body.style.margin = "0px";
+
+		return () => {
+			document.body.style.margin = ORIGINAL_BODY_MARGIN;
+		};
+	}, []);
+
+	const fields = useMemo(
+		(): FieldDef[] =>
+			[
+				{
+					name: "firstName",
+					label: "First Name",
+					type: "text",
+				},
+				{
+					name: "lastName",
+					label: "Last Name",
+					type: "text",
+				},
+			],
+		[],
+	);
+
+	const buttons = useMemo<ButtonProps[]>(() => [
+		{
+			label: "Save",
+			color: "yellow",
+			variant: "contained",
+			type: "submit",
+		},
+	], []);
+
+	const onSubmit = async () => {
+		const { valid, data } = await dispatch(formActions.submitForm());
+		if (!valid) return;
+
+		alert("Form submitted with the following data: " + JSON.stringify(data, null, " "));
+	};
+
+	return (
+		<div style={{ height: "100vh" }}>
+			<Form
+				buttons={buttons}
+				title="Quick Submit"
+				state={state}
+				fields={fields}
+				dispatch={dispatch}
+				onSubmit={onSubmit}
+			/>
+		</div>
+	);
+};


### PR DESCRIPTION
Includes the following to support native HTML form submission behaviour:

- Adds an `onSubmit` property to be provided to `Form` which will pass through to the integrated HTML `form` element
- Adds a `type` property to the `Button` component which will pass through to the integrated HTML `button` element. It can be `"submit"` or `"button"` but will be `"button"` by default.

Default form submission behaviour is always prevented.