### PR TITLE
MOS-1222 Form tabbing

### DIFF
--- a/automation_testing/tests/Components/Content/Content.spec.ts
+++ b/automation_testing/tests/Components/Content/Content.spec.ts
@@ -52,7 +52,7 @@ test.describe.parallel("Components - Content - Playground", () => {
 		expect(await contentPage.getBackgroundColorFromElement(contentPage.titleBarLocator)).toBe(theme.newColors.grey2["100"]);
 
 		// Get total number of buttons present in the page.
-		const buttonCount = await contentPage.button.count();
+		const buttonCount = await contentPage.button.count() - 1;
 		expect(await contentPage.titleBarLocator.locator("button").count()).toBe(buttonCount);
 	});
 

--- a/src/components/Field/FormFieldColorPicker/ColorPicker.styled.tsx
+++ b/src/components/Field/FormFieldColorPicker/ColorPicker.styled.tsx
@@ -4,9 +4,10 @@ import { ColorSelectedProps } from "./ColorPickerTypes";
 import { TransientProps } from "@root/types";
 import Popover from "@mui/material/Popover";
 
-export const ColorContainer = styled.div<TransientProps<ColorSelectedProps, "displayColorPicker" | "disabled">>`
+export const ColorContainer = styled.button<TransientProps<ColorSelectedProps, "displayColorPicker" | "disabled">>`
   background: ${theme.newColors.grey1["100"]};
   border: ${theme.borders.simplyGrey};
+  cursor: pointer;
   margin-bottom: ${({ $displayColorPicker }) => ($displayColorPicker ? "8px" : 0)};
   opacity: ${({ $disabled }) => ($disabled ? 0.5 : 1)};
   padding: 10px;
@@ -26,7 +27,6 @@ export const ColorDiv = styled.div<TransientProps<ColorSelectedProps, "disabled"
 			return `background: ${$color};`;
 		}
 	}}
-  cursor: ${({ $disabled }) => (!$disabled ? "pointer" : "auto")};
   height: 31px;
   pointer-events: ${({ $disabled }) => (!$disabled ? "auto" : "none")};
   width: 80px;

