### PR TITLE
MOS-1336, MOS-1290 - Address field fixes

### DIFF
--- a/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
+++ b/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
@@ -219,6 +219,12 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 		});
 
 		if (warnings.length) {
+			console.warn(
+				"Some components could not be resolved.",
+				"\n\nComponents received:\n", addressComponents,
+				"\n\nBy type they are:\n", addressComponents.map(({ types: [type], long_name }) => `${type}: ${long_name}`).join("\n"),
+				"\n\nMosaic Result:\n", parts,
+			);
 			setSnackBarLabel(warnings.map(({ label }) => label).join(", "));
 			setOpenSnackbar(true);
 		}

--- a/src/components/Field/FormFieldAddress/utils/addressUtils.ts
+++ b/src/components/Field/FormFieldAddress/utils/addressUtils.ts
@@ -1,25 +1,14 @@
 /**
- * An array of strings denoting the type of the returned geocoded element.
- * For a list of possible strings, refer to the <a href=
- * "https://developers.google.com/maps/documentation/javascript/geocoding#GeocodingAddressTypes">
- * Address Component Types</a> section of the Developer&#39;s Guide.
-*/
-export const components = ["route", "locality", "postal_town", "postal_code", "administrative_area_level_1", "country", "street_number"];
-
-export const initalAddressComponent = {
-	label: "",
-	value: "",
-};
-
-/**
- * Maps the address components object response of the autocomplete API to string values used
- * to display a message with  missing components on a snackback.
+ * @see https://developers.google.com/maps/documentation/javascript/geocoding#GeocodingAddressTypes
  */
-export const componentsToAddress = {
-	route: "address",
-	locality: "city",
+export const componentType = {
+	no: "street_number",
+	street: "route",
+	neighborhood: "neighborhood",
+	locality: "locality",
+	town: "postal_town",
+	area1: "administrative_area_level_1",
+	area2: "administrative_area_level_2",
 	country: "country",
-	administrative_area_level_1: "state",
-	postal_code: "postal code",
-	street_number: "street number",
+	postcode: "postal_code",
 };


### PR DESCRIPTION
Gives `AddressDrawer` a refactor to squash a number of bugs:

- The address 2 and state fields are now correctly populated in all checked cases, which are a number of both US and UK addresses. Note that there are many world addresses which are not currently supported. It's really a minefield, since the different components given to us by Google depend on the country for which you're querying. For example, as described [here](https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform):
  - In the UK and in Sweden, the component to display the city is postal_town.
  - In Japan, components differ across prefectures.
  - Brooklyn and other parts of New York City do not include the city as part of the address. Instead, they use sublocality_level_1.
- The state is now correctly cleared when changing country.
- The empty fields are now correctly reported, with capitalised field labels.