### PR TITLE
MOS-1221 Table resize issue in Safari

### DIFF
--- a/src/components/Field/FormFieldNumberTable/FormFieldNumberTable.styled.tsx
+++ b/src/components/Field/FormFieldNumberTable/FormFieldNumberTable.styled.tsx
@@ -5,6 +5,7 @@ export const StyledTable = styled.table`
   border-collapse: collapse;
   color: ${theme.newColors.almostBlack["100"]};
   background-color: white;
+  width: 100%;
 `;
 
 export const Th = styled.th`


### PR DESCRIPTION
Provides `FormFieldNumberTable`'s table with an explicit full width to ensure it stretches (or shrinks) to the width of it's containing element.