### PR TITLE
MOS-1181 Rework

### DIFF
--- a/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectDropdownContent.tsx
+++ b/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectDropdownContent.tsx
@@ -40,7 +40,7 @@ function DataViewFilterMultiselectDropdownContent(props: DataViewFilterMultisele
 
 	// mark the active comparison
 	const activeComparison = props.comparisons ? props.comparisons.find(val => val.value === state.comparison) : undefined;
-	const disabled = state.selected.length >= props.selectLimit;
+	const disabled = props.selectLimit > 0 && state.selected.length >= props.selectLimit;
 
 	useEffect(() => {
 		async function fetchData() {

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -17,7 +17,7 @@ function getValueLimit(def: FieldDef): number | undefined {
 	}
 
 	if (def.type === "advancedSelection") {
-		if (def.inputSettings.selectLimit === 1) {
+		if (def.inputSettings.selectLimit < 2) {
 			return;
 		}
 

--- a/src/components/Field/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
+++ b/src/components/Field/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
@@ -33,7 +33,7 @@ export const Playground = (): ReactElement => {
 	);
 	const getOptionsLimit = number("Get options limit", 5);
 	const createNewOptionsKnob = boolean("Create new option", true);
-	const selectLimit = text("Select limit", "");
+	const selectLimit = number("Select limit", -1);
 
 	const categoriesApi = new JSONDB(categories);
 
@@ -86,7 +86,7 @@ export const Playground = (): ReactElement => {
 							? getOptionsLimit
 							: undefined,
 						createNewOption: createNewOptionsKnob ? createNewOption : undefined,
-						selectLimit: selectLimit.trim() !== "" && !isNaN(Number(selectLimit)) ? Number(selectLimit) : undefined,
+						selectLimit,
 					},
 				},
 			],

--- a/src/components/Field/FormFieldAdvancedSelection/AdvancedSelectionDrawer.tsx
+++ b/src/components/Field/FormFieldAdvancedSelection/AdvancedSelectionDrawer.tsx
@@ -67,6 +67,10 @@ const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactE
 		};
 	};
 
+	// TODO: Already doing this in FormFieldAdvancedSelection.
+	// Clean it up.
+	const selectLimit = (fieldDef?.inputSettings?.selectLimit || 0) > 0 ? fieldDef?.inputSettings?.selectLimit : -1;
+
 	return (
 		<FormDrawerWrapper className="advancedSelection">
 			<PageHeader
@@ -83,7 +87,7 @@ const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactE
 				onApply={onSubmit}
 				placeholder="Search..."
 				limit={externalOptions?.getOptionsLimit}
-				selectLimit={fieldDef.inputSettings?.selectLimit}
+				selectLimit={selectLimit}
 				onChange={(value) => setSelectedOptions(value)}
 				hideButtons={true}
 				createNewOption={fieldDef.inputSettings?.createNewOption}

--- a/src/components/Field/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
+++ b/src/components/Field/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
@@ -38,6 +38,8 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [isMobileView, setIsMobileView] = useState(false);
 
+	const selectLimit = (fieldDef?.inputSettings?.selectLimit || 0) > 0 ? fieldDef?.inputSettings?.selectLimit : -1;
+
 	useEffect(() => {
 		const setResponsiveness = () => {
 			setIsMobileView(window.innerWidth < BREAKPOINTS.mobile);
@@ -80,7 +82,7 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 		<>
 			{value?.length > 0 && !isModalOpen ? (
 				<AdvancedSelectionWrapper>
-					{(!fieldDef?.inputSettings?.selectLimit || value?.length < fieldDef?.inputSettings?.selectLimit) && (
+					{(selectLimit < 0 || value?.length < selectLimit) && (
 						<Button
 							color="teal"
 							variant="text"


### PR DESCRIPTION
Ensures a negative `selectLimit` input setting imposes no limit. Changes the `selectLimit` Playground story control to use a number input instead of a text input.