--- a/src/components/Field/FormFieldColorPicker/ColorPickerTypes.tsx
+++ b/src/components/Field/FormFieldColorPicker/ColorPickerTypes.tsx
@@ -4,7 +4,7 @@ export interface ColorSelectedProps {
 	color: any;
 	displayColorPicker?: boolean;
 	disabled?: boolean;
-	onClick?: React.MouseEventHandler<HTMLDivElement>;
+	onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 export type ColorData = string;

--- a/src/components/Field/FormFieldColorPicker/ColorSelected.tsx
+++ b/src/components/Field/FormFieldColorPicker/ColorSelected.tsx
@@ -7,12 +7,16 @@ const ColorSelected = (props: ColorSelectedProps): ReactElement => {
 	const { disabled, color, onClick, displayColorPicker } = props;
 
 	return (
-		<ColorContainer $disabled={disabled} $displayColorPicker={displayColorPicker}>
+		<ColorContainer
+			$disabled={disabled}
+			$displayColorPicker={displayColorPicker}
+			onClick={onClick}
+			type="button"
+		>
 			<ColorDiv
 				data-testid="colordiv-test"
 				$disabled={disabled}
 				$color={color}
-				onClick={onClick}
 			/>
 		</ColorContainer>
 	);

--- a/src/components/Field/FormFieldImageUpload/FormFieldImageUpload.styled.ts
+++ b/src/components/Field/FormFieldImageUpload/FormFieldImageUpload.styled.ts
@@ -26,14 +26,7 @@ export const DragAndDropSpan = styled.span<{ $isOver?: boolean }>`
 `;
 
 export const FileInput = styled.input`
-  height: 100%;
-  opacity: 0;
-  position: absolute;
-  width: 100%;
-
-  &:focus {
-    outline: none;
-  }
+  display: none;
 `;
 
 export const Column = styled.div`

--- a/src/components/Field/FormFieldImageUpload/FormFieldImageUpload.tsx
+++ b/src/components/Field/FormFieldImageUpload/FormFieldImageUpload.tsx
@@ -250,7 +250,6 @@ const FormFieldImageUpload = (
 								disabled={disabled}
 								label="UPLOAD FILES"
 								onClick={uploadFiles}
-								muiAttrs={{ disableRipple: true }}
 							/>
 						</>
 					)}

--- a/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/BrowseOption/BrowseOption.tsx
+++ b/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/BrowseOption/BrowseOption.tsx
@@ -32,6 +32,7 @@ const BrowseOption = (props: BrowseOptionProps): ReactElement => {
 				$disabled={disabled}
 				onClick={async (e) => await handleBrowse(e, assetType)}
 				data-testid={`browse-${assetType}-test`}
+				type="button"
 			>
 				<IconComponent />
 			</RoundBackground>

--- a/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsing.styled.tsx
+++ b/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/ImageVideoLinkDocumentBrowsing.styled.tsx
@@ -178,11 +178,12 @@ export const StyledTooltip = styled(Tooltip)`
   }
 `;
 
-export const RoundBackground = styled.div<TransientProps<BrowseOptionProps, "disabled">>`
+export const RoundBackground = styled.button<TransientProps<BrowseOptionProps, "disabled">>`
   align-items: center;
   cursor: ${({ $disabled }) => (!$disabled ? "pointer" : "auto")};
   background-color: ${theme.newColors.realTeal["100"]};
   border-radius: 22px;
+  border: 0;
   display: flex;
   height: 40px;
   justify-content: center;

--- a/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
+++ b/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
@@ -68,6 +68,7 @@ const FormFieldTextEditor = (
 		direction,
 		language,
 		limitChars: maxCharacters,
+		tabIndex: 0,
 	}), [
 		disabled,
 		spellcheck,

--- a/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { memo, SyntheticEvent, useEffect, useState, useMemo, useId } from "react";
+import { memo, SyntheticEvent, useCallback, useEffect, useState, useMemo, useRef, useId } from "react";
 import Button from "@root/components/Button";
 import { MosaicFieldProps } from "@root/components/Field";
 import Snackbar from "@root/components/Snackbar";
@@ -26,6 +26,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 	const { addWait } = methods || {};
 	const generatedId = useId();
 	const id = providedId || generatedId;
+	const inputRef = useRef<HTMLInputElement | undefined>();
 
 	const {
 		limit = -1,
@@ -235,6 +236,14 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 		onChange((items = []) => items.filter(item => item.id !== id));
 	};
 
+	const handleUploadButtonClick = useCallback(() => {
+		if (!inputRef.current) {
+			return;
+		}
+
+		inputRef.current.click();
+	}, []);
+
 	const closeSnackbar = (_event?: SyntheticEvent, reason?: string) => {
 		if (reason === "clickaway") {
 			return;
@@ -271,8 +280,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 								variant="outlined"
 								label="UPLOAD FILES"
 								disabled={disabled}
-								as="label"
-								muiAttrs={{ htmlFor: `${id}-input` }}
+								onClick={handleUploadButtonClick}
 							/>
 						</>
 					)}
@@ -286,6 +294,7 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 						multiple={limit < 0 || (limit > 1 && limit - currentLength > 1)}
 						accept={fileExtensions.acceptAttr}
 						id={`${id}-input`}
+						ref={inputRef}
 					/>
 				</DragAndDropContainer>
 			)}


### PR DESCRIPTION
Addresses a number of field types to improve accessibility, specifically ensuring all fields can be focused through the use of keyboard tabbing.

- FormFieldColorPicker: Swaps the containing `div` element for a `button` element.
- FormFieldImageUpload: Enables the button ripple and prevents display of input instead of hiding hacks.
- FormFieldImageVideoLinkDocumentBrowsing: Swaps circular icon `div` elements out for `button` elements.
- FormFieldTextEditor: Provides the tabIndex property to jodit configuration.
- FormFieldUpload: Swaps the "Upload Files" `label` element for a `button` element.