### PR TITLE
MOS-1269 Loading state rework

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -56,7 +56,7 @@ const Form = (props: FormProps) => {
 		autoFocus,
 	} = props;
 
-	const { init, setFormValues, setSubmitWarning } = methods;
+	const { init, setFormValues, setSubmitWarning, disableForm } = methods;
 	const { errors } = state;
 	const { moveToError } = stable;
 
@@ -244,6 +244,8 @@ const Form = (props: FormProps) => {
 
 	useEffect(() => {
 		(async () => {
+			disableForm({ disabled: true });
+
 			const values = getFormValues ? (await getFormValues()) : {};
 
 			setFormValues({
@@ -251,7 +253,7 @@ const Form = (props: FormProps) => {
 				initial: true,
 			});
 		})();
-	}, [getFormValues, setFormValues]);
+	}, [disableForm, getFormValues, setFormValues]);
 
 	const onSubmitProxy = useCallback<FormProps["onSubmit"]>((e) => {
 		e.preventDefault();

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -244,7 +244,10 @@ const Form = (props: FormProps) => {
 
 	useEffect(() => {
 		(async () => {
-			disableForm({ disabled: true });
+			disableForm({
+				disabled: true,
+				initial: true,
+			});
 
 			const values = getFormValues ? (await getFormValues()) : {};
 

--- a/src/components/Form/stories/Playground.stories.tsx
+++ b/src/components/Form/stories/Playground.stories.tsx
@@ -96,6 +96,7 @@ export const Playground = (): ReactElement => {
 		"toggleSwitch": true,
 		"color": "#a8001791",
 		"date": new Date(),
+		"time": "16:30",
 		"address": [
 			{
 				"id": 1,
@@ -133,6 +134,27 @@ export const Playground = (): ReactElement => {
 				"value": "Image Video Thumbnail",
 			},
 		],
+		"imageUpload": {
+			imgName: "pexels-isaac-ramos-17583913.jpg",
+			size: 499318,
+			type: "image/jpeg",
+			height: 1080,
+			width: 1620,
+		},
+		"mapCoordinates": {
+			lat: 48.858384,
+			lng: 2.294567,
+		},
+		"upload": [
+			{
+				id: "_OD_0354_c78fbb66-c75a-4804-9430-9af38ed8e9d5.jpg",
+				name: "_OD_0354_c78fbb66-c75a-4804-9430-9af38ed8e9d5.jpg",
+				size: 499318,
+				thumbnailUrl: imageVideoSrc,
+				fileUrl: imageVideoSrc,
+			},
+		],
+		"textEditor": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet augue augue.",
 		"numberTable": numberTableDefaultValue,
 	});
 

--- a/src/components/Form/stories/Playground.stories.tsx
+++ b/src/components/Form/stories/Playground.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ReactElement, useEffect, useMemo, useState, useCallback } from "react";
+import { ReactElement, useEffect, useMemo, useCallback } from "react";
 import { withKnobs, boolean, object, text, select, number } from "@storybook/addon-knobs";
 
 // Utils
@@ -41,7 +41,6 @@ const createNewOption = async (newOptionLabel) => {
 };
 
 export const Playground = (): ReactElement => {
-	const [loadReady, setLoadReady] = useState(false);
 	const controller = useForm();
 	const { state, methods, handleSubmit } = controller;
 
@@ -61,7 +60,6 @@ export const Playground = (): ReactElement => {
 	const onBack = boolean("onBack", false);
 	const prepopulate = boolean("Prepopulate", false);
 	const prepopulateDuration = number("Prepopulate Duration", 2);
-	const showGetFormValues = select("GetFormValues", ["None", "Returns Undefined", "Returns Data"], "Returns Data");
 	const showSave = boolean("Show SAVE button", true);
 	const showCancel = boolean("Show CANCEL button", true);
 	const required = boolean("Required", true);
@@ -448,24 +446,16 @@ export const Playground = (): ReactElement => {
 	 * is disabled while fields values are being resolved.
 	 */
 	const getFormValues = useCallback(async () => {
+		if (!prepopulate) {
+			return;
+		}
+
 		await new Promise((res) => setTimeout(res, prepopulateDuration * 1000));
 
-		if (showGetFormValues === "Returns Undefined") {
-			return undefined;
-		} else {
-			return {
-				...prepopulateValues,
-			};
-		}
-	}, [prepopulateValues, showGetFormValues, prepopulateDuration]);
-
-	useEffect(() => {
-		const resetForm = async () => {
-			reset();
-			setLoadReady(true);
+		return {
+			...prepopulateValues,
 		};
-		prepopulate ? resetForm() : setLoadReady(false);
-	}, [reset, prepopulate, showGetFormValues, showDefaultValues]);
+	}, [prepopulate, prepopulateDuration, prepopulateValues]);
 
 	const buttons = useMemo<ButtonProps[]>(() => [
 		{
@@ -490,7 +480,7 @@ export const Playground = (): ReactElement => {
 				onBack={onBack ? () => alert("Cancelling, going back to previous site") : undefined}
 				description={text("Description", "This is a description example")}
 				fields={fields}
-				getFormValues={showGetFormValues === "None" ? undefined : (loadReady && getFormValues)}
+				getFormValues={getFormValues}
 				sections={showSections > 0 ? sectionsAmount : undefined}
 				buttons={buttons}
 				showActive={showActive}

--- a/src/components/Form/useForm/reducers.ts
+++ b/src/components/Form/useForm/reducers.ts
@@ -14,15 +14,20 @@ function touchedFromValues(values: MosaicObject<any>) {
 	}), {});
 }
 
-function shallowEqual<T extends MosaicObject>(obj1: T, obj2: T) {
-	if (obj1 === obj2) {
-		return true;
+function shallowEqual<T extends MosaicObject<any>>(objA: T, objB: T): boolean {
+	if (objA === null || objB === null || objA === undefined || objB === undefined) {
+		return false;
 	}
 
-	const entries = Object.entries(obj1);
+	const keysA = Object.keys(objA);
+	const keysB = Object.keys(objB);
 
-	for (const [key, value] of entries) {
-		if (obj2[key] !== value) {
+	if (keysA.length !== keysB.length) {
+		return false;
+	}
+
+	for (const key of keysA) {
+		if (objA[key] !== objB[key]) {
 			return false;
 		}
 	}

--- a/src/components/Form/useForm/reducers.ts
+++ b/src/components/Form/useForm/reducers.ts
@@ -91,6 +91,15 @@ export function reducer(state: FormState, action: FormAction): FormState {
 			...getInitialState(),
 			data: action.data,
 			internalData: action.internalData,
+			disabled: false,
+			loadingInitial: false,
+		};
+	}
+	case "FORM_DISABLE": {
+		return {
+			...state,
+			disabled: action.disabled,
+			loadingInitial: action.loadingInitial !== undefined ? action.loadingInitial : state.loadingInitial,
 		};
 	}
 	// LEGACY

--- a/src/components/Form/useForm/types.ts
+++ b/src/components/Form/useForm/types.ts
@@ -53,12 +53,19 @@ export type ActionSetSubmitWarning = FormState["submitWarning"] & {
 	type: "SET_SUBMIT_WARNING";
 };
 
+export type ActionDisable = {
+	type: "FORM_DISABLE";
+	disabled: boolean;
+	loadingInitial?: boolean;
+};
+
 export type FormAction =
 	| ActionSetFieldErrors
 	| ActionSetFieldValues
 	| ActionSetFormWaits
 	| ActionReset
 	| ActionSetSubmitWarning
+	| ActionDisable
     | LegacyFormAction;
 
 export type GetFieldErrorParams = {
@@ -146,6 +153,7 @@ export type AddWait = (params?: AddWaitParams) => AddWaitResult;
 
 export type DisableFormParams = {
 	disabled?: boolean;
+	initial?: boolean;
 };
 
 export type DisableForm = (params: DisableFormParams) => void;

--- a/src/components/Form/useForm/useForm.ts
+++ b/src/components/Form/useForm/useForm.ts
@@ -222,6 +222,8 @@ export function useForm(): UseFormReturn {
 			hasBlurred: {},
 			data: values,
 			internalData: internalValues,
+			disabled: false,
+			loadingInitial: false,
 		};
 
 		dispatch({
@@ -304,11 +306,13 @@ export function useForm(): UseFormReturn {
 	}, [getFieldFromExtra, validateField]);
 
 	const disableForm = useCallback<DisableForm>(({
-		disabled,
+		disabled = false,
+		initial,
 	}) => {
 		dispatch({
-			type: disabled ? "FORM_START_DISABLE" : "FORM_END_DISABLE",
-			value: disabled,
+			type: "FORM_DISABLE",
+			disabled,
+			loadingInitial: initial,
 		});
 	}, []);
 


### PR DESCRIPTION
- Adds populate values for fields that are missing initial data
- Ensures the disable dispatch that is invoked before loading the `getFormValues` result turns on the `loadingInitial` boolean.