### PR TITLE
MOS-1222 Rework

### DIFF
--- a/src/components/Field/FormFieldAddress/AddressCard/AddressCard.styled.tsx
+++ b/src/components/Field/FormFieldAddress/AddressCard/AddressCard.styled.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 // Utils
 import theme from "@root/theme";
+import ButtonRow from "@root/components/ButtonRow";
 
 export const StyledAddressCard = styled.div`
   display: flex;
@@ -28,17 +29,7 @@ export const AddressTitle = styled.span`
   margin-bottom: 12px !important;
 `;
 
-export const ButtonsWrapper = styled.div`
+export const StyledButtonRow = styled(ButtonRow)`
   align-self: flex-end;
-  display: flex;
   margin-top: auto;
-
-  span:first-child {
-    border-right: ${theme.borders.simplyGrey};
-    padding-right: 16px;
-  }
-
-  span:last-child {
-    padding-left: 16px;
-  }
 `;

--- a/src/components/Field/FormFieldAddress/AddressCard/AddressCard.tsx
+++ b/src/components/Field/FormFieldAddress/AddressCard/AddressCard.tsx
@@ -14,7 +14,6 @@ import {
 // Types
 import { AddressCardProps } from "../AddressTypes";
 import { joinAnd } from "@root/utils/string";
-import ButtonRow from "@root/components/ButtonRow";
 
 const AddressCard = (props: AddressCardProps): ReactElement => {
 	const { address, onEdit, onRemoveAddress, disabled } = props;

--- a/src/components/Field/FormFieldAddress/AddressCard/AddressCard.tsx
+++ b/src/components/Field/FormFieldAddress/AddressCard/AddressCard.tsx
@@ -15,10 +15,6 @@ import {
 import { AddressCardProps } from "../AddressTypes";
 import { joinAnd } from "@root/utils/string";
 
-const buttonMuiAttrs = {
-	disableRipple: true,
-};
-
 const AddressCard = (props: AddressCardProps): ReactElement => {
 	const { address, onEdit, onRemoveAddress, disabled } = props;
 
@@ -42,13 +38,11 @@ const AddressCard = (props: AddressCardProps): ReactElement => {
 					color="teal"
 					variant="text"
 					disabled={disabled}
-					muiAttrs={buttonMuiAttrs}
 					onClick={() => onEdit(address)}
 				/>
 				<Button
 					color="red"
 					variant="text"
-					muiAttrs={buttonMuiAttrs}
 					disabled={disabled}
 					label="Remove"
 					onClick={() => onRemoveAddress(address)}

--- a/src/components/Field/FormFieldAddress/AddressCard/AddressCard.tsx
+++ b/src/components/Field/FormFieldAddress/AddressCard/AddressCard.tsx
@@ -7,13 +7,14 @@ import Button from "@root/components/Button";
 // Styles
 import {
 	AddressTitle,
-	ButtonsWrapper,
 	StyledAddressCard,
+	StyledButtonRow,
 } from "./AddressCard.styled";
 
 // Types
 import { AddressCardProps } from "../AddressTypes";
 import { joinAnd } from "@root/utils/string";
+import ButtonRow from "@root/components/ButtonRow";
 
 const AddressCard = (props: AddressCardProps): ReactElement => {
 	const { address, onEdit, onRemoveAddress, disabled } = props;
@@ -32,7 +33,7 @@ const AddressCard = (props: AddressCardProps): ReactElement => {
 				{`${address?.city}, ${address?.state?.label ? address.state.label : ""} ${address?.postalCode}`}
 			</span>
 			<span>{address?.country?.label}</span>
-			<ButtonsWrapper>
+			<StyledButtonRow separator>
 				<Button
 					label="Edit"
 					color="teal"
@@ -47,7 +48,7 @@ const AddressCard = (props: AddressCardProps): ReactElement => {
 					label="Remove"
 					onClick={() => onRemoveAddress(address)}
 				/>
-			</ButtonsWrapper>
+			</StyledButtonRow>
 		</StyledAddressCard>
 	);
 };

--- a/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/FormFieldImageVideoLinkDocumentBrowsing.tsx
+++ b/src/components/Field/FormFieldImageVideoLinkDocumentBrowsing/FormFieldImageVideoLinkDocumentBrowsing.tsx
@@ -245,7 +245,6 @@ const FormFieldImageVideoLinkDocumentBrowsing = (
 							color="teal"
 							variant="text"
 							label="Browse"
-							muiAttrs={{ disableRipple: true }}
 							disabled={disabled}
 							onClick={async (e) => await handleBrowse(e, assetType)}
 						/>
@@ -253,7 +252,6 @@ const FormFieldImageVideoLinkDocumentBrowsing = (
 							color="red"
 							variant="text"
 							label="Remove"
-							muiAttrs={{ disableRipple: true }}
 							disabled={disabled}
 							onClick={(e) => handleRemove(e)}
 						/>


### PR DESCRIPTION
Re-enables the Material ripple effect for the address card and asset browser buttons because it's used for indication of element focus.