### PR TITLE
MOS-1269 Form initial value loading state

### DIFF
--- a/src/components/Form/stories/Playground.stories.tsx
+++ b/src/components/Form/stories/Playground.stories.tsx
@@ -472,9 +472,10 @@ export const Playground = (): ReactElement => {
 			onClick: () => reset(),
 			color: "gray",
 			variant: "outlined",
+			show: !state.loadingInitial,
 		},
 		...renderButtons(handleSubmit, { showCancel, showSave }),
-	], [handleSubmit, reset, showCancel, showSave]);
+	], [handleSubmit, reset, showCancel, showSave, state.loadingInitial]);
 
 	return (
 		<div style={{ boxShadow: "0 1px 2px 0 rgb(0 0 0 / 0.05)", height: containerHeight }}>

--- a/src/components/Form/useForm/initial.ts
+++ b/src/components/Form/useForm/initial.ts
@@ -8,6 +8,7 @@ export const initialState: FormState = {
 	touched: {},
 	submitWarning: { open: false, lead: "", reasons: [] },
 	waits: [],
+	loadingInitial: true,
 };
 
 export const initialStable: FormStable = {
@@ -18,4 +19,5 @@ export const initialStable: FormStable = {
 	internalValidators: {},
 	hasBlurred: {},
 	moveToError: false,
+	loadingInitial: true,
 };

--- a/src/components/Form/useForm/types.ts
+++ b/src/components/Form/useForm/types.ts
@@ -3,8 +3,6 @@ import { FieldDef } from "../FormTypes";
 import { FieldDefSanitized } from "@root/components/Field";
 
 export type ActionTypes =
-    | "FIELD_ON_CHANGE"
-    | "FIELDS_ON_CHANGE"
     | "FIELD_TOUCHED"
     | "FIELD_VALIDATE"
     | "FIELD_UNVALIDATE"
@@ -30,6 +28,15 @@ export type ActionSetFieldErrors = {
 	moveToError?: boolean;
 };
 
+export type ActionSetFieldValues = {
+	type: "SET_FIELD_VALUES";
+	values: MosaicObject<string>;
+	internalValues: MosaicObject<string>;
+	merge?: boolean;
+	touched?: boolean;
+	loadingInitial?: boolean;
+};
+
 export type ActionSetFormWaits = {
 	type: "SET_FORM_WAITS";
 	waits: FormWait[];
@@ -47,6 +54,7 @@ export type ActionSetSubmitWarning = FormState["submitWarning"] & {
 
 export type FormAction =
 	| ActionSetFieldErrors
+	| ActionSetFieldValues
 	| ActionSetFormWaits
 	| ActionReset
 	| ActionSetSubmitWarning
@@ -200,6 +208,7 @@ export type FormState = {
 	touched: MosaicObject<boolean>;
 	submitWarning: { open: boolean; lead: string; reasons: string[] };
 	waits: FormWait[];
+	loadingInitial: boolean;
 };
 
 export type UseFormReturn = {

--- a/src/components/Form/useForm/useForm.ts
+++ b/src/components/Form/useForm/useForm.ts
@@ -177,10 +177,10 @@ export function useForm(): UseFormReturn {
 		}
 
 		return dispatch({
-			type: "FIELDS_ON_CHANGE",
-			value: values,
-			internalValue: internalValues,
-			clearErrors: true,
+			type: "SET_FIELD_VALUES",
+			values,
+			internalValues: internalValues,
+			loadingInitial: !initial,
 		});
 	}, [getFieldFromExtra]);
 
@@ -238,14 +238,15 @@ export function useForm(): UseFormReturn {
 
 		const providedValueResolved = typeof providedValue === "function" ? providedValue(data[name]) : providedValue;
 		const { internalValue, value } = field.getResolvedValue(providedValueResolved);
+		const cleanedValue = cleanValue(value);
 
-		stable.current.data[name] = value;
+		stable.current.data[name] = cleanedValue;
 
 		dispatch({
-			type: "FIELD_ON_CHANGE",
-			name,
-			internalValue,
-			value: cleanValue(value),
+			type: "SET_FIELD_VALUES",
+			values: { [name]: cleanedValue },
+			internalValues: { [name]: internalValue },
+			merge: true,
 			touched,
 		});
 

--- a/src/components/Form/useForm/utils.ts
+++ b/src/components/Form/useForm/utils.ts
@@ -17,7 +17,7 @@ import {
 	Validator,
 } from "./types";
 
-export const cleanValue = (value: unknown) => {
+export const cleanValue = (value: any) => {
 	if (value === "" || (Array.isArray(value) && value.length === 0)) {
 		return undefined;
 	}
@@ -33,6 +33,7 @@ export function stateFromStable({
 	touched,
 	submitWarning,
 	waits,
+	loadingInitial,
 }: FormStable): FormState {
 	return {
 		internalData,
@@ -42,6 +43,7 @@ export function stateFromStable({
 		touched,
 		submitWarning,
 		waits,
+		loadingInitial,
 	};
 }
 


### PR DESCRIPTION
Introduces a `loadingInitial` property on the form's state. This is a `boolean` property that always starts out as `true`. It will be changed to `false` once the form mounts. If a `getFormValues` callback has been provided to the form component, it will change to `true` after the returned promise has resolved.