### PR TITLE
MOS-1225 Date filter invalid option

### DIFF
--- a/src/components/DataViewFilterDate/DataViewFilterDate.tsx
+++ b/src/components/DataViewFilterDate/DataViewFilterDate.tsx
@@ -50,7 +50,11 @@ export default function DataViewFilterDate(props: DataViewFilterDateProps): Reac
 				valueString = `to ${endFormat}`;
 			}
 		} else if ("option" in props.data && props.data.option !== undefined && props.args.options !== undefined) {
-			valueString = props.args.options.filter(option => "option" in props.data ? option.value === props.data.option : undefined)[0].label;
+			const selectedOption = props.args.options.find(({ value }) => "option" in props.data && value === props.data.option);
+
+			if (selectedOption) {
+				valueString = selectedOption.label;
+			}
 		}
 
 	return (


### PR DESCRIPTION
The date filter plucks the selected option from the list of provided options and displays the label of that option in the dropdown box. This prevents an error being thrown if the corresponding option is no longer available in those provided.