### PR TITLE
MOS-1286 Meaningful ButtonRow item key

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -39,6 +39,7 @@ const ButtonBase = forwardRef<HTMLButtonElement, ButtonProps>(function ButtonBas
 		onBlur: props.onBlur,
 		href: props.href,
 		name: props.name,
+		id: props.id,
 		type: props.type || "button",
 		ref,
 		...props.muiAttrs,

--- a/src/components/Button/ButtonTypes.tsx
+++ b/src/components/Button/ButtonTypes.tsx
@@ -34,6 +34,7 @@ export interface ButtonProps {
 	show?: MosaicToggle;
 	component?: React.ComponentType;
 	type?: "button" | "submit";
+	id?: string;
 }
 
 export interface ButtonPopoverContextProps {

--- a/src/components/ButtonRow/ButtonRow.tsx
+++ b/src/components/ButtonRow/ButtonRow.tsx
@@ -13,9 +13,9 @@ function ButtonRowWrapper({ className, wrap, children, separator }: ButtonsRowWr
 
 	return (
 		<Row className={className} $wrap={wrap} data-testid="button-row" role="toolbar">
-			{children.map((elem: React.ReactNode, i: number) => (
-				<Item key={i} $separator={separator}>
-					{elem}
+			{children.map(({ item, key }) => (
+				<Item key={key} $separator={separator}>
+					{item}
 				</Item>
 			))}
 		</Row>
@@ -25,11 +25,10 @@ function ButtonRowWrapper({ className, wrap, children, separator }: ButtonsRowWr
 function ButtonRowWithDef(props: Omit<ButtonRowProps, "children">) {
 	const buttons = useMemo(() => props.buttons || [], [props.buttons]);
 	const shownButtons = useToggle(buttons, "show");
-	const children = useMemo(() => shownButtons.map((button, i) => {
-		return (
-			<Button key={i} {...button} />
-		);
-	}), [shownButtons]);
+	const children = useMemo(() => shownButtons.map((button) => ({
+		item: <Button {...button} />,
+		key: `${typeof button.label === "string" ? button.label : ""}-${button.name}`,
+	})), [shownButtons]);
 
 	return (
 		<ButtonRowWrapper {...props}>
@@ -38,8 +37,15 @@ function ButtonRowWithDef(props: Omit<ButtonRowProps, "children">) {
 	);
 }
 
+function isReactElement(elem: React.ReactNode): elem is React.ReactElement {
+	return typeof elem === "object" && elem !== null && "key" in elem;
+}
+
 function ButtonRowWithChildren(props: Omit<ButtonRowProps, "buttons">) {
-	const children = useMemo(() => React.Children.toArray(props.children), [props.children]);
+	const children = useMemo(() => React.Children.toArray(props.children).map((item, index) => ({
+		item,
+		key: isReactElement(item) ? item.key : index,
+	})), [props.children]);
 
 	return (
 		<ButtonRowWrapper {...props}>

--- a/src/components/ButtonRow/ButtonRow.tsx
+++ b/src/components/ButtonRow/ButtonRow.tsx
@@ -25,9 +25,9 @@ function ButtonRowWrapper({ className, wrap, children, separator }: ButtonsRowWr
 function ButtonRowWithDef(props: Omit<ButtonRowProps, "children">) {
 	const buttons = useMemo(() => props.buttons || [], [props.buttons]);
 	const shownButtons = useToggle(buttons, "show");
-	const children = useMemo(() => shownButtons.map((button) => ({
+	const children = useMemo(() => shownButtons.map((button, index) => ({
 		item: <Button {...button} />,
-		key: button.id || [button.label, button.name].filter(Boolean).join("-"),
+		key: button.id || [button.label, button.name].filter(Boolean).join("-") || index,
 	})), [shownButtons]);
 
 	return (

--- a/src/components/ButtonRow/ButtonRow.tsx
+++ b/src/components/ButtonRow/ButtonRow.tsx
@@ -27,7 +27,7 @@ function ButtonRowWithDef(props: Omit<ButtonRowProps, "children">) {
 	const shownButtons = useToggle(buttons, "show");
 	const children = useMemo(() => shownButtons.map((button) => ({
 		item: <Button {...button} />,
-		key: `${typeof button.label === "string" ? button.label : ""}-${button.name}`,
+		key: button.id || [button.label, button.name].filter(Boolean).join("-"),
 	})), [shownButtons]);
 
 	return (

--- a/src/components/ButtonRow/ButtonRowTypes.ts
+++ b/src/components/ButtonRow/ButtonRowTypes.ts
@@ -2,7 +2,10 @@ import React from "react";
 import { ButtonProps } from "../Button";
 
 export type ButtonsRowWrapperProps = Pick<ButtonRowProps, "className" | "wrap" | "separator"> & {
-	children: ReturnType<typeof React.Children.toArray>;
+	children: {
+		item: ReturnType<typeof React.Children.toArray>[number];
+		key: number | string;
+	}[];
 };
 
 export type ButtonRowWithDefProps = Omit<ButtonRowProps, "children" | "buttons"> & {

--- a/src/components/Form/stories/Playground.stories.tsx
+++ b/src/components/Form/stories/Playground.stories.tsx
@@ -468,6 +468,7 @@ export const Playground = (): ReactElement => {
 
 	const buttons = useMemo<ButtonProps[]>(() => [
 		{
+			name: "reset",
 			label: "Reset",
 			onClick: () => reset(),
 			color: "gray",


### PR DESCRIPTION
Items that are rendered as a part of the `ButtonRow` component are now given a meaningful key where available:

- If the` ButtonProps` variation is used:
  - Optionally accept an `id` property for `ButtonProps`, if provided this will always be used as the `key`
  - If no `id` is provided in the `ButtonProps` object, then use a combination of the `label` (if it is a string) and `name` properties.
- If the `children` variation is used, extract the key from each child if it is a valid `ReactElement`
- As a last resort, uses the item’s index.

If button rows are expected to change order throughout their lifecycle, products should not allow the key to fall back to their indexes.