### PR TITLE
MOS-1256 Upload field refactor

### DIFF
--- a/automation_testing/pages/FormFields/FormFieldUpload/FormFieldUploadPage.ts
+++ b/automation_testing/pages/FormFields/FormFieldUpload/FormFieldUploadPage.ts
@@ -19,7 +19,7 @@ export class FormFieldUploadPage extends BasePage {
 		this.page = page;
 		this.uploadFilesLocator = page.locator("#uploadField");
 		this.uploadFilesInput = this.uploadFilesLocator.locator("input");
-		this.uploadFilesButton = this.uploadFilesLocator.locator("button");
+		this.uploadFilesButton = this.uploadFilesLocator.getByText("UPLOAD FILES");
 		this.uploadFilesSpan = this.uploadFilesLocator.locator("span.button");
 		this.fileCardContainerLocator = page.locator("[data-testid='file-card-container']");
 		this.fileDeleteButton = page.locator(".file-delete-btn button");

--- a/automation_testing/utils/data/knobs.ts
+++ b/automation_testing/utils/data/knobs.ts
@@ -28,7 +28,7 @@ export const playgroundKnobs = {
 export const uploadKnobs = {
 	knobUploadLimit: "knob-Limit=",
 	knobTriggerErrorsWhenLoading: "knob-Trigger%20errors%20when%20loading=",
-	knobSimulateInitialFieldValue: "knob-Simulate%20initial%20field%20value=",
+	knobSimulateInitialFieldValue: "knob-Prepopulate=",
 };
 
 export const dataviewKnobs = {

--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -161,6 +161,8 @@ export const StyledButton = styled(Button)<TransientProps<ButtonProps, "color" |
 			padding: ${getPadding($variant, $size)};
 			width: ${$fullWidth ? "100%" : "auto"};
 			text-transform: ${$variant === "text" || $variant === "input" ? "none" : "uppercase"};
+			line-height: 1.75;
+			cursor: pointer;
 
 			${$variant !== "input" ? `
 				font-family: ${theme.fontFamily};

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -41,6 +41,7 @@ const ButtonBase = forwardRef<HTMLButtonElement, ButtonProps>(function ButtonBas
 		name: props.name,
 		id: props.id,
 		type: props.type || "button",
+		as: props.as,
 		ref,
 		...props.muiAttrs,
 	};

--- a/src/components/Button/ButtonTypes.tsx
+++ b/src/components/Button/ButtonTypes.tsx
@@ -1,5 +1,6 @@
 import { MosaicObject, MosaicToggle, SvgIconComponent } from "@root/types";
 import { MenuItemProps } from "../MenuItem";
+import { WebTarget } from "styled-components";
 
 export type ColorTypes = "black" | "blue" | "lightBlue" | "red" | "yellow" | "teal" | "gray" | "white";
 export interface ButtonProps {
@@ -35,6 +36,7 @@ export interface ButtonProps {
 	component?: React.ComponentType;
 	type?: "button" | "submit";
 	id?: string;
+	as?: WebTarget;
 }
 
 export interface ButtonPopoverContextProps {

--- a/src/components/Field/FieldTypes.tsx
+++ b/src/components/Field/FieldTypes.tsx
@@ -37,7 +37,7 @@ export interface MosaicFieldProps<T = any, U = any, V = any> {
 	/**
 	 * Function that listens to changes on the field and updates its value.
 	 */
-	onChange?: (e: V) => Promise<void>;
+	onChange?: (value: V | ((current: V) => V)) => Promise<void>;
 	/**
 	 * Function that listens to a blur event on the field and executes an action.
 	 */

--- a/src/components/Field/FormFieldUpload/FileCard/FileCard.styled.ts
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCard.styled.ts
@@ -1,7 +1,8 @@
+import Spinner from "@root/components/Spinner";
 import theme from "@root/theme";
 import styled from "styled-components";
 
-export const StyledFileCard = styled.div<{ $error?: boolean }>`
+export const StyledFileCard = styled.div<{ $error?: boolean; $isDeleting?: boolean }>`
 	display: flex;
 	flex-direction: row;
 	background-color: ${theme.colors.white};
@@ -9,6 +10,10 @@ export const StyledFileCard = styled.div<{ $error?: boolean }>`
 	padding: 16px;
 	width: 100%;
 	column-gap: 16px;
+
+	${({ $isDeleting }) => $isDeleting && `
+		opacity: 0.5;
+	`}
 
 	& > div {
 		display: flex;
@@ -74,4 +79,9 @@ export const StyledFileCard = styled.div<{ $error?: boolean }>`
 		font-weight: ${theme.fontWeight.normal};
 		line-height: 24px;
 	}
+`;
+
+export const StyledSpinner = styled(Spinner)`
+	flex: none;
+	align-self: center;
 `;

--- a/src/components/Field/FormFieldUpload/FileCard/FileCard.test.tsx
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCard.test.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import FileCard from "./FileCard";
+import FileCardPending from "./FileCardPending";
+import { FileCardPendingProps } from "./FileCardTypes";
 
 const onFileDelete = jest.fn();
 
@@ -20,17 +22,26 @@ const fileCards = [
 		size: 123,
 		onFileDelete,
 	},
+];
+
+const pendingFileCards: FileCardPendingProps[] = [
 	{ // Pending
 		id: "1",
 		name: "MyCard.jpg",
 		size: 123,
 		percent: 50,
+		isPending: true,
+		rawData: new File([""], "Woody.png"),
+		onFileDelete,
 	},
 	{ // Error
 		id: "1",
 		name: "MyCard.jpg",
 		size: 123,
 		error: "File size exceeded",
+		isPending: true,
+		rawData: new File([""], "Woody.png"),
+		onFileDelete,
 	},
 ];
 
@@ -68,28 +79,28 @@ describe("File card", () => {
 	});
 
 	it("Should render a pending card", () => {
-		render(<FileCard {...fileCards[2]} />);
+		render(<FileCardPending {...pendingFileCards[0]} />);
 
 		const name = screen.getByTestId("file-name");
 		const size = screen.getByTestId("file-size");
 		const progressBar = screen.getByRole("progressbar");
 
-		expect(name.textContent).toBe(fileCards[2].name);
-		expect(size.textContent).toBe(`${fileCards[2].size} B`);
-		expect(progressBar.getAttribute("aria-valuenow")).toBe(fileCards[2].percent.toString());
+		expect(name.textContent).toBe(pendingFileCards[0].name);
+		expect(size.textContent).toBe(`${pendingFileCards[0].size} B`);
+		expect(progressBar.getAttribute("aria-valuenow")).toBe(pendingFileCards[0].percent.toString());
 	});
 
 	it("Should render an uploaded card with img", () => {
-		render(<FileCard {...fileCards[3]} />);
+		render(<FileCardPending {...pendingFileCards[1]} />);
 
 		const name = screen.getByTestId("file-name");
 		const size = screen.getByTestId("file-size");
 		const errorIcon = screen.getByTestId("DoNotDisturbIcon");
 		const errorMessage = screen.getByText("File size exceeded");
 
-		expect(name.textContent).toBe(fileCards[3].name);
-		expect(size.textContent).toBe(`${fileCards[3].size} B`);
+		expect(name.textContent).toBe(pendingFileCards[1].name);
+		expect(size.textContent).toBe(`${pendingFileCards[1].size} B`);
 		expect(errorIcon).toBeInTheDocument();
-		expect(errorMessage.textContent).toBe(fileCards[3].error);
+		expect(errorMessage.textContent).toBe(pendingFileCards[1].error);
 	});
 });

--- a/src/components/Field/FormFieldUpload/FileCard/FileCard.tsx
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCard.tsx
@@ -8,8 +8,8 @@ import { StyledFileCard } from "./FileCard.styled";
 import InsertDriveFile from "@mui/icons-material/InsertDriveFile";
 import ButtonRow from "@root/components/ButtonRow/ButtonRow";
 import Downloader from "@root/components/Downloader/Downloader";
-import Typography from "@root/components/Typography";
 import { useHumanSize } from "@root/utils/hooks/useHumanSize";
+import FileCardTitle from "./FileCardTitle";
 
 const FileCard = (props: FileCardProps) => {
 	const {
@@ -53,15 +53,11 @@ const FileCard = (props: FileCardProps) => {
 				<div className="file-data" data-testid="file-data">
 					{fileUrl ? (
 						<a href={fileUrl} rel="noreferrer" target="_blank" className="file-name" data-testid="file-name">
-							<Typography maxLines={1} breakAll>
-								{name ?? "File title"}
-							</Typography>
+							<FileCardTitle name={name} />
 						</a>
 					) : (
 						<p className="file-name" data-testid="file-name">
-							<Typography maxLines={1} breakAll>
-								{name ?? "File title"}
-							</Typography>
+							<FileCardTitle name={name} />
 						</p>
 					)}
 					<p className="file-size" data-testid="file-size">{sizeHuman ?? "File size"}</p>

--- a/src/components/Field/FormFieldUpload/FileCard/FileCard.tsx
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCard.tsx
@@ -8,8 +8,8 @@ import { StyledFileCard } from "./FileCard.styled";
 import InsertDriveFile from "@mui/icons-material/InsertDriveFile";
 import ButtonRow from "@root/components/ButtonRow/ButtonRow";
 import Downloader from "@root/components/Downloader/Downloader";
-import { pretty } from "@root/utils/formatters";
 import Typography from "@root/components/Typography";
+import { useHumanSize } from "@root/utils/hooks/useHumanSize";
 
 const FileCard = (props: FileCardProps) => {
 	const {
@@ -38,11 +38,7 @@ const FileCard = (props: FileCardProps) => {
 		return <img src={thumbnailUrl} />;
 	}, [thumbnailUrl]);
 
-	const sizeHuman = useMemo(() => {
-		// Support legacy string size, i.e. "123 bytes"
-		const sanitized = parseInt(String(size), 10);
-		return pretty(sanitized);
-	}, [size]);
+	const sizeHuman = useHumanSize(size);
 
 	return (
 		<div data-testid="file-card-container">

--- a/src/components/Field/FormFieldUpload/FileCard/FileCard.tsx
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCard.tsx
@@ -4,7 +4,7 @@ import { memo, useMemo } from "react";
 import { FileCardProps } from "./FileCardTypes";
 import DeleteIcon from "@mui/icons-material/Delete";
 import CloudDownload from "@mui/icons-material/CloudDownload";
-import { StyledFileCard } from "./FileCard.styled";
+import { StyledFileCard, StyledSpinner } from "./FileCard.styled";
 import InsertDriveFile from "@mui/icons-material/InsertDriveFile";
 import ButtonRow from "@root/components/ButtonRow/ButtonRow";
 import Downloader from "@root/components/Downloader/Downloader";
@@ -22,6 +22,7 @@ const FileCard = (props: FileCardProps) => {
 		downloadStrategy: providedDownloadStrategy,
 		onFileDelete,
 		disabled,
+		isDeleting,
 	} = props;
 
 	const downloadStrategy = providedDownloadStrategy !== undefined ? providedDownloadStrategy : downloadUrl ? "iframe" : "anchor";
@@ -42,16 +43,16 @@ const FileCard = (props: FileCardProps) => {
 
 	return (
 		<div data-testid="file-card-container">
-			<StyledFileCard>
+			<StyledFileCard $isDeleting={isDeleting}>
 				<div className="file-img" data-testid="file-img">
-					{fileUrl ? (
+					{(fileUrl && !isDeleting) ? (
 						<a href={fileUrl} rel="noreferrer" target="_blank">{renderImg}</a>
 					) : (
 						renderImg
 					)}
 				</div>
 				<div className="file-data" data-testid="file-data">
-					{fileUrl ? (
+					{(fileUrl && !isDeleting) ? (
 						<a href={fileUrl} rel="noreferrer" target="_blank" className="file-name" data-testid="file-name">
 							<FileCardTitle name={name} />
 						</a>
@@ -62,37 +63,41 @@ const FileCard = (props: FileCardProps) => {
 					)}
 					<p className="file-size" data-testid="file-size">{sizeHuman ?? "File size"}</p>
 				</div>
-				<ButtonRow separator>
-					{(downloadUrl || fileUrl) && (
-						<div className="file-download-btn">
-							{downloadStrategy === "anchor" ? (
+				{isDeleting ? (
+					<StyledSpinner />
+				) : (
+					<ButtonRow separator>
+						{(downloadUrl || fileUrl) && (
+							<div className="file-download-btn">
+								{downloadStrategy === "anchor" ? (
+									<Button
+										muiAttrs={{ download: true }}
+										href={fileUrl}
+										color="gray"
+										variant="icon"
+										mIcon={CloudDownload}
+									/>
+								) : (
+									<Downloader
+										url={downloadUrl || fileUrl}
+										color="gray"
+										variant="icon"
+									/>
+								)}
+							</div>
+						)}
+						{onFileDelete && !disabled && (
+							<div className="file-delete-btn">
 								<Button
-									muiAttrs={{ download: true }}
-									href={fileUrl}
 									color="gray"
 									variant="icon"
-									mIcon={CloudDownload}
+									mIcon={DeleteIcon}
+									onClick={() => onFileDelete({ id: id })}
 								/>
-							) : (
-								<Downloader
-									url={downloadUrl || fileUrl}
-									color="gray"
-									variant="icon"
-								/>
-							)}
-						</div>
-					)}
-					{onFileDelete && !disabled && (
-						<div className="file-delete-btn">
-							<Button
-								color="gray"
-								variant="icon"
-								mIcon={DeleteIcon}
-								onClick={() => onFileDelete({ id: id })}
-							/>
-						</div>
-					)}
-				</ButtonRow>
+							</div>
+						)}
+					</ButtonRow>
+				)}
 			</StyledFileCard>
 		</div>
 	);

--- a/src/components/Field/FormFieldUpload/FileCard/FileCard.tsx
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCard.tsx
@@ -4,10 +4,7 @@ import { memo, useMemo } from "react";
 import { FileCardProps } from "./FileCardTypes";
 import DeleteIcon from "@mui/icons-material/Delete";
 import CloudDownload from "@mui/icons-material/CloudDownload";
-import DoNotDisturb from "@mui/icons-material/DoNotDisturb";
-import Spinner from "@root/components/Spinner";
 import { StyledFileCard } from "./FileCard.styled";
-import HelperText from "@root/components/Field/HelperText";
 import InsertDriveFile from "@mui/icons-material/InsertDriveFile";
 import ButtonRow from "@root/components/ButtonRow/ButtonRow";
 import Downloader from "@root/components/Downloader/Downloader";
@@ -24,31 +21,13 @@ const FileCard = (props: FileCardProps) => {
 		downloadUrl,
 		downloadStrategy: providedDownloadStrategy,
 		onFileDelete,
-		error,
-		percent,
 		disabled,
 	} = props;
 
 	const downloadStrategy = providedDownloadStrategy !== undefined ? providedDownloadStrategy : downloadUrl ? "iframe" : "anchor";
 
 	const renderImg = useMemo(() => {
-		if (error) {
-			return (
-				<div>
-					<DoNotDisturb />
-				</div>
-			);
-		}
-
 		if (!thumbnailUrl) {
-			if (percent !== undefined && percent < 100) {
-				return (
-					<div>
-						<Spinner progress={percent} />
-					</div>
-				);
-			}
-
 			return (
 				<div>
 					<InsertDriveFile />
@@ -57,7 +36,7 @@ const FileCard = (props: FileCardProps) => {
 		}
 
 		return <img src={thumbnailUrl} />;
-	}, [percent, thumbnailUrl, error]);
+	}, [thumbnailUrl]);
 
 	const sizeHuman = useMemo(() => {
 		// Support legacy string size, i.e. "123 bytes"
@@ -67,7 +46,7 @@ const FileCard = (props: FileCardProps) => {
 
 	return (
 		<div data-testid="file-card-container">
-			<StyledFileCard $error={!!error}>
+			<StyledFileCard>
 				<div className="file-img" data-testid="file-img">
 					{fileUrl ? (
 						<a href={fileUrl} rel="noreferrer" target="_blank">{renderImg}</a>
@@ -123,9 +102,6 @@ const FileCard = (props: FileCardProps) => {
 					)}
 				</ButtonRow>
 			</StyledFileCard>
-			{error && (
-				<HelperText error={error !== undefined}>{error}</HelperText>
-			)}
 		</div>
 	);
 };

--- a/src/components/Field/FormFieldUpload/FileCard/FileCardPending.tsx
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCardPending.tsx
@@ -1,0 +1,78 @@
+import Button from "@root/components/Button";
+import * as React from "react";
+import { memo, useMemo } from "react";
+import { FileCardPendingProps } from "./FileCardTypes";
+import DeleteIcon from "@mui/icons-material/Delete";
+import DoNotDisturb from "@mui/icons-material/DoNotDisturb";
+import Spinner from "@root/components/Spinner";
+import { StyledFileCard } from "./FileCard.styled";
+import HelperText from "@root/components/Field/HelperText";
+import InsertDriveFile from "@mui/icons-material/InsertDriveFile";
+import ButtonRow from "@root/components/ButtonRow/ButtonRow";
+import { pretty } from "@root/utils/formatters";
+import Typography from "@root/components/Typography";
+
+const FileCardPending = (props: FileCardPendingProps) => {
+	const {
+		id,
+		name,
+		size,
+		onFileDelete,
+		error,
+		percent,
+		disabled,
+	} = props;
+
+	const sizeHuman = useMemo(() => {
+		// Support legacy string size, i.e. "123 bytes"
+		const sanitized = parseInt(String(size), 10);
+		return pretty(sanitized);
+	}, [size]);
+
+	return (
+		<div data-testid="file-card-container">
+			<StyledFileCard $error={!!error}>
+				<div className="file-img" data-testid="file-img">
+					{error ? (
+						<div>
+							<DoNotDisturb />
+						</div>
+					) : percent !== undefined && percent < 100 ? (
+						<div>
+							<Spinner progress={percent} />
+						</div>
+					) : (
+						<div>
+							<InsertDriveFile />
+						</div>
+					)}
+				</div>
+				<div className="file-data" data-testid="file-data">
+					<p className="file-name" data-testid="file-name">
+						<Typography maxLines={1} breakAll>
+							{name ?? "File title"}
+						</Typography>
+					</p>
+					<p className="file-size" data-testid="file-size">{sizeHuman ?? "File size"}</p>
+				</div>
+				<ButtonRow separator>
+					{onFileDelete && !disabled && (
+						<div className="file-delete-btn">
+							<Button
+								color="gray"
+								variant="icon"
+								mIcon={DeleteIcon}
+								onClick={() => onFileDelete({ id: id })}
+							/>
+						</div>
+					)}
+				</ButtonRow>
+			</StyledFileCard>
+			{error && (
+				<HelperText error={error !== undefined}>{error}</HelperText>
+			)}
+		</div>
+	);
+};
+
+export default memo(FileCardPending);

--- a/src/components/Field/FormFieldUpload/FileCard/FileCardPending.tsx
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCardPending.tsx
@@ -1,6 +1,6 @@
 import Button from "@root/components/Button";
 import * as React from "react";
-import { memo, useMemo } from "react";
+import { memo } from "react";
 import { FileCardPendingProps } from "./FileCardTypes";
 import DeleteIcon from "@mui/icons-material/Delete";
 import DoNotDisturb from "@mui/icons-material/DoNotDisturb";
@@ -9,8 +9,8 @@ import { StyledFileCard } from "./FileCard.styled";
 import HelperText from "@root/components/Field/HelperText";
 import InsertDriveFile from "@mui/icons-material/InsertDriveFile";
 import ButtonRow from "@root/components/ButtonRow/ButtonRow";
-import { pretty } from "@root/utils/formatters";
 import Typography from "@root/components/Typography";
+import { useHumanSize } from "@root/utils/hooks/useHumanSize";
 
 const FileCardPending = (props: FileCardPendingProps) => {
 	const {
@@ -23,11 +23,7 @@ const FileCardPending = (props: FileCardPendingProps) => {
 		disabled,
 	} = props;
 
-	const sizeHuman = useMemo(() => {
-		// Support legacy string size, i.e. "123 bytes"
-		const sanitized = parseInt(String(size), 10);
-		return pretty(sanitized);
-	}, [size]);
+	const sizeHuman = useHumanSize(size);
 
 	return (
 		<div data-testid="file-card-container">

--- a/src/components/Field/FormFieldUpload/FileCard/FileCardPending.tsx
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCardPending.tsx
@@ -9,8 +9,8 @@ import { StyledFileCard } from "./FileCard.styled";
 import HelperText from "@root/components/Field/HelperText";
 import InsertDriveFile from "@mui/icons-material/InsertDriveFile";
 import ButtonRow from "@root/components/ButtonRow/ButtonRow";
-import Typography from "@root/components/Typography";
 import { useHumanSize } from "@root/utils/hooks/useHumanSize";
+import FileCardTitle from "./FileCardTitle";
 
 const FileCardPending = (props: FileCardPendingProps) => {
 	const {
@@ -29,25 +29,19 @@ const FileCardPending = (props: FileCardPendingProps) => {
 		<div data-testid="file-card-container">
 			<StyledFileCard $error={!!error}>
 				<div className="file-img" data-testid="file-img">
-					{error ? (
-						<div>
+					<div>
+						{error ? (
 							<DoNotDisturb />
-						</div>
-					) : percent !== undefined && percent < 100 ? (
-						<div>
+						) : percent !== undefined && percent < 100 ? (
 							<Spinner progress={percent} />
-						</div>
-					) : (
-						<div>
+						) : (
 							<InsertDriveFile />
-						</div>
-					)}
+						)}
+					</div>
 				</div>
 				<div className="file-data" data-testid="file-data">
 					<p className="file-name" data-testid="file-name">
-						<Typography maxLines={1} breakAll>
-							{name ?? "File title"}
-						</Typography>
+						<FileCardTitle name={name} />
 					</p>
 					<p className="file-size" data-testid="file-size">{sizeHuman ?? "File size"}</p>
 				</div>

--- a/src/components/Field/FormFieldUpload/FileCard/FileCardPending.tsx
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCardPending.tsx
@@ -46,7 +46,7 @@ const FileCardPending = (props: FileCardPendingProps) => {
 					<p className="file-size" data-testid="file-size">{sizeHuman ?? "File size"}</p>
 				</div>
 				<ButtonRow separator>
-					{onFileDelete && !disabled && (
+					{onFileDelete && !disabled && (percent === undefined || percent === 100) && (
 						<div className="file-delete-btn">
 							<Button
 								color="gray"

--- a/src/components/Field/FormFieldUpload/FileCard/FileCardTitle.tsx
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCardTitle.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import Typography from "@root/components/Typography";
+import { FileCardTitleProps } from "./FileCardTypes";
+import Blank from "@root/components/Blank";
+
+function FileCardTitle ({ name }: FileCardTitleProps) {
+	return (
+		<Typography maxLines={1} breakAll>
+			{name ?? <Blank />}
+		</Typography>
+	);
+}
+
+export default FileCardTitle;

--- a/src/components/Field/FormFieldUpload/FileCard/FileCardTypes.ts
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCardTypes.ts
@@ -9,3 +9,7 @@ export type FileCardPendingProps = UploadDataPending & {
 	onFileDelete: OnFileDelete;
 	disabled?: boolean;
 };
+
+export interface FileCardTitleProps {
+	name?: string;
+}

--- a/src/components/Field/FormFieldUpload/FileCard/FileCardTypes.ts
+++ b/src/components/Field/FormFieldUpload/FileCard/FileCardTypes.ts
@@ -1,8 +1,11 @@
-import { UploadData, UploadFieldInputSettings } from "../FormFieldUploadTypes";
+import { OnFileDelete, UploadData, UploadDataPending, UploadFieldInputSettings } from "../FormFieldUploadTypes";
 
 export type FileCardProps = {
 	onFileDelete?: UploadFieldInputSettings["onFileDelete"];
-	percent?: number;
-	error?: string;
 	disabled?: boolean;
 } & UploadData;
+
+export type FileCardPendingProps = UploadDataPending & {
+	onFileDelete: OnFileDelete;
+	disabled?: boolean;
+};

--- a/src/components/Field/FormFieldUpload/FormFieldUpload.stories.tsx
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.stories.tsx
@@ -53,20 +53,21 @@ export const Playground = (): ReactElement => {
 		["No limit", 1, 2, 3],
 		"No limit",
 	);
+	const mockDB = boolean("Prepopulate", false);
+	const timeToLoad = number("Secs to upload", 2);
+	const timeToDelete = number("Secs to delete", 2);
+	const thumbnailUrl = text("onUploadComplete thumbail URL", "");
+	const fileUrl = text("onUploadComplete file URL", "");
+	const downloadUrl = text("onUploadComplete download URL", "");
+	const error = text("Throw upload error", "");
+	const acceptCsv = text("Comma separated accepted extensions", "");
+	const maxFileSize = text("Max file size (KB)", "");
+	const maxTotalSize = text("Max total size (KB)", "");
 	const disabled = boolean("Disabled", false);
 	const required = boolean("Required", false);
 	const helperText = text("Helper text", "Helper text");
 	const instructionText = text("Instruction text", "Instruction text");
 	const label = text("Label", "Label");
-	const mockDB = boolean("Simulate initial field value", false);
-	const timeToLoad = number("Time to upload load (seconds)", 2);
-	const thumbnailUrl = text("Override onUploadComplete thumbail URL", "");
-	const fileUrl = text("Override onUploadComplete file URL", "");
-	const downloadUrl = text("Override onUploadComplete download URL", "");
-	const error = boolean("Trigger errors when loading", false);
-	const acceptCsv = text("Comma separated accepted extensions", "");
-	const maxFileSize = text("Max file size (KB)", "");
-	const maxTotalSize = text("Max total size (KB)", "");
 
 	// One line change
 
@@ -96,7 +97,7 @@ export const Playground = (): ReactElement => {
 		}
 
 		if (error) {
-			throw new Error("File size exceeded");
+			throw new Error(error);
 		}
 
 		await onUploadComplete({
@@ -115,9 +116,9 @@ export const Playground = (): ReactElement => {
 		error,
 	]);
 
-	const onFileDelete = async () => {
-		await new Promise((resolve) => setTimeout(() => resolve(null), 2000));
-	};
+	const onFileDelete = useCallback(async () => {
+		await new Promise((resolve) => setTimeout(() => resolve(null), timeToDelete * 1000));
+	}, [timeToDelete]);
 
 	const getFormValues = useCallback(async () => ({
 		...initialValues,
@@ -155,6 +156,7 @@ export const Playground = (): ReactElement => {
 			accept,
 			maxFileSize,
 			maxTotalSize,
+			onFileDelete,
 		],
 	);
 

--- a/src/components/Field/FormFieldUpload/FormFieldUpload.stories.tsx
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.stories.tsx
@@ -91,6 +91,10 @@ export const Playground = (): ReactElement => {
 			);
 		}
 
+		if (file.name === "broken_file") {
+			throw new Error("This file is broken");
+		}
+
 		if (error) {
 			throw new Error("File size exceeded");
 		}

--- a/src/components/Field/FormFieldUpload/FormFieldUpload.styled.ts
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.styled.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const StyledFileGrid = styled.div`
+export const StyledFileList = styled.div`
 	margin-top: 16px;
 	display: flex;
 	flex-direction: column;

--- a/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
@@ -223,6 +223,11 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 	};
 
 	const handleFileDelete = async (id: UploadData["id"], isPending = false) => {
+		onChange((items = []) => items.map(item => item.id === id ? ({
+			...item,
+			isDeleting: true,
+		}) : item));
+
 		if (!isPending) {
 			await onFileDelete({ id });
 		}

--- a/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
@@ -226,15 +226,13 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 		}));
 	};
 
-	const handleFileDelete = async ({ id }) => {
-		await onFileDelete({ id });
-		const newValues = value.filter(file => file.id !== id);
-		await onChange(newValues);
-	};
+	const handleFileDelete = async (id: UploadData["id"], isPending = false) => {
+		if (!isPending) {
+			await onFileDelete({ id });
+		}
 
-	// const handleErrorDelete = async ({ id }) => {
-	// 	onChange((items) => items.filter(item => item.id !== id));
-	// };
+		onChange((items = []) => items.filter(item => item.id !== id));
+	};
 
 	const closeSnackbar = (_event?: SyntheticEvent, reason?: string) => {
 		if (reason === "clickaway") {
@@ -294,7 +292,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 						<FileCardPending
 							key={file.id}
 							{...file}
-							onFileDelete={handleFileDelete}
+							onFileDelete={({ id }) => handleFileDelete(id, true)}
 							disabled={disabled}
 							percent={file.percent}
 							error={file.error}
@@ -303,7 +301,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 						<FileCard
 							key={file.id}
 							{...file}
-							onFileDelete={handleFileDelete}
+							onFileDelete={({ id }) => handleFileDelete(id)}
 							disabled={disabled}
 						/>
 					))}

--- a/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
@@ -6,17 +6,17 @@ import * as React from "react";
 import { memo, SyntheticEvent, useEffect, useRef, useState, useMemo } from "react";
 import { DragAndDropContainer, DragAndDropSpan, FileInput } from "../../../forms/shared/styledComponents";
 import FileCard from "./FileCard";
-import { StyledFileGrid } from "./FormFieldUpload.styled";
-import { TransformedFile, UploadData, UploadFieldInputSettings } from "./FormFieldUploadTypes";
+import { StyledFileList } from "./FormFieldUpload.styled";
+import { UploadDataPending, UploadData, UploadFieldInputSettings, isPendingUploadData } from "./FormFieldUploadTypes";
 import { FileExtensions } from "@root/utils/classes";
 import { pretty } from "@root/utils/formatters";
-import { MosaicObject } from "@root/types";
 import { sum } from "@root/utils/math/sum";
+import FileCardPending from "./FileCard/FileCardPending";
 
-const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSettings, UploadData[]>) => {
+const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSettings, (UploadData | UploadDataPending)[]>) => {
 	const {
 		fieldDef,
-		value,
+		value: providedValue,
 		onChange,
 		disabled,
 		methods,
@@ -34,22 +34,23 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 	} = fieldDef.inputSettings;
 
 	const [isOver, setIsOver] = useState(false);
-	const [pendingFiles, setPendingFiles] = useState<MosaicObject<TransformedFile>>({});
 	const [snackbar, setSnackbar] = useState<{ open: boolean; text: string }>({
 		open: false,
 		text: "",
 	});
+
 	const fileInputField = useRef(null);
 	const prevValueRef = useRef([]);
-	const currentLength = Object.keys(pendingFiles).length + (value || []).length;
+
+	const value = useMemo(() => providedValue || [], [providedValue]);
+	const currentLength = value.length;
 	const isMaxedOut = limit >= 0 && currentLength >= limit;
 
 	const fileExtensions = useMemo(() => new FileExtensions(accept), [accept]);
 
-	const pendingWithoutError = useMemo(() =>
-		Object.values(pendingFiles).filter((pendingFile: { error: string }) => pendingFile.error === undefined).length,
-	[pendingFiles],
-	);
+	const pendingWithoutError = useMemo(() => {
+		return value.filter(item => isPendingUploadData(item) && item.error === undefined).length;
+	}, [value]);
 
 	useEffect(() => {
 		prevValueRef.current = value;
@@ -107,15 +108,10 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 	};
 
 	const onChunkComplete = async ({ uuid, percent }) => {
-		setPendingFiles((prevState) => (
-			{
-				...prevState,
-				[uuid]: {
-					...prevState[uuid],
-					percent: percent * 100,
-				},
-			}
-		));
+		onChange((items = []) => items.map(item => uuid === item.id ? ({
+			...item,
+			percent: percent * 100,
+		}) : item));
 	};
 
 	useEffect(() => {
@@ -141,25 +137,16 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 	]);
 
 	const onUploadComplete = async ({ uuid, data }) => {
-		onChange(prevValueRef?.current ? [...prevValueRef.current, data] : [data]);
-
-		setPendingFiles((prevState) => {
-			const newPendingFiles = { ...prevState };
-			delete newPendingFiles[uuid];
-			return newPendingFiles;
-		});
+		onChange((items = []) => items.map(item => uuid === item.id ? ({
+			...data,
+		}) : item));
 	};
 
 	const onError = async ({ uuid, message }) => {
-		setPendingFiles((prevState) => (
-			{
-				...prevState,
-				[uuid]: {
-					...prevState[uuid],
-					error: message,
-				},
-			}
-		));
+		onChange((items = []) => items.map(item => uuid === item.id ? ({
+			...item,
+			error: message,
+		}) : item));
 	};
 
 	/**
@@ -177,34 +164,20 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 			return;
 		}
 
-		let transformedFiles: { [key: string]: TransformedFile } = {};
-
-		newFiles.forEach(file => {
-			const id = uniqueId();
-
-			transformedFiles = {
-				...transformedFiles,
-				[id]: {
-					data: {
-						id,
-						name: file.name,
-						size: file.size,
-					},
-					percent: 0,
-					error: undefined,
-					rawData: file,
-				},
-			};
-		});
-
-		const pendingFilesEntries = Object.entries(pendingFiles);
-		const transformFilesEntries = Object.entries(transformedFiles);
+		const uploadQueueItems = newFiles.map<UploadDataPending>(file => ({
+			id: uniqueId(),
+			name: file.name,
+			size: file.size,
+			percent: 0,
+			error: undefined,
+			rawData: file,
+			isPending: true,
+		}));
 
 		if (maxTotalSize) {
 			const totalSize = sum([
-				...(value || []).map(({ size }) => size),
-				...pendingFilesEntries.map(([, item]) => item.rawData.size),
-				...transformFilesEntries.map(([, item]) => item.rawData.size),
+				...value.map(({ size }) => size),
+				...uploadQueueItems.map((item) => item.rawData.size),
 			]);
 
 			if (maxTotalSize < totalSize) {
@@ -226,47 +199,42 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 		 * the percentage and error message, and which file to
 		 * remove from the pending when its upload is complete.
 		 */
-		setPendingFiles({ ...pendingFiles, ...transformedFiles });
+		onChange((items = []) => ([...items, ...uploadQueueItems]));
 
-		await Promise.all(transformFilesEntries.map(async ([key, file]) => {
-			if (!fileExtensions.isValidFileName(file.rawData.name)) {
-				onError({ uuid: key, message: `We only allow ${fileExtensions.human} file uploads` });
+		await Promise.all(uploadQueueItems.map(async (item) => {
+			if (!fileExtensions.isValidFileName(item.rawData.name)) {
+				onError({ uuid: item.id, message: `We only allow ${fileExtensions.human} file uploads` });
 				return;
 			}
 
-			if (maxFileSize && maxFileSize < file.rawData.size) {
-				onError({ uuid: key, message: `Individual file upload size should not exceed ${pretty(maxFileSize)}` });
+			if (maxFileSize && maxFileSize < item.rawData.size) {
+				onError({ uuid: item.id, message: `Individual file upload size should not exceed ${pretty(maxFileSize)}` });
 				return;
 			}
 
 			try {
 				await onFileAdd({
-					file: file?.rawData,
-					onChunkComplete: ({ percent }) => onChunkComplete({ uuid: key, percent }),
-					onUploadComplete: (data) => onUploadComplete({ uuid: key, data }),
-					onError: (message) => onError({ uuid: key, message }),
+					file: item?.rawData,
+					onChunkComplete: ({ percent }) => onChunkComplete({ uuid: item.id, percent }),
+					onUploadComplete: (data) => onUploadComplete({ uuid: item.id, data }),
+					onError: (message) => onError({ uuid: item.id, message }),
 				});
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
-				onError({ uuid: key, message });
+				onError({ uuid: item.id, message });
 			}
 		}));
 	};
 
 	const handleFileDelete = async ({ id }) => {
 		await onFileDelete({ id });
-
-		const newValues = [...value].filter(file => file.id !== id);
+		const newValues = value.filter(file => file.id !== id);
 		await onChange(newValues);
 	};
 
-	const handleErrorDelete = async ({ id }) => {
-		setPendingFiles((prevState) => {
-			const newPendingFiles = { ...prevState };
-			delete newPendingFiles[id];
-			return newPendingFiles;
-		});
-	};
+	// const handleErrorDelete = async ({ id }) => {
+	// 	onChange((items) => items.filter(item => item.id !== id));
+	// };
 
 	const closeSnackbar = (_event?: SyntheticEvent, reason?: string) => {
 		if (reason === "clickaway") {
@@ -320,46 +288,26 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 					/>
 				</DragAndDropContainer>
 			)}
-			{/**
-			 * We'll have 2 FileGrids, 1 for the successfully
-			 * uploaded files, and 1 for the pending / errors.
-			 */}
-			{value?.length > 0 && (
-				<StyledFileGrid>
-					{value.map(file => (
+			{value.length > 0 && (
+				<StyledFileList>
+					{value.map(file => isPendingUploadData(file) ? (
+						<FileCardPending
+							key={file.id}
+							{...file}
+							onFileDelete={handleFileDelete}
+							disabled={disabled}
+							percent={file.percent}
+							error={file.error}
+						/>
+					) : (
 						<FileCard
 							key={file.id}
-							id={file.id}
-							name={file.name}
-							size={file.size}
-							thumbnailUrl={file.thumbnailUrl}
-							fileUrl={file.fileUrl}
-							downloadUrl={file.downloadUrl}
+							{...file}
 							onFileDelete={handleFileDelete}
 							disabled={disabled}
 						/>
 					))}
-				</StyledFileGrid>
-			)}
-			{pendingFiles && Object.keys(pendingFiles).length > 0 && !disabled && (
-				<StyledFileGrid>
-					{Object.entries(pendingFiles).map(([key, file]) => {
-						return (
-							<FileCard
-								key={key}
-								id={key}
-								name={file.data?.name}
-								size={file.data?.size}
-								thumbnailUrl={file.data?.thumbnailUrl}
-								fileUrl={file.data?.fileUrl}
-								downloadUrl={file.data?.downloadUrl}
-								error={file.error}
-								percent={file.percent}
-								onFileDelete={file.error && handleErrorDelete}
-							/>
-						);
-					})}
-				</StyledFileGrid>
+				</StyledFileList>
 			)}
 			<Snackbar
 				autoHideDuration={6000}

--- a/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
+++ b/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
@@ -7,7 +7,23 @@ export type TransformedFile = {
 	rawData: File;
 };
 
+type OnFileDeleteData = {
+	id: UploadData["id"];
+};
+
 export type OnFileDelete = (deletedData: OnFileDeleteData) => Promise<void>;
+
+type OnError = (message: string) => Promise<void>;
+
+type OnFileAddData = {
+	file: File;
+	onChunkComplete: (data: { percent: number }) => Promise<void>;
+	onUploadComplete: (data: UploadData) => Promise<void>;
+	/**
+	 * @deprecated - Throw an error within `onFileAdd` callback instead.
+	 */
+	onError: OnError;
+};
 
 export type OnFileAdd = (addedData: OnFileAddData) => Promise<void>;
 
@@ -64,32 +80,5 @@ export type UploadData = {
 	 */
 	name: string;
 };
-
-type OnError = (message: string) => Promise<void>;
-
-type OnFileAddData = {
-	file: File;
-	onChunkComplete: (data: { percent: number }) => Promise<void>;
-	onUploadComplete: (data: UploadData) => Promise<void>;
-	/**
-	 * @deprecated - Throw an error within `onFileAdd` callback instead.
-	 */
-	onError: OnError;
-};
-
-type OnFileDeleteData = {
-	id: UploadData["id"];
-};
-
-export interface QueuedFile {
-	id: string;
-	data: {
-		name: string;
-		size: number;
-	};
-	percent: number;
-	error?: string;
-	file: File;
-}
 
 export type FieldDefUpload = FieldDefBase<"upload", UploadFieldInputSettings>;

--- a/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
+++ b/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
@@ -39,6 +39,10 @@ export type UploadData = UploadDataBase & {
 	 * if no downloadUrl is provided, or "iframe" if it is.
 	 */
 	downloadStrategy?: "anchor" | "iframe";
+	/**
+	 * If the file is currently being deleted
+	 */
+	isDeleting?: boolean;
 };
 
 export type UploadDataPending = UploadDataBase & {

--- a/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
+++ b/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
@@ -39,8 +39,8 @@ export type UploadData = {
 };
 
 export type UploadDataPending = UploadData & {
-	percent: number;
-	error: string | undefined;
+	percent?: number;
+	error?: string;
 	rawData: File;
 	isPending: true;
 };

--- a/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
+++ b/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
@@ -1,10 +1,21 @@
 import { FieldDefBase } from "@root/components/Field";
 
-export type UploadData = {
+export type UploadDataBase = {
 	/**
 	 * A unique identifier, used as React "key"
 	 */
 	id: string | number;
+	/**
+	 * The numerical size of the file in bytes
+	 */
+	size: number;
+	/**
+	 * The name of the file, which will be rendered as the file title
+	 */
+	name: string;
+};
+
+export type UploadData = UploadDataBase & {
 	/**
 	 * The URL to the uploaded file which the uploaded item's
 	 * image and title will link to
@@ -28,17 +39,9 @@ export type UploadData = {
 	 * if no downloadUrl is provided, or "iframe" if it is.
 	 */
 	downloadStrategy?: "anchor" | "iframe";
-	/**
-	 * The numerical size of the file in bytes
-	 */
-	size: number;
-	/**
-	 * The name of the file, which will be rendered as the file title
-	 */
-	name: string;
 };
 
-export type UploadDataPending = UploadData & {
+export type UploadDataPending = UploadDataBase & {
 	percent?: number;
 	error?: string;
 	rawData: File;

--- a/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
+++ b/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
@@ -1,48 +1,5 @@
 import { FieldDefBase } from "@root/components/Field";
 
-export type TransformedFile = {
-	data: UploadData;
-	percent: number;
-	error: string | undefined;
-	rawData: File;
-};
-
-type OnFileDeleteData = {
-	id: UploadData["id"];
-};
-
-export type OnFileDelete = (deletedData: OnFileDeleteData) => Promise<void>;
-
-type OnError = (message: string) => Promise<void>;
-
-type OnFileAddData = {
-	file: File;
-	onChunkComplete: (data: { percent: number }) => Promise<void>;
-	onUploadComplete: (data: UploadData) => Promise<void>;
-	/**
-	 * @deprecated - Throw an error within `onFileAdd` callback instead.
-	 */
-	onError: OnError;
-};
-
-export type OnFileAdd = (addedData: OnFileAddData) => Promise<void>;
-
-export type UploadFieldInputSettings = {
-	onFileDelete: OnFileDelete;
-	onFileAdd: OnFileAdd;
-	limit?: number;
-	accept?: string[];
-	/**
-	 * Maximum size limit for each file uploaded
-	 */
-	maxFileSize?: number;
-	/**
-	 * Maximum size limit for cumulative total
-	 * of files uploaded
-	 */
-	maxTotalSize?: number;
-};
-
 export type UploadData = {
 	/**
 	 * A unique identifier, used as React "key"
@@ -79,6 +36,53 @@ export type UploadData = {
 	 * The name of the file, which will be rendered as the file title
 	 */
 	name: string;
+};
+
+export type UploadDataPending = UploadData & {
+	percent: number;
+	error: string | undefined;
+	rawData: File;
+	isPending: true;
+};
+
+export function isPendingUploadData(item: UploadData | UploadDataPending): item is UploadDataPending {
+	return "isPending" in item && item.isPending;
+}
+
+type OnFileDeleteData = {
+	id: UploadData["id"];
+};
+
+export type OnFileDelete = (deletedData: OnFileDeleteData) => Promise<void>;
+
+type OnError = (message: string) => Promise<void>;
+
+type OnFileAddData = {
+	file: File;
+	onChunkComplete: (data: { percent: number }) => Promise<void>;
+	onUploadComplete: (data: UploadData) => Promise<void>;
+	/**
+	 * @deprecated - Throw an error within `onFileAdd` callback instead.
+	 */
+	onError: OnError;
+};
+
+export type OnFileAdd = (addedData: OnFileAddData) => Promise<void>;
+
+export type UploadFieldInputSettings = {
+	onFileDelete: OnFileDelete;
+	onFileAdd: OnFileAdd;
+	limit?: number;
+	accept?: string[];
+	/**
+	 * Maximum size limit for each file uploaded
+	 */
+	maxFileSize?: number;
+	/**
+	 * Maximum size limit for cumulative total
+	 * of files uploaded
+	 */
+	maxTotalSize?: number;
 };
 
 export type FieldDefUpload = FieldDefBase<"upload", UploadFieldInputSettings>;

--- a/src/components/Form/Col/fieldConfigMap.ts
+++ b/src/components/Form/Col/fieldConfigMap.ts
@@ -191,10 +191,10 @@ const fieldConfigMap: Partial<Record<Exclude<FieldDef["type"], FieldDefCustom["t
 		Component: FormFieldUpload,
 		validate: "onChange",
 		getResolvedValue: (
-			value: (UploadData | UploadDataPending)[],
+			value: (UploadData | UploadDataPending)[] = [],
 		) => {
 			return {
-				value: cleanValue((value || []).filter((item) => !isPendingUploadData(item))),
+				value: cleanValue(value.filter((item) => !isPendingUploadData(item) && !item.isDeleting)),
 				internalValue: value || [],
 			};
 		},

--- a/src/components/Form/Col/fieldConfigMap.ts
+++ b/src/components/Form/Col/fieldConfigMap.ts
@@ -19,12 +19,13 @@ import FormFieldAdvancedSelection from "@root/components/Field/FormFieldAdvanced
 import FormFieldMapCoordinates from "@root/components/Field/FormFieldMapCoordinates";
 import FormFieldImageUpload from "@root/components/Field/FormFieldImageUpload";
 import FormFieldMatrix from "@root/components/Field/FormFieldMatrix";
-import FormFieldUpload from "@root/components/Field/FormFieldUpload";
+import FormFieldUpload, { UploadData, UploadDataPending, isPendingUploadData } from "@root/components/Field/FormFieldUpload";
 import FormFieldNumberTable from "@root/components/Field/FormFieldNumberTable";
 import { matchTime } from "@root/utils/date";
+import { cleanValue } from "../useForm/utils";
 
 export function defaultResolver(value: any) {
-	return { internalValue: value, value };
+	return { internalValue: value, value: cleanValue(value) };
 }
 
 const fieldConfigMap: Partial<Record<Exclude<FieldDef["type"], FieldDefCustom["type"]>, FieldConfig>> = {
@@ -189,7 +190,14 @@ const fieldConfigMap: Partial<Record<Exclude<FieldDef["type"], FieldDefCustom["t
 	upload: {
 		Component: FormFieldUpload,
 		validate: "onChange",
-		getResolvedValue: defaultResolver,
+		getResolvedValue: (
+			value: (UploadData | UploadDataPending)[],
+		) => {
+			return {
+				value: cleanValue((value || []).filter((item) => !isPendingUploadData(item))),
+				internalValue: value || [],
+			};
+		},
 	},
 	numberTable: {
 		Component: FormFieldNumberTable,

--- a/src/components/Form/useForm/useForm.ts
+++ b/src/components/Form/useForm/useForm.ts
@@ -28,7 +28,7 @@ import { FieldDefSanitized } from "../../Field";
 import { getFieldConfig } from "../Col/fieldConfigMap";
 import { getInitialState, getInitialStable } from "./initial";
 import { reducer } from "./reducers";
-import { cleanValue, mapsValidators, runValidators, stateFromStable } from "./utils";
+import { mapsValidators, runValidators, stateFromStable } from "./utils";
 
 export function useForm(): UseFormReturn {
 	const stable = useRef<FormStable>(getInitialStable());
@@ -237,18 +237,17 @@ export function useForm(): UseFormReturn {
 		touched,
 		validate,
 	}) => {
-		const { errors, data, hasBlurred } = stable.current;
+		const { errors, internalData, hasBlurred } = stable.current;
 		const field = getFieldFromExtra(name);
+		const providedValueResolved = typeof providedValue === "function" ? providedValue(internalData[name]) : providedValue;
+		const { value, internalValue } = field.getResolvedValue(providedValueResolved);
 
-		const providedValueResolved = typeof providedValue === "function" ? providedValue(data[name]) : providedValue;
-		const { internalValue, value } = field.getResolvedValue(providedValueResolved);
-		const cleanedValue = cleanValue(value);
-
-		stable.current.data[name] = cleanedValue;
+		stable.current.data[name] = value;
+		stable.current.internalData[name] = internalValue;
 
 		dispatch({
 			type: "SET_FIELD_VALUES",
-			values: { [name]: cleanedValue },
+			values: { [name]: value },
 			internalValues: { [name]: internalValue },
 			merge: true,
 			touched,

--- a/src/forms/shared/styledComponents.ts
+++ b/src/forms/shared/styledComponents.ts
@@ -41,7 +41,7 @@ export const FormDrawerWrapper = styled.div`
   }
 `;
 
-export const DragAndDropContainer = styled.div<{ $isOver?: boolean }>`
+export const DragAndDropContainer = styled.label<{ $isOver?: boolean }>`
   align-items: center;
   border: ${({ $isOver }) =>
 		$isOver ? `1px dashed ${theme.newColors.realTeal["100"]}` : ""};
@@ -67,15 +67,7 @@ export const DragAndDropSpan = styled.span<{ $isOver?: boolean }>`
 `;
 
 export const FileInput = styled.input`
-  height: 100%;
-  opacity: 0;
-  position: absolute;
-  width: 100%;
-  z-index: 100;
-
-  &:focus {
-    outline: none;
-  }
+  display: none;
 `;
 
 export const StyledDisabledText = styled.p`

--- a/src/utils/hooks/useHumanSize/index.ts
+++ b/src/utils/hooks/useHumanSize/index.ts
@@ -1,0 +1,1 @@
+export { default as useHumanSize } from "./useHumanSize";

--- a/src/utils/hooks/useHumanSize/useHumanSize.ts
+++ b/src/utils/hooks/useHumanSize/useHumanSize.ts
@@ -1,0 +1,14 @@
+import { useMemo } from "react";
+import { pretty } from "@root/utils/formatters";
+
+function useHumanSize(size: number | string) {
+	const sizeHuman = useMemo(() => {
+		// Support legacy string size, i.e. "123 bytes"
+		const sanitized = parseInt(String(size), 10);
+		return pretty(sanitized);
+	}, [size]);
+
+	return sizeHuman;
+}
+
+export default useHumanSize;

--- a/src/utils/hooks/useWhatChanged.ts
+++ b/src/utils/hooks/useWhatChanged.ts
@@ -19,11 +19,16 @@ export function useWhatChanged(props: Record<string, any>) {
 
 	previous.current = props;
 
-	const count = Object.keys(differences);
+	const keys = Object.keys(differences);
+	const rows = keys.reduce((acc, curr) => [
+		...acc,
+		{ Property: curr, Previous: differences[curr].previous, Current: differences[curr].current },
+	], []);
 
-	if (!count.length) {
+	if (!keys.length) {
 		console.log("There were no changes");
 	} else {
-		console.log("Some things changed:", differences);
+		console.log("Some things changed:");
+		console.table(rows, ["Property", "Previous", "Current"]);
 	}
 }


### PR DESCRIPTION
Addresses a number of issues regarding the upload field component:

- Modifies the `setFieldValue` method of the form controller and by further extension the `onChange` method that fields recieve, to allow for a callback style value setter. That callback recieves the most up to date value as a reference.
- Merges pending items with current value items and utilises internal data to store both sets as a single array.
- Splits the `FileCard` component into `FileCard` for uploaded items and `FileCardPending` for pending uploads due to their specialised responsibilities.
- Moves the form value cleaner to the default resolver instead of performing value cleaning inside `setFieldValue` making individual field value resolvers responsible for cleaning their values.
- Removes the button onclick hack with proper HTML labels with `for` attributes.
- Fixes drag over functionality by keeping a `dragEnter` and `dragLeave` counter instead of using a boolean.
- Corrects deletion order of operations and displays a spinner whilst an item is being deleted.
- Other minor refactors such as reordering and renaming of types.