### PR TITLE
MOS-1277 Rework

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,33 +1,40 @@
 import * as React from "react";
-import { memo } from "react";
+import { useId, memo } from "react";
 import { CheckboxProps } from "./CheckboxTypes";
 
 import { StyledCheckbox, StyledFormControlLabel } from "./Checkbox.styled";
 
-const Checkbox = (props: CheckboxProps) => (
-	<>
-		<StyledFormControlLabel
-			label={props.label}
-			labelPlacement="end"
-			data-testid="label-test-id"
-			value={props.value}
-			disabled={props.disabled}
-			control={(
-				<StyledCheckbox
-					data-testid="checkbox-test-id"
-					className={`
-						custom-checkbox
-						${props.checked ? "checked" : ""}
-						${props.className ? props.className : ""}
-					`}
-					edge={props.edge}
-					checked={props.checked}
-					onClick={props.onClick}
-					indeterminate={props.indeterminate}
-				/>
-			)}
-		/>
-	</>
-);
+const Checkbox = (props: CheckboxProps) => {
+	const fallbackId = useId();
+	const id = props.id || fallbackId;
+
+	return (
+		<>
+			<StyledFormControlLabel
+				label={props.label}
+				labelPlacement="end"
+				data-testid="label-test-id"
+				value={props.value}
+				disabled={props.disabled}
+				htmlFor={id}
+				control={(
+					<StyledCheckbox
+						data-testid="checkbox-test-id"
+						className={`
+							custom-checkbox
+							${props.checked ? "checked" : ""}
+							${props.className ? props.className : ""}
+						`}
+						edge={props.edge}
+						checked={props.checked}
+						onClick={props.onClick}
+						indeterminate={props.indeterminate}
+						id={id}
+					/>
+				)}
+			/>
+		</>
+	);
+};
 
 export default memo(Checkbox);

--- a/src/components/Checkbox/CheckboxTypes.tsx
+++ b/src/components/Checkbox/CheckboxTypes.tsx
@@ -39,4 +39,9 @@ export interface CheckboxProps extends MUICheckboxProps {
 	 * current checkbox can be selected or not
 	 */
 	disabled?: boolean;
+	/**
+	 * A unique ID that should be provided to the
+	 * checkbox and be referenced by a label.
+	 */
+	id?: string;
 }

--- a/src/components/CheckboxList/CheckboxList.tsx
+++ b/src/components/CheckboxList/CheckboxList.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useMemo, useCallback, ReactElement, HTMLAttributes } from "react";
+import { useId, useMemo, useCallback, ReactElement, HTMLAttributes } from "react";
 import xorBy from "lodash/xorBy";
 
 import Checkbox from "@root/components/Checkbox";
