### PR TITLE
MOS-1285 Prevent DatePicker from failing tests

### DIFF
--- a/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 import { ReactElement, useState } from "react";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
-import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+//import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { DesktopDatePicker as DatePicker } from "@mui/x-date-pickers/DesktopDatePicker";
 import { DatePickerProps } from ".";
 
 // Styles


### PR DESCRIPTION
Forces the date field to use the `DesktopDatePicker` rather than the `DatePicker` MUI component to avoid issues when testing caused by headless browsers not supporting the `(pointer: fine)` media query.