### PR TITLE
MOS-1280 Hides action column when no row actions are available

### DIFF
--- a/src/components/DataView/DataView.stories.tsx
+++ b/src/components/DataView/DataView.stories.tsx
@@ -411,6 +411,7 @@ export const Playground = (): ReactElement => {
 	const onBack = boolean("onBack", false);
 	const savedViewAllowSharedViewSave = boolean("savedViewAllowSharedViewSave", true);
 	const bulkActions = boolean("bulkActions", true);
+	const accessibilityAction = boolean("accessibilityAction", true);
 	const bulkAllActions = boolean("bulkAllActions", true);
 	const primaryActions = boolean("primaryActions", true);
 	const additionalActions = boolean("additionalActions", true);
@@ -569,7 +570,7 @@ export const Playground = (): ReactElement => {
 		onBack: onBack ? () => alert("Cancelling, going back to previous site") : undefined,
 		columns: (display === "list" || display === undefined) ? listColumns : gridColumns,
 		gridColumnsMap,
-		primaryActions: primaryActions ? [
+		primaryActions: [
 			{
 				name: "edit",
 				color: "black",
@@ -578,7 +579,7 @@ export const Playground = (): ReactElement => {
 				onClick: function ({ data }) {
 					alert(`EDIT ${data.id}`);
 				},
-				show: ({ row }) => row.title !== "Accessibility",
+				show: ({ row }) => primaryActions && row.title !== "Accessibility",
 			},
 			{
 				name: "accessibility",
@@ -588,17 +589,17 @@ export const Playground = (): ReactElement => {
 				onClick: function ({ data }) {
 					alert(`ACCESSIBLE ${data.id}`);
 				},
-				show: ({ row }) => row.title === "Accessibility",
+				show: ({ row }) => accessibilityAction && row.title === "Accessibility",
 			},
-		] : undefined,
-		additionalActions: additionalActions ? [
+		],
+		additionalActions: [
 			{
 				name: "view_children",
 				label: "View Children",
 				onClick: function ({ data }) {
 					alert(`View Children ${data.id}`);
 				},
-				show: ({ row }) => row.title !== "Accessibility",
+				show: ({ row }) => additionalActions && row.title !== "Accessibility",
 			},
 			{
 				name: "history",
@@ -606,9 +607,9 @@ export const Playground = (): ReactElement => {
 				onClick: function ({ data }) {
 					alert(`History ${data.id}`);
 				},
-				show: ({ row }) => row.title !== "Accessibility",
+				show: ({ row }) => additionalActions && row.title !== "Accessibility",
 			},
-		] : undefined,
+		],
 		bulkActions: bulkActions ? [
 			{
 				name: "download",

--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -5,9 +5,9 @@ import styled from "styled-components";
 import DataViewTitleBar from "./DataViewTitleBar";
 import theme from "@root/theme";
 import { DataViewDisplayList, DataViewDisplayGrid } from "./DataViewDisplays";
-import { DataViewProps, StateViewDef } from "./DataViewTypes";
+import { DataViewProps, DataViewRowActions, StateViewDef } from "./DataViewTypes";
 import DataViewActionsRow from "./DataViewActionsRow";
-import { useWrappedToggle } from "@root/utils/toggle";
+import { getToggle, useWrappedToggle, wrapToggle } from "@root/utils/toggle";
 
 const StyledWrapper = styled.div`
 	font-family: ${theme.fontFamily};
@@ -268,6 +268,16 @@ const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (pr
 
 	const actionsHidden = (props.checked || []).some(checked => checked);
 
+	const rowActions = useMemo<DataViewRowActions>(() => {
+		return props.data.reduce((acc, curr) => ({
+			...acc,
+			[curr.id as string]: {
+				primary: props.primaryActions ? props.primaryActions.filter(action => getToggle(wrapToggle(action.show, { row: curr }, true))) : [],
+				additional: props.additionalActions ? props.additionalActions.filter(action => getToggle(wrapToggle(action.show, { row: curr }, true))) : [],
+			},
+		}), {});
+	}, [props.data, props.additionalActions, props.primaryActions]);
+
 	return (
 		<StyledWrapper
 			className={`
@@ -344,9 +354,8 @@ const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (pr
 					bulkActions={shownBulkActions}
 					sort={props.sort}
 					data={props.data}
-					additionalActions={props.additionalActions}
 					disabled={props.disabled}
-					primaryActions={props.primaryActions}
+					rowActions={rowActions}
 					activeColumns={props.activeColumns}
 					gridColumnsMap={props.gridColumnsMap}
 					limit={props.limit}

--- a/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
+++ b/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
@@ -85,8 +85,8 @@ function DataViewDisplayGrid(props: DataViewDisplayGridProps) {
 									</div>
 									<div className="right">
 										<DataViewActionsButtonRow
-											primaryActions={props.primaryActions}
-											additionalActions={props.additionalActions}
+											primaryActions={props.rowActions?.[row.id as string]?.primary}
+											additionalActions={props.rowActions?.[row.id as string]?.additional}
 											actionsHidden={props.actionsHidden}
 											originalRowData={row}
 											activeDisplay="grid"

--- a/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGridTypes.ts
+++ b/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGridTypes.ts
@@ -1,4 +1,4 @@
-import { DataViewProps } from "../DataViewTypes";
+import { DataViewProps, DataViewRowActions } from "../DataViewTypes";
 
 export interface DataViewDisplayGridProps {
 	bulkActions?: DataViewProps["bulkActions"];
@@ -12,8 +12,7 @@ export interface DataViewDisplayGridProps {
 	onCheckAllPagesClick?: () => void;
 	onCheckboxClick?: (i: any) => void;
 	onSortChange?: DataViewProps["onSortChange"];
-	primaryActions?: DataViewProps["primaryActions"];
-	additionalActions?: DataViewProps["additionalActions"];
+	rowActions: DataViewRowActions;
 	actionsHidden?: boolean;
 	rowCount?: number;
 	sort?: DataViewProps["sort"];

--- a/src/components/DataView/DataViewDisplayList/DataViewDisplayList.tsx
+++ b/src/components/DataView/DataViewDisplayList/DataViewDisplayList.tsx
@@ -25,6 +25,7 @@ import DataViewTBody from "../DataViewTBody";
 import { transformRows } from "@root/utils/dataViewTools";
 import { DataViewDisplayListProps } from "./DataViewDisplayListTypes";
 import { restrictToBoundingRect } from "@root/utils/dom/restrictToBoundingRect";
+import { sum } from "@root/utils/math/sum";
 
 const StyledTable = styled.table`
 	width: 100%;
@@ -33,18 +34,13 @@ const StyledTable = styled.table`
 
 function DataViewDisplayList(props: DataViewDisplayListProps) {
 	const tBodyRef = useRef<HTMLTableSectionElement>();
-	const { primaryActions, additionalActions } = props;
+	const { rowActions } = props;
 	// execute the transforms in the rows
 	const transformedData = useMemo(() => {
 		return transformRows(props.data, props.activeColumnObjs);
 	}, [props.data, props.activeColumnObjs]);
 
-	const hasActions = useMemo(
-		() =>
-			(additionalActions && additionalActions.length > 0) ||
-			(primaryActions && primaryActions.length > 0),
-		[additionalActions, primaryActions],
-	);
+	const hasActions = sum(Object.entries(rowActions).map(([, { primary = [], additional = [] }]) => primary.length + additional.length)) > 0;
 
 	const sensors = useSensors(
 		useSensor(PointerSensor),
@@ -129,10 +125,9 @@ function DataViewDisplayList(props: DataViewDisplayListProps) {
 						hasActions={hasActions}
 						transformedData={transformedData}
 						bulkActions={props.bulkActions}
-						additionalActions={props.additionalActions}
 						actionsHidden={props.actionsHidden}
 						disabled={props.disabled}
-						primaryActions={props.primaryActions}
+						rowActions={rowActions}
 						onCheckboxClick={props.onCheckboxClick}
 						onReorder={props.onReorder}
 						ref={tBodyRef}

--- a/src/components/DataView/DataViewDisplayList/DataViewDisplayListTypes.ts
+++ b/src/components/DataView/DataViewDisplayList/DataViewDisplayListTypes.ts
@@ -1,4 +1,4 @@
-import { DataViewProps } from "../DataViewTypes";
+import { DataViewProps, DataViewRowActions } from "../DataViewTypes";
 
 export interface DataViewDisplayListProps {
 	activeColumns?: DataViewProps["activeColumns"];
@@ -15,9 +15,8 @@ export interface DataViewDisplayListProps {
 	onCheckAllClick?: () => void;
 	onCheckAllPagesClick?: () => void;
 	onColumnsChange?: DataViewProps["onColumnsChange"];
-	additionalActions?: DataViewProps["additionalActions"];
 	disabled?: DataViewProps["disabled"];
-	primaryActions?: DataViewProps["primaryActions"];
+	rowActions: DataViewRowActions;
 	onCheckboxClick?: (i: number) => void;
 	activeColumnObjs: DataViewProps["columns"];
 	anyChecked?: boolean;

--- a/src/components/DataView/DataViewTBody/DataViewTBody.tsx
+++ b/src/components/DataView/DataViewTBody/DataViewTBody.tsx
@@ -33,8 +33,8 @@ const DataViewTBody = forwardRef<HTMLTableSectionElement, DataViewTBodyProps>((p
 				key={row.id as string}
 				row={row}
 				originalRowData={props.data[i]}
-				primaryActions={props.primaryActions}
-				additionalActions={props.additionalActions}
+				primaryActions={props.rowActions?.[row.id as string]?.primary}
+				additionalActions={props.rowActions?.[row.id as string]?.additional}
 				actionsHidden={props.actionsHidden}
 				disabled={props.disabled}
 				onCheckboxClick={props.onCheckboxClick ? () => props.onCheckboxClick(i) : undefined}

--- a/src/components/DataView/DataViewTBody/DataViewTBodyTypes.ts
+++ b/src/components/DataView/DataViewTBody/DataViewTBodyTypes.ts
@@ -1,5 +1,5 @@
 import { MosaicObject } from "@root/types";
-import { DataViewProps } from "../DataViewTypes";
+import { DataViewProps, DataViewRowActions } from "../DataViewTypes";
 import { DataViewDisplayListProps } from "../DataViewDisplayList";
 
 export interface DataViewTBodyProps {
@@ -8,8 +8,7 @@ export interface DataViewTBodyProps {
 	transformedData: MosaicObject[];
 	data: DataViewProps["data"];
 	bulkActions?: DataViewProps["bulkActions"];
-	primaryActions?: DataViewProps["primaryActions"];
-	additionalActions?: DataViewProps["additionalActions"];
+	rowActions?: DataViewRowActions;
 	actionsHidden?: boolean;
 	disabled?: DataViewProps["disabled"];
 	checked?: DataViewProps["checked"];

--- a/src/components/DataView/DataViewTypes.ts
+++ b/src/components/DataView/DataViewTypes.ts
@@ -236,3 +236,8 @@ export interface DataViewProps {
 	onBack?: () => void;
 	backLabel?: TitleWrapperProps["backLabel"];
 }
+
+export type DataViewRowActions = Record<string, {
+	primary?: DataViewProps["primaryActions"];
+	additional?: DataViewProps["additionalActions"];
+}>;


### PR DESCRIPTION
Ensures that the actions column is not rendered if no row-specific actions (primary or additional) are available for any of the rows. This includes cases where no actions are available as a result of their `show` evaluation.