### PR TITLE
MOS-1312 Toggle wrappers

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -20,6 +20,7 @@ import ButtonRow from "../ButtonRow";
 import { ButtonProps } from "./ButtonTypes";
 import { useStoryBookCssReset } from "@root/utils/reactTools";
 import { useToggle } from "@root/utils/toggle";
+import { toggleMap, toggleMapInverse, toggleOptions, toggleOptionsInverse } from "@root/utils/storyUtils";
 
 export default {
 	title: "Components/Button",
@@ -50,34 +51,6 @@ const menuContent = (
 		<MenuItem >Logout</MenuItem>
 	</div>
 );
-
-const commonToggleMap = {
-	"Undefined": undefined,
-	"True": true,
-	"False": false,
-	"Function that returns true": () => true,
-	"Function that returns false": () => false,
-};
-
-const showMap = {
-	...commonToggleMap,
-	"Array of true values": [true, true, true],
-	"Array with one falsy value": [true, false, true],
-	"Array of functions that return true": [() => true, () => true],
-	"Array of functions, one returns false": [() => false, () => true],
-};
-
-const showOptions = Object.keys(showMap);
-
-const disabledMap = {
-	...commonToggleMap,
-	"Array of false values": [false, false, false],
-	"Array with one truthy value": [false, true, false],
-	"Array of functions that return false": [() => false, () => false],
-	"Array of functions, one returns true": [() => true, () => false],
-};
-
-const disabledOptions = Object.keys(disabledMap);
 
 export const Playground = (): ReactElement => {
 	const buttonVariant = select(
@@ -113,12 +86,12 @@ export const Playground = (): ReactElement => {
 	);
 	const show = select(
 		"Show",
-		showOptions,
+		toggleOptions,
 		"Undefined",
 	);
 	const disabled = select(
 		"Disabled",
-		disabledOptions,
+		toggleOptionsInverse,
 		"Undefined",
 	);
 	const label = select("Type of label", ["String", "JSX"], "String");
@@ -153,7 +126,7 @@ export const Playground = (): ReactElement => {
 	const action = {
 		name: "show",
 		onClick: () => alert("Clicked"),
-		show: showMap[show],
+		show: toggleMap[show],
 		color: buttonColor,
 		variant: buttonVariant,
 	};
@@ -172,7 +145,7 @@ export const Playground = (): ReactElement => {
 						variant={buttonVariant}
 						color={buttonColor}
 						fullWidth={fullWidth}
-						disabled={disabledMap[disabled]}
+						disabled={toggleMapInverse[disabled]}
 						tooltip={tooltipType}
 						size={size}
 						mIcon={useIcon && AddIcon}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -110,6 +110,15 @@ function ButtonWithState(props: ButtonProps) {
 		anchorProps.onMouseLeave();
 	};
 
+	const shownMenuItems = useToggle(props.menuItems || [], "show", true);
+
+	// If this is a button with menu items
+	// but there are no menu items to show
+	// then no need to render the button.
+	if (props.menuItems && !shownMenuItems.length) {
+		return null;
+	}
+
 	return (
 		<>
 			<ButtonBase
@@ -140,7 +149,7 @@ function ButtonWithState(props: ButtonProps) {
 					</PopoverWrapper>
 				</Popover>
 			) : props.menuItems ? (
-				<Menu items={props.menuItems} anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={closeMenu} />
+				<Menu items={shownMenuItems} anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={closeMenu} />
 			) : props.menuContent && (
 				<MenuBase anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={closeMenu}>
 					{props.menuContent}

--- a/src/components/ButtonRow/ButtonRow.stories.mdx
+++ b/src/components/ButtonRow/ButtonRow.stories.mdx
@@ -1,0 +1,1 @@
+<Meta title="Components/ButtonRow/Readme"/>

--- a/src/components/ButtonRow/ButtonRow.stories.tsx
+++ b/src/components/ButtonRow/ButtonRow.stories.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import { ReactElement, useMemo } from "react";
+import { withKnobs, select } from "@storybook/addon-knobs";
+
+import ButtonRow from ".";
+import { ButtonProps } from "../Button";
+import styled from "styled-components";
+
+export default {
+	title: "Components/ButtonRow",
+	decorators: [withKnobs],
+};
+
+const StyledButtonRow = styled(ButtonRow)`
+	border: 2px solid maroon;
+	background: #eee;
+	padding: 1rem;
+`;
+
+const showMap = {
+	"Undefined": undefined,
+	"True": true,
+	"False": false,
+	"Function that returns true": () => true,
+	"Function that returns false": () => false,
+	"Array of true values": [true, true, true],
+	"Array with one falsy value": [true, false, true],
+	"Array of functions that return true": [() => true, () => true],
+	"Array of functions, one returns false": [() => false, () => true],
+};
+
+const showOptions = Object.keys(showMap) as (keyof typeof showMap)[];
+
+export const Playground = (): ReactElement => {
+	const showToast = select("Show toast", showOptions, "Undefined");
+	const showTea = select("Show tea", showOptions, "Undefined");
+	const showCrumpets = select("Show crumpets", showOptions, "Undefined");
+
+	const buttonDefs: ButtonProps[] = useMemo(() => [
+		{
+			color: "red",
+			variant: "contained",
+			label: "Toast",
+			show: showMap[showToast],
+		},
+		{
+			color: "blue",
+			variant: "contained",
+			label: "Tea",
+			show: showMap[showTea],
+		},
+		{
+			color: "yellow",
+			variant: "contained",
+			label: "Crumpets",
+			show: showMap[showCrumpets],
+		},
+	], [showToast, showTea, showCrumpets]);
+
+	return (
+		<StyledButtonRow buttons={buttonDefs} />
+	);
+};

--- a/src/components/ButtonRow/ButtonRow.stories.tsx
+++ b/src/components/ButtonRow/ButtonRow.stories.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import { ReactElement, useMemo } from "react";
+import styled from "styled-components";
 import { withKnobs, select } from "@storybook/addon-knobs";
+import { toggleMap, toggleOptions } from "@root/utils/storyUtils";
 
 import ButtonRow from ".";
 import { ButtonProps } from "../Button";
-import styled from "styled-components";
 
 export default {
 	title: "Components/ButtonRow",
@@ -17,43 +18,29 @@ const StyledButtonRow = styled(ButtonRow)`
 	padding: 1rem;
 `;
 
-const showMap = {
-	"Undefined": undefined,
-	"True": true,
-	"False": false,
-	"Function that returns true": () => true,
-	"Function that returns false": () => false,
-	"Array of true values": [true, true, true],
-	"Array with one falsy value": [true, false, true],
-	"Array of functions that return true": [() => true, () => true],
-	"Array of functions, one returns false": [() => false, () => true],
-};
-
-const showOptions = Object.keys(showMap) as (keyof typeof showMap)[];
-
 export const Playground = (): ReactElement => {
-	const showToast = select("Show toast", showOptions, "Undefined");
-	const showTea = select("Show tea", showOptions, "Undefined");
-	const showCrumpets = select("Show crumpets", showOptions, "Undefined");
+	const showToast = select("Show toast", toggleOptions, "Undefined");
+	const showTea = select("Show tea", toggleOptions, "Undefined");
+	const showCrumpets = select("Show crumpets", toggleOptions, "Undefined");
 
 	const buttonDefs: ButtonProps[] = useMemo(() => [
 		{
 			color: "red",
 			variant: "contained",
 			label: "Toast",
-			show: showMap[showToast],
+			show: toggleMap[showToast],
 		},
 		{
 			color: "blue",
 			variant: "contained",
 			label: "Tea",
-			show: showMap[showTea],
+			show: toggleMap[showTea],
 		},
 		{
 			color: "yellow",
 			variant: "contained",
 			label: "Crumpets",
-			show: showMap[showCrumpets],
+			show: toggleMap[showCrumpets],
 		},
 	], [showToast, showTea, showCrumpets]);
 

--- a/src/components/Form/Row/Row.tsx
+++ b/src/components/Form/Row/Row.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import { memo } from "react";
+import { memo, useMemo } from "react";
 
 import { RowPropTypes } from "./RowTypes";
 import { StyledRow } from "./RowStyled";
 
 // Components
 import Col from "../Col";
+import { useWrappedToggle } from "@root/utils";
 
 const Row = (props: RowPropTypes) => {
 	const {
@@ -18,6 +19,21 @@ const Row = (props: RowPropTypes) => {
 		spacing,
 		methods,
 	} = props;
+
+	/**
+	 * TODO We're already performing this field search within ColField, so it's
+	 * a waste to do it here as well. It's worth only doing it here and
+	 * passing the field defs down
+	 */
+	const fieldDefsFlattened = useMemo(
+		() => row.flat().flat().map(fieldName => fieldsDef.find((fieldDef) => fieldName === fieldDef.name)),
+		[fieldsDef, row],
+	);
+	const shownFields = useWrappedToggle(fieldDefsFlattened, state, "show", true);
+
+	if (!shownFields.length) {
+		return null;
+	}
 
 	return (
 		<StyledRow data-layout="row" $columns={row.length} $gridMinWidth={gridMinWidth} $spacing={spacing}>

--- a/src/components/Form/stories/FormWithLayout.stories.tsx
+++ b/src/components/Form/stories/FormWithLayout.stories.tsx
@@ -1,15 +1,15 @@
 import * as React from "react";
 import { ReactElement, useEffect, useMemo } from "react";
 import { withKnobs, boolean, object, select } from "@storybook/addon-knobs";
+import DeleteIcon from "@mui/icons-material/Delete";
+import AddIcon from "@mui/icons-material/Add";
 
 // Utils
 import { checkboxOptions } from "@root/components/Field/FormFieldCheckbox/FormFieldCheckboxUtils";
 import { useForm } from "@root/components/Form";
 import { validateEmail, validateSlow } from "../validators";
 import { menuOptions } from "@root/forms/MenuFormFieldCard/MenuFormFieldUtils";
-import { renderButtons } from "@root/utils/storyUtils";
-import DeleteIcon from "@mui/icons-material/Delete";
-import AddIcon from "@mui/icons-material/Add";
+import { renderButtons, toggleMap, toggleOptions } from "@root/utils/storyUtils";
 
 // Components
 import Form from "../Form";
@@ -35,28 +35,14 @@ function randomNumber(min: number, max: number) {
 	return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
-const showMap = {
-	"Undefined": undefined,
-	"True": true,
-	"False": false,
-	"Function that returns true": () => true,
-	"Function that returns false": () => false,
-	"Array of true values": [true, true, true],
-	"Array with one falsy value": [true, false, true],
-	"Array of functions that return true": [() => true, () => true],
-	"Array of functions, one returns false": [() => false, () => true],
-};
-
-const showOptions = Object.keys(showMap) as (keyof typeof showMap)[];
-
 export const FormWithLayout = (props: { height?: string }): ReactElement => {
 	const showState = boolean("Show state", false);
 	const collapsed = boolean("Collapse sections", false);
 	const section1Fields = object("Section 1 Fields", initialSection1Fields);
 
-	const showSimpleText = select("Show Simple Text", showOptions, "Undefined");
-	const showBigText = select("Show Big Text", showOptions, "Undefined");
-	const showTextFieldValidatesEmail = select("Show TextField that validates email", showOptions, "Undefined");
+	const showSimpleText = select("Show Simple Text", toggleOptions, "Undefined");
+	const showBigText = select("Show Big Text", toggleOptions, "Undefined");
+	const showTextFieldValidatesEmail = select("Show TextField that validates email", toggleOptions, "Undefined");
 
 	const controller = useForm();
 	const { state, methods: { setFieldValue }, handleSubmit } = controller;
@@ -103,7 +89,7 @@ export const FormWithLayout = (props: { height?: string }): ReactElement => {
 					label: "Simple Text",
 					type: "text",
 					instructionText: "Instruction text text1",
-					show: showMap[showSimpleText],
+					show: toggleMap[showSimpleText],
 				},
 				{
 					name: "textarea",
@@ -113,7 +99,7 @@ export const FormWithLayout = (props: { height?: string }): ReactElement => {
 					inputSettings: {
 						multiline: true,
 					},
-					show: showMap[showBigText],
+					show: toggleMap[showBigText],
 				},
 				{
 					name: "text2",
@@ -122,7 +108,7 @@ export const FormWithLayout = (props: { height?: string }): ReactElement => {
 					helperText: state.data.text2,
 					instructionText: "Instruction text text2",
 					validators: [validateEmail, validateSlow],
-					show: showMap[showTextFieldValidatesEmail],
+					show: toggleMap[showTextFieldValidatesEmail],
 				},
 				{
 					name: "text3",

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -1,13 +1,16 @@
 import * as React from "react";
 import { ReactElement } from "react";
+import { withKnobs, select } from "@storybook/addon-knobs";
 import CreateIcon from "@mui/icons-material/Create";
 import DeleteIcon from "@mui/icons-material/Delete";
 import CloudDownloadIcon from "@mui/icons-material/CloudDownload";
 
 import { default as Button, ButtonProps } from "../Button";
+import { toggleMap, toggleOptions } from "@root/utils/storyUtils";
 
 export default {
 	title : "Components/Menu",
+	decorators: [withKnobs],
 };
 
 const MENU_ITEMS = [
@@ -32,9 +35,19 @@ const MENU_ITEMS = [
 ];
 
 export const example = (): ReactElement => {
+	const showItems = {
+		"Item 1": select("Show Item 1", toggleOptions, "Undefined"),
+		"Item 2": select("Show Item 2", toggleOptions, "Undefined"),
+		"Item 3": select("Show Item 3", toggleOptions, "Undefined"),
+		"Item 4": select("Show Item 4", toggleOptions, "Undefined"),
+		"Item 5": select("Show Item 5", toggleOptions, "Undefined"),
+		"Item 6": select("Show Item 6", toggleOptions, "Undefined"),
+	};
+
 	const menuItems: ButtonProps["menuItems"] = MENU_ITEMS.map((val) => {
 		return {
 			...val,
+			show: toggleMap[showItems[val.label]],
 			onClick : function() {
 				alert(`Clicked ${val.label}`);
 			},

--- a/src/components/SideNav/SideNav.stories.tsx
+++ b/src/components/SideNav/SideNav.stories.tsx
@@ -39,7 +39,9 @@ const showOptions = Object.keys(showMap) as (keyof typeof showMap)[];
 export const Example = (): ReactElement => {
 	const [content, setContent] = useState<JSX.Element>(homeContent);
 	const [active, setActive] = useState("home");
-	const show = select("Show Google", showOptions, "Undefined");
+	const showAssets = select("Show assets", showOptions, "Undefined");
+	const showMapPublisher = select("Show map publisher", showOptions, "Undefined");
+	const showDynamicContent = select("Show dynamic content", showOptions, "Undefined");
 
 	const onNav = (args: SideNavArgs) => {
 		setActive(args.item.name);
@@ -107,7 +109,6 @@ export const Example = (): ReactElement => {
 					href: "https://www.google.co.uk",
 				},
 				onNav: false,
-				show: showMap[show],
 			},
 			{
 				label: "Google (New Tab)",
@@ -128,6 +129,7 @@ export const Example = (): ReactElement => {
 					setActive(args.item.name);
 					setContent(<h1>Assets</h1>);
 				},
+				show: showMap[showAssets],
 			},
 			{
 				label: "Map Publisher",
@@ -136,6 +138,7 @@ export const Example = (): ReactElement => {
 					setActive(args.item.name);
 					setContent(<h1>Map Publisher</h1>);
 				},
+				show: showMap[showMapPublisher],
 			},
 			{
 				label: "Dynamic Content",
@@ -144,6 +147,7 @@ export const Example = (): ReactElement => {
 					setActive(args.item.name);
 					setContent(<h1>Dynamic Content</h1>);
 				},
+				show: showMap[showDynamicContent],
 			},
 		],
 		[
@@ -181,7 +185,7 @@ export const Example = (): ReactElement => {
 				},
 			},
 		],
-	], [show]);
+	], [showAssets, showMapPublisher, showDynamicContent]);
 
 	const parentHeight = number("Parent height (px)", 500);
 

--- a/src/components/SideNav/SideNav.stories.tsx
+++ b/src/components/SideNav/SideNav.stories.tsx
@@ -14,6 +14,7 @@ import TaskAltIcon from "@mui/icons-material/TaskAlt";
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 import OpenInNew from "@mui/icons-material/OpenInNew";
 import Link from "@mui/icons-material/Link";
+import { toggleMap, toggleOptions } from "@root/utils/storyUtils";
 
 export default {
 	title: "Components/SideNav",
@@ -22,26 +23,12 @@ export default {
 
 const homeContent = <h1>Welcome home!</h1>;
 
-const showMap = {
-	"Undefined": undefined,
-	"True": true,
-	"False": false,
-	"Function that returns true": () => true,
-	"Function that returns false": () => false,
-	"Array of true values": [true, true, true],
-	"Array with one falsy value": [true, false, true],
-	"Array of functions that return true": [() => true, () => true],
-	"Array of functions, one returns false": [() => false, () => true],
-};
-
-const showOptions = Object.keys(showMap) as (keyof typeof showMap)[];
-
 export const Example = (): ReactElement => {
 	const [content, setContent] = useState<JSX.Element>(homeContent);
 	const [active, setActive] = useState("home");
-	const showAssets = select("Show assets", showOptions, "Undefined");
-	const showMapPublisher = select("Show map publisher", showOptions, "Undefined");
-	const showDynamicContent = select("Show dynamic content", showOptions, "Undefined");
+	const showAssets = select("Show assets", toggleOptions, "Undefined");
+	const showMapPublisher = select("Show map publisher", toggleOptions, "Undefined");
+	const showDynamicContent = select("Show dynamic content", toggleOptions, "Undefined");
 
 	const onNav = (args: SideNavArgs) => {
 		setActive(args.item.name);
@@ -129,7 +116,7 @@ export const Example = (): ReactElement => {
 					setActive(args.item.name);
 					setContent(<h1>Assets</h1>);
 				},
-				show: showMap[showAssets],
+				show: toggleMap[showAssets],
 			},
 			{
 				label: "Map Publisher",
@@ -138,7 +125,7 @@ export const Example = (): ReactElement => {
 					setActive(args.item.name);
 					setContent(<h1>Map Publisher</h1>);
 				},
-				show: showMap[showMapPublisher],
+				show: toggleMap[showMapPublisher],
 			},
 			{
 				label: "Dynamic Content",
@@ -147,7 +134,7 @@ export const Example = (): ReactElement => {
 					setActive(args.item.name);
 					setContent(<h1>Dynamic Content</h1>);
 				},
-				show: showMap[showDynamicContent],
+				show: toggleMap[showDynamicContent],
 			},
 		],
 		[

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -16,6 +16,10 @@ import { useToggle } from "@root/utils/toggle";
 const SideNavGroup = ({ items, collapse, onLinkClicked, active }: SideNavGroupProps): ReactElement => {
 	const shownItems = useToggle(items, "show", true);
 
+	if (!shownItems.length) {
+		return null;
+	}
+
 	return (
 		<LinksWrapper data-testid="section-wrapper" $collapse={collapse}>
 			{shownItems.map((item, idx) => {

--- a/src/utils/storyUtils.ts
+++ b/src/utils/storyUtils.ts
@@ -21,3 +21,31 @@ export const renderButtons = (handleSubmit: FormHandleSubmit, show = { showCance
 		show: show.showSave,
 	},
 ];
+
+const commonToggleMap = {
+	"Undefined": undefined,
+	"True": true,
+	"False": false,
+	"Function that returns true": () => true,
+	"Function that returns false": () => false,
+};
+
+export const toggleMap = {
+	...commonToggleMap,
+	"Array of true values": [true, true, true],
+	"Array with one falsy value": [true, false, true],
+	"Array of functions that return true": [() => true, () => true],
+	"Array of functions, one returns false": [() => false, () => true],
+};
+
+export const toggleOptions = Object.keys(toggleMap) as (keyof typeof toggleMap)[];
+
+export const toggleMapInverse = {
+	...commonToggleMap,
+	"Array of false values": [false, false, false],
+	"Array with one truthy value": [false, true, false],
+	"Array of functions that return false": [() => false, () => false],
+	"Array of functions, one returns true": [() => true, () => false],
+};
+
+export const toggleOptionsInverse = Object.keys(toggleMapInverse) as (keyof typeof toggleMapInverse)[];


### PR DESCRIPTION
Improves on the show mechanic to ensure wrapping elements are not rendered if there are no items to render within as a result of their `show` evaluation. Specifically:
- Buttons should not render if the `menuItems` property is provided, but there are no menu items to render.
- Form rows should not render if there are no fields and by further extension columns to render within.
- SideNav groups should not render if there are no navigation items to render within.