### PR TITLE
MOS-1277 Form field accessibility

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -45,6 +45,20 @@ function useValueLimit(value: any, fieldDef: FieldDef): [number, number] | undef
 	}, [fieldDef, value]);
 }
 
+const typesWithRealLabel: FieldDef["type"][] = [
+	"color",
+	"date",
+	"dropdown",
+	"phone",
+	"text",
+	/**
+	 * I can't work out a way to add an ID to Jodit's
+	 * embedded contenteditable element..
+	 */
+	// "textEditor",
+	"time",
+];
+
 const Field = ({
 	children,
 	error,
@@ -84,6 +98,8 @@ const Field = ({
 		return unmount;
 	}, [mountField, fieldDef.name, inputRef]);
 
+	const hasRealLabel = typesWithRealLabel.includes(fieldDef?.type);
+
 	return (
 		<StyledFieldContainer
 			id={id}
@@ -98,11 +114,12 @@ const Field = ({
 					{hasLabelComponent && (
 						<Label
 							required={fieldDef?.required}
-							htmlFor={fieldDef?.name || undefined}
 							limit={limit}
 							value={value}
 							instructionText={fieldDef?.instructionText}
 							colsInRow={colsInRow}
+							htmlFor={hasRealLabel && fieldDef?.name ? `${fieldDef.name}-input` : undefined}
+							as={hasRealLabel ? "label" : "div"}
 						>
 							{fieldDef?.label}
 						</Label>

--- a/src/components/Field/FormFieldColorPicker/ColorPickerTypes.tsx
+++ b/src/components/Field/FormFieldColorPicker/ColorPickerTypes.tsx
@@ -5,6 +5,7 @@ export interface ColorSelectedProps {
 	displayColorPicker?: boolean;
 	disabled?: boolean;
 	onClick?: React.MouseEventHandler<HTMLButtonElement>;
+	id?: string;
 }
 
 export type ColorData = string;

--- a/src/components/Field/FormFieldColorPicker/ColorSelected.tsx
+++ b/src/components/Field/FormFieldColorPicker/ColorSelected.tsx
@@ -4,7 +4,7 @@ import { ColorContainer, ColorDiv } from "./ColorPicker.styled";
 import { ColorSelectedProps } from "./ColorPickerTypes";
 
 const ColorSelected = (props: ColorSelectedProps): ReactElement => {
-	const { disabled, color, onClick, displayColorPicker } = props;
+	const { disabled, color, onClick, displayColorPicker, id } = props;
 
 	return (
 		<ColorContainer
@@ -12,6 +12,7 @@ const ColorSelected = (props: ColorSelectedProps): ReactElement => {
 			$displayColorPicker={displayColorPicker}
 			onClick={onClick}
 			type="button"
+			id={id}
 		>
 			<ColorDiv
 				data-testid="colordiv-test"

--- a/src/components/Field/FormFieldColorPicker/FormFieldColorPicker.tsx
+++ b/src/components/Field/FormFieldColorPicker/FormFieldColorPicker.tsx
@@ -46,6 +46,7 @@ const FormFieldColorPicker = (
 		onChange,
 		onBlur,
 		disabled,
+		id,
 	} = props;
 
 	// State variables
@@ -68,7 +69,7 @@ const FormFieldColorPicker = (
 		onChange(RGBAToHexA(color.rgb));
 	};
 
-	const id = open ? `${fieldDef.name}-popover` : undefined;
+	const popoverId = open ? `${fieldDef.name}-popover` : undefined;
 
 	return (
 		<>
@@ -76,10 +77,11 @@ const FormFieldColorPicker = (
 				disabled={disabled}
 				color={color?.rgb || value || { r: 0, g: 141, b: 168, a: 1 }}
 				onClick={handleClick}
+				id={id}
 			/>
 			{!disabled && (
 				<PopOver
-					id={id}
+					id={popoverId}
 					open={displayColorPicker}
 					anchorEl={anchorEl}
 					onClose={handleClose}

--- a/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
@@ -27,6 +27,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		error,
 		methods,
 		inputRef,
+		id,
 	} = props;
 
 	const showTime = fieldDef?.inputSettings?.showTime;
@@ -125,6 +126,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		<DateTimeInputRow $hasTimeField={showTime}>
 			<DateTimePickerWrapper>
 				<DatePicker
+					id={id}
 					error={error}
 					onChange={handleDateChange}
 					fieldDef={{
@@ -148,6 +150,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 			{showTime && (
 				<DateTimePickerWrapper>
 					<TimePicker
+						id={`${fieldDef?.name}-time`}
 						error={error}
 						onChange={handleTimeChange}
 						fieldDef={{

--- a/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
@@ -15,7 +15,7 @@ import {
 import { DATE_FORMAT_FULL } from "@root/constants";
 
 const DateFieldPicker = (props: DatePickerProps): ReactElement => {
-	const { fieldDef, onChange, value = null, onBlur, disabled, inputRef } = props;
+	const { fieldDef, onChange, value = null, onBlur, disabled, inputRef, id } = props;
 
 	const [isPickerOpen, setIsPickerOpen] = useState(false);
 
@@ -30,6 +30,7 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 	const renderInput = (params) => (
 		<DatePickerTextField
 			{...params}
+			id={id}
 			onBlur={onBlur}
 			required={fieldDef.required}
 			disabled={disabled}

--- a/src/components/Field/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
+++ b/src/components/Field/FormFieldDropdownSingleSelection/FormFieldDropdownSingleSelection.tsx
@@ -23,6 +23,7 @@ const DropdownSingleSelection = (props: MosaicFieldProps<"dropdown", DropdownSin
 		value,
 		disabled,
 		inputRef,
+		id,
 	} = props;
 
 	const [isOpen, setIsOpen] = useState(false);
@@ -70,6 +71,7 @@ const DropdownSingleSelection = (props: MosaicFieldProps<"dropdown", DropdownSin
 
 							params.inputProps.ref.current = el;
 						},
+						id,
 					}}
 				/>
 			</InputWrapper>

--- a/src/components/Field/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
+++ b/src/components/Field/FormFieldPhoneSelectionDropdown/FormFieldPhoneSelectionDropdown.tsx
@@ -23,6 +23,7 @@ const FormFieldPhoneSelectionDropdown = (
 		value,
 		disabled,
 		inputRef,
+		id,
 	} = props;
 
 	const [dialCode, setDialCode] = useState("");
@@ -52,6 +53,7 @@ const FormFieldPhoneSelectionDropdown = (
 				inputProps={{
 					required: fieldDef?.required,
 					ref: inputRef,
+					id,
 				}}
 				tabbableDropdown={false}
 			/>

--- a/src/components/Field/FormFieldText/FormFieldText.tsx
+++ b/src/components/Field/FormFieldText/FormFieldText.tsx
@@ -20,6 +20,7 @@ const TextField = (
 		value,
 		disabled,
 		inputRef,
+		id,
 	} = props;
 
 	const leadingElement = fieldDef?.inputSettings?.prefixElement
@@ -47,7 +48,7 @@ const TextField = (
 
 	return (
 		<StyledTextField
-			id={fieldDef?.name}
+			id={id}
 			data-testid="form-field-text-test-id"
 			value={value ?? ""}
 			onChange={onFieldChange}

--- a/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
+++ b/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
@@ -36,7 +36,7 @@ const buttonList = [
 const FormFieldTextEditor = (
 	props: MosaicFieldProps<"textEditor", TextEditorInputSettings, TextEditorData>,
 ): ReactElement => {
-	const { fieldDef, onBlur, onChange, value, disabled, error, inputRef } = props;
+	const { fieldDef, onBlur, onChange, value, disabled, error, inputRef, id } = props;
 
 	const {
 		inputSettings = {},
@@ -119,8 +119,8 @@ const FormFieldTextEditor = (
 	}, [value]);
 
 	return (
-		<EditorWrapper $error={!!error} data-testid="text-editor-testid">
-			<textarea ref={textArea} />
+		<EditorWrapper $error={!!error} data-testid="text-editor-testid" id={id}>
+			<textarea ref={textArea} id={id} />
 		</EditorWrapper>
 	);
 };

--- a/src/components/Field/FormFieldTime/TimeField/FormFieldTime.tsx
+++ b/src/components/Field/FormFieldTime/TimeField/FormFieldTime.tsx
@@ -24,6 +24,7 @@ const FormFieldTime = (props: MosaicFieldProps<"time", TimeFieldInputSettings, T
 		error,
 		methods,
 		inputRef,
+		id,
 	} = props;
 
 	const { addError, removeError } = useFieldErrors({
@@ -63,6 +64,7 @@ const FormFieldTime = (props: MosaicFieldProps<"time", TimeFieldInputSettings, T
 
 	return (
 		<TimePicker
+			id={id}
 			error={error}
 			onChange={handleTimeChange}
 			fieldDef={{

--- a/src/components/Field/FormFieldTime/TimePicker/TimePicker.tsx
+++ b/src/components/Field/FormFieldTime/TimePicker/TimePicker.tsx
@@ -14,7 +14,7 @@ import { TimePickerDef, TimePickerData } from "./TimePickerTypes";
 import { ThemeProvider } from "@mui/material/styles";
 
 const TimeFieldPicker = (props: MosaicFieldProps<"timePicker", TimePickerDef, TimePickerData>): ReactElement => {
-	const { fieldDef, onChange, value = null, onBlur, disabled, inputRef } = props;
+	const { fieldDef, onChange, value = null, onBlur, disabled, inputRef, id } = props;
 
 	const [isPickerOpen, setIsPickerOpen] = useState(false);
 
@@ -31,6 +31,7 @@ const TimeFieldPicker = (props: MosaicFieldProps<"timePicker", TimePickerDef, Ti
 	const renderInput = (params) => (
 		<TextField
 			{...params}
+			id={id}
 			onBlur={onBlur}
 			required={fieldDef.required}
 			disabled={disabled}

--- a/src/components/Field/Label.tsx
+++ b/src/components/Field/Label.tsx
@@ -76,6 +76,7 @@ interface LabelProps {
 	limit?: [number, number];
 	instructionText?: string;
 	colsInRow?: number;
+	as?: "label" | "div";
 }
 
 const Label = (props: LabelProps): ReactElement => {
@@ -87,13 +88,14 @@ const Label = (props: LabelProps): ReactElement => {
 		limit,
 		instructionText,
 		colsInRow,
+		as = "label",
 	} = props;
 
 	const { anchorProps, tooltipProps } = useTooltip();
 
 	return (
 		<LabelWrapper className={className}>
-			<StyledInputLabel htmlFor={htmlFor}>
+			<StyledInputLabel htmlFor={htmlFor} as={as}>
 				{children}
 				{required && <StyledRequiredIndicator>*</StyledRequiredIndicator>}
 			</StyledInputLabel>

--- a/src/components/Form/Col/ColField.tsx
+++ b/src/components/Form/Col/ColField.tsx
@@ -73,6 +73,7 @@ const ColField = ({
 			disabled={disabled}
 			methods={methods}
 			inputRef={inputRef}
+			id={`${field.name}-input`}
 		/>
 	), [
 		Component,
@@ -83,6 +84,7 @@ const ColField = ({
 		onBlur,
 		disabled,
 		methods,
+		field.name,
 	]);
 
 	if (!shouldShow) {


### PR DESCRIPTION
Ensures each applicable field has a label whose for attribute corresponds to the field input within. This improves form accessibility. Field types that follow this rule are:

- `color`
- `date`
- `dropdown`
- `phone`
- `text`
- `time`

The `textEditor` field type _should_ ideally follow this rule as well, but I can't currently find a way to add an ID attribute to the `contenteditable` element that Jodit renders.