### PR TITLE
MOS-1150 Have form controls inherit form's disabled state

### DIFF
--- a/src/components/Form/Form.styled.ts
+++ b/src/components/Form/Form.styled.ts
@@ -9,11 +9,6 @@ export const StyledContainerForm = styled.div<{ $fullHeight?: boolean }>`
 	display: flex;
 	flex-direction: column;
 
-	&.disabled {
-		opacity: .5;
-		pointer-events: none;
-	}
-
 	container-type: inline-size;
 	container-name: ${CONTAINERS.FORM};
 
@@ -34,6 +29,7 @@ export const StyledFormContent = styled.div<{ $spacing?: FormSpacing }>`
 	flex-grow: 1;
 	min-width: 0;
 	padding: ${({ $spacing }) => $spacing === "compact" ? "16px" : "24px"};
+	position: relative;
 `;
 
 export const StyledFormPrimary = styled.div`
@@ -45,6 +41,14 @@ export const StyledFormPrimary = styled.div`
 	${containerQuery("xl", "FORM")} {
 		flex-direction: row;
 	}
+`;
+
+export const StyledFormOverlay = styled.div`
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 100%;
+	height: 100%;
 `;
 
 export const StyledSideNav = styled(SideNav)`

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -9,6 +9,7 @@ import {
 	StyledContainerForm,
 	StyledFormPrimary,
 	StyledSideNav,
+	StyledFormOverlay,
 } from "./Form.styled";
 import Layout from "./Layout";
 import Top from "./Top";
@@ -33,7 +34,7 @@ const sidebarCollapseContainer: MosaicCSSContainer = {
 
 const Form = (props: FormProps) => {
 	const {
-		buttons,
+		buttons: providedButtons,
 		state,
 		title,
 		onBack,
@@ -230,12 +231,21 @@ const Form = (props: FormProps) => {
 		onSubmit && onSubmit(e);
 	}, [onSubmit]);
 
+	const buttons = useMemo(() => providedButtons.map(button => ({
+		...button,
+		disabled: state.disabled ? true : button.disabled,
+	})), [state.disabled, providedButtons]);
+
+	const fieldsWithDisable = useMemo(() => fields.map(field => ({
+		...field,
+		disabled: state.disabled ? true : field.disabled,
+	})), [state.disabled, fields]);
+
 	return (
 		<>
 			<StyledContainerForm
 				data-testid="form-test-id"
 				ref={formContainerRef}
-				className={state.disabled ? "disabled" : ""}
 				aria-busy={isBusy ? "true" : "false"}
 				role="form"
 				aria-label={title}
@@ -267,11 +277,14 @@ const Form = (props: FormProps) => {
 							<Layout
 								registerRef={registerRef}
 								state={state}
-								fields={fields}
+								fields={fieldsWithDisable}
 								sections={shownSections}
 								spacing={spacing}
 								methods={methods}
 							/>
+							{state.disabled && (
+								<StyledFormOverlay />
+							)}
 						</StyledFormContent>
 					</StyledFormPrimary>
 				</StyledForm>

--- a/src/components/Form/stories/Playground.stories.tsx
+++ b/src/components/Form/stories/Playground.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ReactElement, useEffect, useMemo, useState, useCallback } from "react";
-import { withKnobs, boolean, object, text, select } from "@storybook/addon-knobs";
+import { withKnobs, boolean, object, text, select, number } from "@storybook/addon-knobs";
 
 // Utils
 import { checkboxOptions } from "@root/components/Field/FormFieldCheckbox/FormFieldCheckboxUtils";
@@ -60,6 +60,7 @@ export const Playground = (): ReactElement => {
 	const showState = boolean("Show state", false);
 	const onBack = boolean("onBack", false);
 	const prepopulate = boolean("Prepopulate", false);
+	const prepopulateDuration = number("Prepopulate Duration", 2);
 	const showGetFormValues = select("GetFormValues", ["None", "Returns Undefined", "Returns Data"], "Returns Data");
 	const showSave = boolean("Show SAVE button", true);
 	const showCancel = boolean("Show CANCEL button", true);
@@ -447,7 +448,7 @@ export const Playground = (): ReactElement => {
 	 * is disabled while fields values are being resolved.
 	 */
 	const getFormValues = useCallback(async () => {
-		await new Promise((res) => setTimeout(res, 1000));
+		await new Promise((res) => setTimeout(res, prepopulateDuration * 1000));
 
 		if (showGetFormValues === "Returns Undefined") {
 			return undefined;
@@ -456,7 +457,7 @@ export const Playground = (): ReactElement => {
 				...prepopulateValues,
 			};
 		}
-	}, [prepopulateValues, showGetFormValues]);
+	}, [prepopulateValues, showGetFormValues, prepopulateDuration]);
 
 	useEffect(() => {
 		const resetForm = async () => {

--- a/src/components/Form/useForm/initial.ts
+++ b/src/components/Form/useForm/initial.ts
@@ -4,7 +4,7 @@ export const initialState: FormState = {
 	internalData: {},
 	data: {},
 	errors: {},
-	disabled: false,
+	disabled: true,
 	touched: {},
 	submitWarning: { open: false, lead: "", reasons: [] },
 	waits: [],

--- a/src/components/Form/useForm/reducers.ts
+++ b/src/components/Form/useForm/reducers.ts
@@ -66,6 +66,7 @@ export function reducer(state: FormState, action: FormAction): FormState {
 			internalData: shallowEqual(updates.internalData, state.internalData) ? state.internalData : updates.internalData,
 			touched: shallowEqual(updates.touched, state.touched) ? state.touched : updates.touched,
 			loadingInitial: action.loadingInitial !== undefined ? action.loadingInitial : state.loadingInitial,
+			disabled: action.disabled !== undefined ? action.disabled : state.disabled,
 		};
 
 		if (shallowEqual(updatedState, state)) {

--- a/src/components/Form/useForm/types.ts
+++ b/src/components/Form/useForm/types.ts
@@ -35,6 +35,7 @@ export type ActionSetFieldValues = {
 	merge?: boolean;
 	touched?: boolean;
 	loadingInitial?: boolean;
+	disabled?: boolean;
 };
 
 export type ActionSetFormWaits = {

--- a/src/components/Form/useForm/useForm.ts
+++ b/src/components/Form/useForm/useForm.ts
@@ -174,6 +174,7 @@ export function useForm(): UseFormReturn {
 
 		if (initial) {
 			stable.current.initialData = { ...values };
+			stable.current.disabled = false;
 		}
 
 		return dispatch({
@@ -181,6 +182,7 @@ export function useForm(): UseFormReturn {
 			values,
 			internalValues: internalValues,
 			loadingInitial: !initial,
+			...(initial ? { disabled: false } : {}),
 		});
 	}, [getFieldFromExtra]);
 


### PR DESCRIPTION
Rather than lowering the opacity of the form and removing pointer events, this allows the input controls and buttons within to inherit the form state for true input prevention. In the future, this will be replaced by "skeleton" visuals as described in [MOS-1287](https://simpleviewtools.atlassian.net/browse/MOS-1287) as it provides better loading state indication and an all round smoother user experience.