### PR TITLE
MOS-1181 AdvancedSelection limit figure

### DIFF
--- a/src/components/Field/Label.tsx
+++ b/src/components/Field/Label.tsx
@@ -73,7 +73,7 @@ interface LabelProps {
 	htmlFor?: string;
 	children?: ReactNode;
 	value?: string;
-	maxCharacters?: number;
+	limit?: [number, number];
 	instructionText?: string;
 	colsInRow?: number;
 }
@@ -84,8 +84,7 @@ const Label = (props: LabelProps): ReactElement => {
 		className,
 		required,
 		htmlFor,
-		value,
-		maxCharacters,
+		limit,
 		instructionText,
 		colsInRow,
 	} = props;
@@ -106,9 +105,11 @@ const Label = (props: LabelProps): ReactElement => {
 					</Tooltip>
 				</StyledTooltipWrapper>
 			)}
-			{maxCharacters > 0 && (
-				<CharCounterWrapper $invalid={typeof value === "string" && value.length > maxCharacters}>
-					{(!value ? "0" : value.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").length) + "/" + maxCharacters}
+			{limit && (
+				<CharCounterWrapper $invalid={limit[0] > limit[1]}>
+					{limit[0]}
+					/
+					{limit[1]}
 				</CharCounterWrapper>
 			)}
 		</LabelWrapper>


### PR DESCRIPTION
For text and text editor fields, where a `maxCharacters` property is provided, there is a _x/y_ figure that appears above the input reflecting the maximum characters and the current amount of characters. With this change, we are utilising this same figure for the advanced selection field to denote how many items can be selected and how many items are currently selected. The figure only appears if `selectLimit` is more than 1.