### PR TITLE
MOS-1325 Editor maximum characters

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -7,6 +7,7 @@ import { default as HelperText } from "./HelperText";
 import { default as InstructionText } from "./InstructionText";
 import { FieldDef, MosaicFieldProps } from ".";
 import { Skeleton } from "@mui/material";
+import { stripTags } from "@root/utils/dom/stripTags";
 
 function getValueLimit(def: FieldDef): number | undefined {
 	if (!def || !def.inputSettings) {
@@ -26,6 +27,22 @@ function getValueLimit(def: FieldDef): number | undefined {
 	}
 }
 
+function getValueLength(value: any, fieldDef: FieldDef): number {
+	if (typeof value === "string") {
+		if (fieldDef.type === "textEditor") {
+			return stripTags(value).length;
+		}
+
+		return value.length;
+	}
+
+	if (Array.isArray(value)) {
+		return value.length;
+	}
+
+	return 0;
+}
+
 function useValueLimit(value: any, fieldDef: FieldDef): [number, number] | undefined {
 	return useMemo(() => {
 		const limit = getValueLimit(fieldDef);
@@ -34,13 +51,7 @@ function useValueLimit(value: any, fieldDef: FieldDef): [number, number] | undef
 			return;
 		}
 
-		const current = typeof value === "string" ?
-			// Unfortunately, if it's a string it could be a rich text
-			// editor field that contains some HTML. It's meh.
-			value.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").length :
-			Array.isArray(value) ?
-				value.length :
-				0;
+		const current = getValueLength(value, fieldDef);
 
 		return [current, limit];
 	}, [fieldDef, value]);

--- a/src/components/Form/useForm/useForm.ts
+++ b/src/components/Form/useForm/useForm.ts
@@ -63,7 +63,10 @@ export function useForm(): UseFormReturn {
 		if (field.inputSettings?.maxCharacters > 0) {
 			validators.push({
 				fn: "validateCharacterCount",
-				options: { max: field.inputSettings.maxCharacters },
+				options: {
+					max: field.inputSettings.maxCharacters,
+					ignoreHTML: field.type === "textEditor",
+				},
 			});
 		}
 

--- a/src/components/Form/validators.ts
+++ b/src/components/Form/validators.ts
@@ -1,4 +1,5 @@
 import { DATE_FORMAT_FULL } from "@root/constants";
+import { stripTags } from "@root/utils/dom/stripTags";
 import format from "date-fns/format";
 
 export const VALIDATE_EMAIL_TYPE = "validateEmail";
@@ -173,7 +174,7 @@ export function validateMinDate(value: any, data: any, { min, max }: { min?: Dat
 	}
 }
 
-export function validateCharacterCount(value: string, data: any, options: { max?: number }): string | undefined {
+export function validateCharacterCount(value: string, data: any, options: { max?: number; ignoreHTML?: boolean }): string | undefined {
 	if (!options.max) {
 		return;
 	}
@@ -182,7 +183,9 @@ export function validateCharacterCount(value: string, data: any, options: { max?
 		return;
 	}
 
-	if (value.length > options.max) {
+	const sanitized = options.ignoreHTML ? stripTags(value) : value;
+
+	if (sanitized.length > options.max) {
 		return "You have exceeded the maximum number of characters";
 	}
 }

--- a/src/utils/dom/stripTags.ts
+++ b/src/utils/dom/stripTags.ts
@@ -1,0 +1,4 @@
+export function stripTags(html: string) {
+	const doc = new DOMParser().parseFromString(html, "text/html");
+	return doc.body.textContent || "";
+}


### PR DESCRIPTION
This fixes an issue that caused rich text fields to be incorrectly invalidated due to hidden HTML tags that come as a part of the text editor value naturally. We now consistently strip away any HTML tags for not just the character counter, but also as a part of the maximum character validation function.