### PR TITLE
MOS-1250 Address types bug

### DIFF
--- a/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
+++ b/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
@@ -267,7 +267,7 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 			inputSettings: {
 				options: [
 					...addressTypes,
-					...(addressToEdit ? addressToEdit.types : []),
+					...(addressToEdit ? addressToEdit.types.filter((editingType) => !addressTypes.find(({ value }) => value === editingType.value)) : []),
 				],
 			},
 		},


### PR DESCRIPTION
With a recent edit, when editing an address, the type options were derived from the address being edited as well as the available types from the field itself. This ensures there can be no duplicates when combining the two.