### PR TITLE
MOS-1320 Content overflow

### DIFF
--- a/src/components/Content/Content.stories.tsx
+++ b/src/components/Content/Content.stories.tsx
@@ -76,6 +76,9 @@ const data = {
 	animals: [{ id: 1, species: "Dog", color: "Brown" }, { id: 2, species: "Cat", color: "White" }],
 	cars: [{ id: 1, make: "BMW", model: "M3" }, { id: 2, make: "Volkswagen", model: "Golf" }],
 	multipleTransforms: "This is some text",
+	fieldWithLongWord: "Pneumonoultramicroscopicsilicovolcanoconiosis",
+	fieldWithLongURL: "https://simpleviewinc.github.io/sv-mosaic/master/?path=/story/components-content--kitchen-sink",
+	fieldWithLongSentence: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi mollis diam non imperdiet luctus. Morbi in augue leo. Vestibulum non tellus in elit molestie pretium sollicitudin eget purus. Mauris varius, est sed placerat ornare, nulla libero consequat nisi, id tempor nibh felis non velit.",
 };
 
 const sectionConfigs = {
@@ -293,6 +296,21 @@ export const KitchenSink = (): ReactElement => {
 			name: "emptyArrayValue",
 			label: "Field with empty array value",
 		},
+		{
+			name: "fieldWithLongWord",
+			label: "Long Word",
+		},
+		{
+			name: "fieldWithLongURL",
+			label: "Long URL",
+			transforms: [
+				({ data }) => <Link href={data as string}>{data as string}</Link>,
+			],
+		},
+		{
+			name: "fieldWithLongSentence",
+			label: "Long Sentence",
+		},
 	];
 
 	const columns = [
@@ -300,6 +318,7 @@ export const KitchenSink = (): ReactElement => {
 		[["toggle"], ["date"], ["colorPicker"]],
 		[["thumbnail"], ["chipsAsValue"], []],
 		[["undefinedValue"], ["emptyStringValue"], ["emptyArrayValue"]],
+		[["fieldWithLongWord"], ["fieldWithLongURL"], ["fieldWithLongSentence"]],
 	];
 
 	return (

--- a/src/components/Content/Content.styled.ts
+++ b/src/components/Content/Content.styled.ts
@@ -94,4 +94,14 @@ export const FieldDefinition = styled.dd`
 	color: ${theme.newColors.grey3["100"]};
 	font-size: 14px;
 	margin: 0;
+	display: table;
+	table-layout: fixed;
+	width: 100%;
+`;
+
+export const FieldDefinitionInner = styled.span`
+	display: table-cell;
+	vertical-align: middle;
+	overflow: hidden;
+	word-wrap: break-word;
 `;

--- a/src/components/Content/ContentRow.tsx
+++ b/src/components/Content/ContentRow.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useMemo } from "react";
 import { ContentFieldProps } from "./ContentTypes";
 
 import {
-	FieldContainer, FieldDefinition, FieldTerm,
+	FieldContainer, FieldDefinition, FieldDefinitionInner, FieldTerm,
 } from "./Content.styled";
 import Blank from "@root/components/Blank";
 import testIds from "@root/utils/testIds";
@@ -28,7 +28,9 @@ const ContentField = ({ label, transforms, value: rawValue }: ContentFieldProps)
 		<FieldContainer data-testid={testIds.CONTENT_FIELD}>
 			<FieldTerm>{label}</FieldTerm>
 			<FieldDefinition>
-				{value as ReactNode}
+				<FieldDefinitionInner>
+					{value as ReactNode}
+				</FieldDefinitionInner>
 			</FieldDefinition>
 		</FieldContainer>
 	);


### PR DESCRIPTION
Employs a workaround to prevent typography from overflowing outside of individual content item containers. Words will be forced to be broken even if they have no breaking characters.