### PR TITLE
MOS-1282 Form auto focus

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -16,6 +16,7 @@ const Field = ({
 	id,
 	methods,
 	spacing,
+	inputRef,
 }: MosaicFieldProps<any>): ReactElement => {
 	const { mountField } = methods || {};
 	const fieldRef = useRef<HTMLDivElement | undefined>();
@@ -36,10 +37,11 @@ const Field = ({
 		const { unmount } = mountField({
 			name: fieldDef.name,
 			fieldRef: fieldRef.current,
+			inputRef: inputRef?.current,
 		});
 
 		return unmount;
-	}, [mountField, fieldDef?.name]);
+	}, [mountField, fieldDef.name, inputRef]);
 
 	return (
 		<StyledFieldContainer

--- a/src/components/Field/FieldTypes.tsx
+++ b/src/components/Field/FieldTypes.tsx
@@ -75,6 +75,11 @@ export interface MosaicFieldProps<T = any, U = any, V = any> {
 	 * Methods that can be used to manipulate the form
 	 */
 	methods?: FormMethods;
+	/**
+	 * Reference to the field control, i.e. the HTML input,
+	 * select or textarea element
+	 */
+	inputRef?: MutableRefObject<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>;
 }
 
 // SHARED FIELD DEFINITION - DEVELOPER GENERIC CONTRACT

--- a/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
@@ -26,6 +26,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		disabled,
 		error,
 		methods,
+		inputRef,
 	} = props;
 
 	const showTime = fieldDef?.inputSettings?.showTime;
@@ -140,6 +141,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 					value={value?.date}
 					onBlur={onBlurProxy("date")}
 					disabled={disabled}
+					inputRef={inputRef}
 
 				/>
 			</DateTimePickerWrapper>

--- a/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
@@ -14,7 +14,7 @@ import {
 import { DATE_FORMAT_FULL } from "@root/constants";
 
 const DateFieldPicker = (props: DatePickerProps): ReactElement => {
-	const { fieldDef, onChange, value = null, onBlur, disabled } = props;
+	const { fieldDef, onChange, value = null, onBlur, disabled, inputRef } = props;
 
 	const [isPickerOpen, setIsPickerOpen] = useState(false);
 
@@ -34,6 +34,7 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 			disabled={disabled}
 			inputProps={{
 				...params.inputProps,
+				ref: inputRef,
 				placeholder: fieldDef?.inputSettings?.placeholder,
 			}}
 		/>

--- a/src/components/Field/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
+++ b/src/components/Field/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
@@ -22,6 +22,7 @@ const DropdownSingleSelection = (props: MosaicFieldProps<"dropdown", DropdownSin
 		onBlur,
 		value,
 		disabled,
+		inputRef,
 	} = props;
 
 	const [isOpen, setIsOpen] = useState(false);
@@ -59,6 +60,7 @@ const DropdownSingleSelection = (props: MosaicFieldProps<"dropdown", DropdownSin
 				variant="outlined"
 				placeholder={fieldDef?.inputSettings?.placeholder}
 				required={fieldDef?.required}
+				inputProps={{ ref: inputRef }}
 			/>
 		</InputWrapper>
 	);

--- a/src/components/Field/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
+++ b/src/components/Field/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
@@ -52,18 +52,26 @@ const DropdownSingleSelection = (props: MosaicFieldProps<"dropdown", DropdownSin
 		}
 	}, [internalOptions, value, origin]);
 