@@ -10,6 +10,8 @@ import { MosaicLabelValue } from "@root/types";
 
 const CheckboxList = (props: CheckboxListProps & HTMLAttributes<HTMLInputElement>): ReactElement => {
 	const checkedRef = useStateRef(props.checked);
+	const fallbackId = useId();
+	const id = props.id || fallbackId;
 
 	const handleToggle = useCallback(
 		(value: MosaicLabelValue | { [key: string]: unknown }) => () => {
@@ -37,6 +39,7 @@ const CheckboxList = (props: CheckboxListProps & HTMLAttributes<HTMLInputElement
 						label={option.label}
 						disabled={props.disabled}
 						key={`${option.value}-${i}`}
+						id={`${id}-${i}`}
 						onClick={callbacks[i]}
 						value={option.value}
 					/>

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -83,6 +83,7 @@ const Field = ({
 	inputRef,
 	disabled,
 	skeleton,
+	useRealLabel,
 }: MosaicFieldProps<any>): ReactElement => {
 	const { mountField } = methods || {};
 	const fieldRef = useRef<HTMLDivElement | undefined>();
@@ -111,7 +112,7 @@ const Field = ({
 		return unmount;
 	}, [mountField, fieldDef.name, inputRef]);
 
-	const hasRealLabel = typesWithRealLabel.includes(fieldDef?.type);
+	const hasRealLabel = useRealLabel || typesWithRealLabel.includes(fieldDef?.type);
 
 	return (
 		<StyledFieldContainer

--- a/src/components/Field/FieldTypes.tsx
+++ b/src/components/Field/FieldTypes.tsx
@@ -85,6 +85,12 @@ export interface MosaicFieldProps<T = any, U = any, V = any> {
 	 * of this component
 	 */
 	skeleton?: boolean;
+	/**
+	 * For fields with multiple input/controls, we should
+	 * not render a label element because they can only target
+	 * one control. Instead, render a legend element.
+	 */
+	useRealLabel?: boolean;
 }
 
 // SHARED FIELD DEFINITION - DEVELOPER GENERIC CONTRACT

--- a/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocomplete.tsx
+++ b/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocomplete.tsx
@@ -26,6 +26,7 @@ const AddressAutocomplete = (props: AddressAutocompleteProps): ReactElement => {
 		placeholder,
 		googleMapsApiKey,
 		disabled,
+		id,
 	} = props;
 	const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
 
@@ -59,6 +60,7 @@ const AddressAutocomplete = (props: AddressAutocompleteProps): ReactElement => {
 				fieldSize="lg"
 				onChange={({ target: { value } }) => onChange(value)}
 				disabled={disabled}
+				id={id}
 			/>
 		);
 	}
@@ -76,6 +78,7 @@ const AddressAutocomplete = (props: AddressAutocompleteProps): ReactElement => {
 							onFocus={handleFocus}
 							onBlur={handleBlur}
 							disabled={disabled}
+							id={id}
 						/>
 						<Popover
 							open={Boolean(anchorEl) && suggestions?.length > 0}

--- a/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocompleteTypes.ts
+++ b/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocompleteTypes.ts
@@ -10,6 +10,7 @@ export interface AddressAutocompleteProps {
 	placeholder?: string;
 	googleMapsApiKey: string;
 	disabled?: boolean;
+	id?: string;
 }
 
 export interface InputSettings {

--- a/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
+++ b/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
@@ -33,15 +33,13 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 	} = props;
 
 	const controller = useForm();
+	const { state, methods: { setFieldValue }, handleSubmit } = controller;
 
-	const { state, methods, handleSubmit } = controller;
 	const [address, setAddress] = useState("");
 	const [snackBarLabel, setSnackBarLabel] = useState("");
 	const [openSnackBar, setOpenSnackbar] = useState(false);
 	const [initialState, setInitialState] = useState(state.data);
 	const [apiState, setApiState] = useState<MosaicLabelValue | undefined>();
-
-	const { setFieldValue } = methods;
 
 	useEffect(() => {
 		handleUnsavedChanges(!addressesAreEqual(addressToEdit, state.data as any));
@@ -231,6 +229,7 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 				}}
 				methods={props.methods}
 				disabled={props.disabled}
+				useRealLabel
 			>
 				<AddressAutocomplete
 					onChange={(address) => props.onChange(address)}
@@ -239,6 +238,7 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 					onSelect={inputSettings.onSelect}
 					googleMapsApiKey={googleMapsApiKey}
 					disabled={props.disabled}
+					id={`${fieldDef.name}-input`}
 				/>
 			</Field>
 		);

--- a/src/components/Field/FormFieldCheckbox/FormFieldCheckbox.tsx
+++ b/src/components/Field/FormFieldCheckbox/FormFieldCheckbox.tsx
@@ -18,6 +18,7 @@ const FormFieldCheckbox = (
 		value,
 		disabled,
 		skeleton,
+		id,
 	} = props;
 
 	const [internalOptions, setInternalOptions] = useState<MosaicLabelValue[]>([]);
@@ -73,6 +74,7 @@ const FormFieldCheckbox = (
 			onBlur={onBlur}
 			style={fieldDef.style}
 			className={fieldDef.className}
+			id={id}
 		/>
 	);
 };

--- a/src/components/Field/Label.tsx
+++ b/src/components/Field/Label.tsx
@@ -28,6 +28,13 @@ const LabelWrapper = styled.div<TransientProps<LabelProps, "required">>`
 	}
 `;
 
+const InputLabelDiv = styled.div`
+	font-family: inherit;
+	font-size: 16px;
+	color:  ${theme.newColors.almostBlack["100"]};
+	word-wrap: break-word;
+`;
+
 const CharCounterWrapper = styled.div<{ $invalid?: boolean }>`
 	color: ${({ $invalid }) => $invalid ? theme.newColors.darkRed["100"] : theme.newColors.grey3["100"]};
 	font-size: 12px;
@@ -98,7 +105,7 @@ const Label = (props: LabelProps): ReactElement => {
 		<LabelWrapper className={className}>
 			<StyledInputLabel
 				htmlFor={as === "label" && name ? `${name}-input` : undefined}
-				as={as}
+				as={as === "label" ? InputLabel : InputLabelDiv}
 				data-testid={name && `${testIds.FORM_FIELD_LABEL}:${name}`}
 			>
 				{children}

--- a/src/components/Form/stories/VaryingSections.stories.tsx
+++ b/src/components/Form/stories/VaryingSections.stories.tsx
@@ -36,11 +36,11 @@ export const VaryingSections = (): ReactElement => {
 	const fields = useMemo(
 		() : FieldDef[] =>
 			[
-				{
-					name: "field",
-					label: "Field",
+				...Array(80).fill(null).map<FieldDef>((_, i) => ({
+					name: `field_${i}`,
+					label: `Field ${i}`,
 					type: "text",
-				},
+				})),
 			],
 		[],
 	);
@@ -52,8 +52,8 @@ export const VaryingSections = (): ReactElement => {
 			collapsed: true,
 			fields: [
 				// row 1
-				[["field"]],
-				[["field"]],
+				[["field_1"]],
+				[["field_2"]],
 			],
 		},
 		{
@@ -62,7 +62,7 @@ export const VaryingSections = (): ReactElement => {
 			collapsed: false,
 			fields: [
 				// row 1
-				[["field"]],
+				[["field_3"]],
 			],
 		},
 		{
@@ -71,11 +71,11 @@ export const VaryingSections = (): ReactElement => {
 			collapsed: false,
 			fields: [
 				// row 1
-				[["field"]],
-				[["field"]],
-				[["field"]],
-				[["field"]],
-				[["field"]],
+				[["field_4"]],
+				[["field_5"]],
+				[["field_6"]],
+				[["field_7"]],
+				[["field_8"]],
 			],
 		},
 		...Array(10).fill(null).map((_, i) => ({
@@ -84,11 +84,11 @@ export const VaryingSections = (): ReactElement => {
 			collapsed: true,
 			fields: [
 				// row 1
-				[["field"]],
-				[["field"]],
-				[["field"]],
-				[["field"]],
-				[["field"]],
+				[[`field_${i * 5 + 9}`]],
+				[[`field_${i * 5 + 10}`]],
+				[[`field_${i * 5 + 11}`]],
+				[[`field_${i * 5 + 12}`]],
+				[[`field_${i * 5 + 13}`]],
 			],
 		})),
 		{
@@ -97,11 +97,11 @@ export const VaryingSections = (): ReactElement => {
 			collapsed: false,
 			fields: [
 				// row 1
-				[["field"]],
-				[["field"]],
-				[["field"]],
-				[["field"]],
-				[["field"]],
+				[["field_59"]],
+				[["field_60"]],
+				[["field_61"]],
+				[["field_62"]],
+				[["field_63"]],
 			],
 		},
 		{
@@ -110,7 +110,7 @@ export const VaryingSections = (): ReactElement => {
 			collapsed: false,
 			fields: [
 				// row 1
-				[["field"]],
+				[["field_64"]],
 			],
 		},
 	], []);


### PR DESCRIPTION
- Ensures there is a way for custom fields to render a real `label` element when using `FieldWrapper`.
- Fixes a bug where `FieldWrapper` would use a basic `label` element instead of the one provided by MUI.
- Fixes the custom autocomplete field that is a part of the address field's drawer to ensure its label is fully accessible and corresponds to the autocomplete input.
- Ensures check boxes take on the form field name as their ID, but fallback to a generated ID if it’s not provided or not part of a form field.
- Ensures the varying sections now have uniquely labelled and identified fields.