-	const renderInput = (params) => (
-		<InputWrapper>
-			<TextField
-				{...params}
-				data-testid="textfield-test-id"
-				variant="outlined"
-				placeholder={fieldDef?.inputSettings?.placeholder}
-				required={fieldDef?.required}
-				inputProps={{ ref: inputRef }}
-			/>
-		</InputWrapper>
-	);
+	const renderInput = (params) => {
+		return (
+			<InputWrapper>
+				<TextField
+					{...params}
+					data-testid="textfield-test-id"
+					variant="outlined"
+					placeholder={fieldDef?.inputSettings?.placeholder}
+					required={fieldDef?.required}
+					inputProps={{
+						...params.inputProps,
+						ref: (el) => {
+							inputRef.current = el;
+							params.inputProps.ref.current = el;
+						},
+					}}
+				/>
+			</InputWrapper>
+		);
+	};
 
 	const handleOpen = () => {
 		setIsOpen(!isOpen);

--- a/src/components/Field/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
+++ b/src/components/Field/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
@@ -64,7 +64,10 @@ const DropdownSingleSelection = (props: MosaicFieldProps<"dropdown", DropdownSin
 					inputProps={{
 						...params.inputProps,
 						ref: (el) => {
-							inputRef.current = el;
+							if (inputRef) {
+								inputRef.current = el;
+							}
+
 							params.inputProps.ref.current = el;
 						},
 					}}

--- a/src/components/Field/FormFieldNumberTable/FormFieldNumberTable.tsx
+++ b/src/components/Field/FormFieldNumberTable/FormFieldNumberTable.tsx
@@ -29,7 +29,7 @@ const FormFieldNumberTable = (
 		NumberTableData
 	>,
 ): ReactElement => {
-	const { fieldDef, onChange, value, disabled } = props;
+	const { fieldDef, onChange, value, disabled, inputRef } = props;
 
 	const { inputSettings } = fieldDef;
 	const { displaySumColumn = true, displaySumRow = true } = inputSettings;
@@ -195,6 +195,10 @@ const FormFieldNumberTable = (
 											if (cellRefs?.current) {
 												cellRefs.current[rowIdx] = cellRefs.current[rowIdx] || [];
 												cellRefs.current[rowIdx][colIdx] = el;
+											}
+
+											if (!rowIdx && !colIdx && inputRef) {
+												inputRef.current = el;
 											}
 										}}
 										onKeyDown={(e) => onKeyDown(e, rowIdx, colIdx)}

--- a/src/components/Field/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
+++ b/src/components/Field/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
@@ -22,6 +22,7 @@ const FormFieldPhoneSelectionDropdown = (
 		onBlur,
 		value,
 		disabled,
+		inputRef,
 	} = props;
 
 	const [dialCode, setDialCode] = useState("");
@@ -50,6 +51,7 @@ const FormFieldPhoneSelectionDropdown = (
 				countryCodeEditable={false}
 				inputProps={{
 					required: fieldDef?.required,
+					ref: inputRef,
 				}}
 				tabbableDropdown={false}
 			/>

--- a/src/components/Field/FormFieldText/FormFieldText.tsx
+++ b/src/components/Field/FormFieldText/FormFieldText.tsx
@@ -19,6 +19,7 @@ const TextField = (
 		onBlur,
 		value,
 		disabled,
+		inputRef,
 	} = props;
 
 	const leadingElement = fieldDef?.inputSettings?.prefixElement
@@ -57,7 +58,7 @@ const TextField = (
 			placeholder={fieldDef?.inputSettings?.placeholder}
 			multiline={fieldDef?.inputSettings?.multiline}
 			fieldSize={fieldDef?.size}
-			InputProps={leadingElement}
+			InputProps={{ ...(leadingElement || {}), inputRef }}
 			required={fieldDef?.required}
 			type={fieldDef?.inputSettings?.type === "number" ? "text" : fieldDef?.inputSettings?.type}
 			minRows={fieldDef?.inputSettings?.minRows}

--- a/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
+++ b/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
@@ -36,7 +36,7 @@ const buttonList = [
 const FormFieldTextEditor = (
 	props: MosaicFieldProps<"textEditor", TextEditorInputSettings, TextEditorData>,
 ): ReactElement => {
-	const { fieldDef, onBlur, onChange, value, disabled, error } = props;
+	const { fieldDef, onBlur, onChange, value, disabled, error, inputRef } = props;
 
 	const {
 		inputSettings = {},
@@ -97,8 +97,10 @@ const FormFieldTextEditor = (
 			changeHandler(value);
 		});
 
+		inputRef.current = jodit.current.selection as any;
+
 		return () => jodit.current.destruct();
-	}, [onBlur, onChange, config]);
+	}, [onBlur, onChange, config, inputRef]);
 
 	/**
 	 * Ridiculous hack because Jodit sucks when trying

--- a/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
+++ b/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
@@ -97,7 +97,9 @@ const FormFieldTextEditor = (
 			changeHandler(value);
 		});
 
-		inputRef.current = jodit.current.selection as any;
+		if (inputRef) {
+			inputRef.current = jodit.current.selection as any;
+		}
 
 		return () => jodit.current.destruct();
 	}, [onBlur, onChange, config, inputRef]);

--- a/src/components/Field/FormFieldTime/TimeField/FormFieldTime.tsx
+++ b/src/components/Field/FormFieldTime/TimeField/FormFieldTime.tsx
@@ -23,6 +23,7 @@ const FormFieldTime = (props: MosaicFieldProps<"time", TimeFieldInputSettings, T
 		disabled,
 		error,
 		methods,
+		inputRef,
 	} = props;
 
 	const { addError, removeError } = useFieldErrors({
@@ -75,6 +76,7 @@ const FormFieldTime = (props: MosaicFieldProps<"time", TimeFieldInputSettings, T
 			value={value?.time}
 			onBlur={onBlur}
 			disabled={disabled}
+			inputRef={inputRef}
 		/>
 	);
 };

--- a/src/components/Field/FormFieldTime/TimePicker/TimePicker.tsx
+++ b/src/components/Field/FormFieldTime/TimePicker/TimePicker.tsx
@@ -14,7 +14,7 @@ import { TimePickerDef, TimePickerData } from "./TimePickerTypes";
 import { ThemeProvider } from "@mui/material/styles";
 
 const TimeFieldPicker = (props: MosaicFieldProps<"timePicker", TimePickerDef, TimePickerData>): ReactElement => {
-	const { fieldDef, onChange, value = null, onBlur, disabled } = props;
+	const { fieldDef, onChange, value = null, onBlur, disabled, inputRef } = props;
 
 	const [isPickerOpen, setIsPickerOpen] = useState(false);
 
@@ -37,6 +37,7 @@ const TimeFieldPicker = (props: MosaicFieldProps<"timePicker", TimePickerDef, Ti
 			inputProps={{
 				...params.inputProps,
 				placeholder: fieldDef?.inputSettings?.placeholder,
+				ref: inputRef,
 			}}
 		/>
 	);

--- a/src/components/Form/Col/ColField.tsx
+++ b/src/components/Form/Col/ColField.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo } from "react";
+import React, { memo, useCallback, useMemo, useRef } from "react";
 import { FieldDef } from "../FormTypes";
 import { getFieldConfig } from "./fieldConfigMap";
 import { ColFieldProps } from "./ColTypes";
@@ -31,6 +31,7 @@ const ColField = ({
 	}
 
 	const disabled = useWrappedToggle(field, state, "disabled", false);
+	const inputRef = useRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | undefined>();
 
 	const onChange = useCallback((value: any) => {
 		field.onChangeCb && field.onChangeCb();
@@ -71,6 +72,7 @@ const ColField = ({
 			ref={sanitizedFieldDef.ref}
 			disabled={disabled}
 			methods={methods}
+			inputRef={inputRef}
 		/>
 	), [
 		Component,
@@ -98,6 +100,7 @@ const ColField = ({
 			id={field.name}
 			spacing={spacing}
 			methods={methods}
+			inputRef={inputRef}
 		>
 			{children}
 		</Field>

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -87,6 +87,7 @@ This is the top level component that will render the various parts of your form,
 | `fullHeight` |  | `boolean` | Whether to have the form stretch to the full height of it's parent. (`height: 100%`). Defaults to true. |
 | `spacing` |  | `"normal"` or `"compact"` | What spacing to use for the form. Defaults to `"normal"` |
 | `useSectionHash` |  | `string` or `false` | The string that should be used to prefix the section index in the URL hash when scrolling. Provide `false` to disable the URL hash mechanic entirely. |
+| `autoFocus` |  | `boolean` | If true, once mounted, `Form` will attempt to automatically focus the user's cursor on the first field but only the first field is one of the following field types: `date`, `dropdown`, `numberTable`, `phone`, `text`, `textEditor`, `time`.. |
 
 ## Basic Usage
 In its simplest usage, the `Form` only needs an instance of the controller and an array of fields to work.

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -52,6 +52,7 @@ const Form = (props: FormProps) => {
 		onSubmit,
 		methods,
 		stable,
+		autoFocus,
 	} = props;
 
 	const { init, setFormValues, setSubmitWarning } = methods;
@@ -114,6 +115,32 @@ const Form = (props: FormProps) => {
 			target: mount.fieldRef,
 		});
 	}, [errors, moveToError, scrollTo, stable.fields, stable.mounted]);
+
+	const doneAutoFocus = useRef(false);
+
+	useEffect(() => {
+		if (!autoFocus || doneAutoFocus.current) {
+			return;
+		}
+
+		const [firstField] = Object.entries(stable.fields)
+			.filter(([, field]) => stable.mounted[field.name])
+			.map(([, field]) => field)
+			.sort(({ order: a }, { order: b }) => a - b);
+
+		if (!firstField) {
+			return;
+		}
+
+		const mount = stable.mounted[firstField.name];
+
+		if (!mount || typeof mount?.inputRef?.focus !== "function") {
+			return;
+		}
+
+		doneAutoFocus.current = true;
+		mount.inputRef.focus();
+	}, [autoFocus, stable.fields, stable.mounted]);
 
 	useEffect(() => {
 		if (!useSectionHash) {

--- a/src/components/Form/FormTypes.tsx
+++ b/src/components/Form/FormTypes.tsx
@@ -41,6 +41,7 @@ export interface FormProps {
 	useSectionHash?: string | false;
 	onSubmit?: React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>["onSubmit"];
 	methods: FormMethods;
+	autoFocus?: boolean;
 }
 
 export interface FieldError {

--- a/src/components/Form/stories/QuickSubmitForm.stories.tsx
+++ b/src/components/Form/stories/QuickSubmitForm.stories.tsx
@@ -67,6 +67,7 @@ export const QuickSubmit = (): ReactElement => {
 				title="Quick Submit"
 				fields={fields}
 				onSubmit={onSubmit}
+				autoFocus
 			/>
 		</div>
 	);

--- a/src/components/Form/useForm/types.ts
+++ b/src/components/Form/useForm/types.ts
@@ -144,6 +144,7 @@ export type DisableForm = (params: DisableFormParams) => void;
 export type MountFieldParams = {
 	name: string;
 	fieldRef?: HTMLDivElement;
+	inputRef?: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
 };
 
 export type UnmountField = () => void;
@@ -212,7 +213,7 @@ export type UseFormReturn = {
 export type FormStable = FormState & {
 	initialData: MosaicObject<any>;
 	fields: Record<string, FieldDefSanitized>;
-	mounted: Record<string, false | { fieldRef?: HTMLDivElement }>;
+	mounted: Record<string, false | { fieldRef?: HTMLDivElement; inputRef?: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement }>;
 	internalValidators: Record<string, ((value: any) => string | undefined)[]>;
 	hasBlurred: Record<string, boolean>;
 	moveToError: boolean;

--- a/src/components/Form/useForm/useForm.ts
+++ b/src/components/Form/useForm/useForm.ts
@@ -410,9 +410,10 @@ export function useForm(): UseFormReturn {
 		};
 	}, [removeWait]);
 
-	const mountField = useCallback<MountField>(({ name, fieldRef }) => {
+	const mountField = useCallback<MountField>(({ name, fieldRef, inputRef }) => {
 		stable.current.mounted[name] = {
 			fieldRef,
+			inputRef,
 		};
 
 		return {


### PR DESCRIPTION
Introduces the `autoFocus` property to the `Form` component. If true, once mounted, `Form` will attempt to automatically focus the user's cursor on the first field but only the first field is one of the following field types: `date`, `dropdown`, `numberTable`, `phone`, `text`, `textEditor`, `time`.