### PR TITLE
MOS-1152 Date validator bug

### DIFF
--- a/src/components/Field/FieldTypes.tsx
+++ b/src/components/Field/FieldTypes.tsx
@@ -16,7 +16,7 @@ import { FieldDefText } from "@root/components/Field/FormFieldText";
 import { FieldDefTextEditor } from "@root/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes";
 import { FieldDefToggle } from "@root/components/Field/FormFieldToggle";
 import { FieldDefUpload } from "@root/components/Field/FormFieldUpload";
-import { MosaicToggle } from "@root/types";
+import { ShiftParam, MosaicToggle } from "@root/types";
 import { ElementType, HTMLAttributes, MutableRefObject, ReactNode } from "react";
 import { FieldValueResolver, FormSpacing } from "../Form";
 import { FormMethods, FormState } from "../Form/useForm/types";
@@ -214,12 +214,8 @@ export type FieldDef =
 	| FieldDefNumberTable
 	| FieldDefRaw;
 
-export type Head<T extends any[]> = T extends [ ...infer Head, any ] ? Head : any[];
-
-export type DropParam<T extends (...args: any) => any, R = any> = (...args: Head<Parameters<T>>) => R;
-
 export type FieldDefSanitized = Omit<FieldDef, "getResolvedValue"> & {
-	getResolvedValue: DropParam<FieldValueResolver>;
+	getResolvedValue: ShiftParam<FieldValueResolver>;
 
 	order: number;
 };

--- a/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ReactElement, useState } from "react";
+import { ReactElement, useState, useCallback } from "react";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 //import { DatePicker } from "@mui/x-date-pickers/DatePicker";
@@ -13,6 +13,9 @@ import {
 	popperSx,
 } from "./DatePicker.styled";
 import { DATE_FORMAT_FULL } from "@root/constants";
+import { FilledTextFieldProps, OutlinedTextFieldProps, StandardTextFieldProps } from "@mui/material";
+
+type MuiRenderInput = (props: StandardTextFieldProps | FilledTextFieldProps | OutlinedTextFieldProps) => ReactElement;
 
 const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 	const { fieldDef, onChange, value = null, onBlur, disabled, inputRef, id } = props;
@@ -27,20 +30,29 @@ const DateFieldPicker = (props: DatePickerProps): ReactElement => {
 		}
 	};
 
-	const renderInput = (params) => (
-		<DatePickerTextField
-			{...params}
-			id={id}
-			onBlur={onBlur}
-			required={fieldDef.required}
-			disabled={disabled}
-			inputProps={{
-				...params.inputProps,
-				ref: inputRef,
-				placeholder: fieldDef?.inputSettings?.placeholder,
-			}}
-		/>
-	);
+	const renderInput = useCallback<MuiRenderInput>((params) => {
+		return (
+			<DatePickerTextField
+				{...params}
+				id={id}
+				onBlur={onBlur}
+				required={fieldDef.required}
+				disabled={disabled}
+				inputProps={{
+					...params.inputProps,
+					ref: inputRef,
+					placeholder: fieldDef?.inputSettings?.placeholder,
+				}}
+			/>
+		);
+	}, [
+		disabled,
+		fieldDef?.inputSettings?.placeholder,
+		fieldDef.required,
+		id,
+		inputRef,
+		onBlur,
+	]);
 
 	return (
 		<LocalizationProvider dateAdapter={AdapterDateFns}>

--- a/src/components/Form/formUtils.ts
+++ b/src/components/Form/formUtils.ts
@@ -76,7 +76,7 @@ const fieldConfigMap: Partial<Record<Exclude<FieldDef["type"], FieldDefCustom["t
 	},
 	date: {
 		Component: FormFieldDate,
-		validate: "onBlurChange",
+		validate: "onBlurAmend",
 		getResolvedValue: (
 			value: DateData | Date | undefined,
 			fieldDef: FieldDefDate,
@@ -117,7 +117,7 @@ const fieldConfigMap: Partial<Record<Exclude<FieldDef["type"], FieldDefCustom["t
 	},
 	time: {
 		Component: FormFieldTime,
-		validate: "onBlur",
+		validate: "onBlurAmend",
 		getResolvedValue: (
 			value: TimeData | string | undefined,
 		): {

--- a/src/components/Form/useForm/types.ts
+++ b/src/components/Form/useForm/types.ts
@@ -1,4 +1,4 @@
-import { MosaicObject } from "@root/types";
+import { ShiftParam, MosaicObject } from "@root/types";
 import { FieldDef } from "../FormTypes";
 import { FieldDefSanitized } from "@root/components/Field";
 
@@ -70,6 +70,7 @@ export type FormAction =
 
 export type GetFieldErrorParams = {
 	name: string;
+	validators?: (ValidatorFn | InternalValidatorFn)[];
 };
 
 export type GetFieldError = (params: GetFieldErrorParams) => Promise<string | undefined>;
@@ -94,6 +95,7 @@ export type FieldCanBeValidated = (params: FieldCanBeValidatedParams) => boolean
 export type ValidateFieldParams = {
 	name: string;
 	validateLinkedFields?: boolean;
+	validators?: (ValidatorFn | InternalValidatorFn)[];
 };
 
 export type ValidateField = (params: ValidateFieldParams) => Promise<void>;
@@ -172,15 +174,22 @@ export type MountFieldResult = {
 
 export type MountField = (params: MountFieldParams) => MountFieldResult;
 
-export type RemoveValidator = () => void;
+export type RemoveValidatorParams = {
+	name: string;
+	validator: InternalValidatorFn;
+	validate?: boolean;
+};
+
+export type RemoveValidator = (params: RemoveValidatorParams) => void;
 
 export type AddValidatorParams = {
 	name: string;
-	validator: () => undefined | string;
+	validator: InternalValidatorFn;
+	validate?: boolean;
 };
 
 export type AddValidatorResult = {
-	remove: RemoveValidator;
+	remove: ShiftParam<RemoveValidator>;
 };
 
 export type AddValidator = (params: AddValidatorParams) => AddValidatorResult;
@@ -232,11 +241,24 @@ export type FormStable = FormState & {
 	initialData: MosaicObject<any>;
 	fields: Record<string, FieldDefSanitized>;
 	mounted: Record<string, false | { fieldRef?: HTMLDivElement; inputRef?: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement }>;
-	internalValidators: Record<string, ((value: any) => string | undefined)[]>;
+	internalValidators: Record<string, InternalValidatorFn[]>;
 	hasBlurred: Record<string, boolean>;
 	moveToError: boolean;
 };
 
-export type ValidatorFn = (value: any, data: MosaicObject<any>, options: any) => Promise<string | undefined>;
+export type ValidatorFn = (
+	value: any,
+	data: MosaicObject<any>,
+	options: any,
+	internalValue: any,
+	internalData: any,
+) => Promise<string | undefined>;
+
+export type InternalValidatorFn = (
+	value: any,
+	data: MosaicObject<any>,
+	internalValue: any,
+	internalData: any,
+) => Promise<string | undefined>;
 
 export type Validator = { fn: ValidatorFn; options: any };

--- a/src/components/Form/useForm/utils.ts
+++ b/src/components/Form/useForm/utils.ts
@@ -43,9 +43,17 @@ export async function runValidators(
 	validators: Validator[],
 	value: unknown,
 	data: unknown,
+	internalValue: unknown,
+	internalData: unknown,
 ): Promise<{ errorMessage?: string | undefined; validator: Validator }> {
 	for (const validator of validators) {
-		const result = await validator.fn(value, data, validator.options);
+		const result = await validator.fn(
+			value,
+			data,
+			validator.options,
+			internalValue,
+			internalData,
+		);
 		if (result) {
 			return {
 				errorMessage: result,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,3 +42,7 @@ export type TransientProps<T, K extends keyof T = keyof T> = {
 };
 
 export type WithArrayOf<T> = T | T[];
+
+export type Head<T extends any[]> = T extends [ ...infer Head, any ] ? Head : any[];
+
+export type ShiftParam<T extends (...args: any) => any, R = any> = (...args: Head<Parameters<T>>) => R;

--- a/src/utils/hooks/useValidator.ts
+++ b/src/utils/hooks/useValidator.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { AddValidator } from "@root/components/Form/useForm/types";
+
+export interface UseValidatorParams {
+	name: string;
+	addValidator: AddValidator;
+	validator: Parameters<AddValidator>[0]["validator"];
+	autoRevalidate?: boolean;
+}
+
+function useValidator({
+	name,
+	addValidator,
+	validator,
+	autoRevalidate,
+}: UseValidatorParams) {
+	useEffect(() => {
+		const { remove } = addValidator({
+			name: name,
+			validator,
+			validate: autoRevalidate,
+		});
+
+		return remove;
+	}, [addValidator, name, validator, autoRevalidate]);
+}
+
+export default useValidator;


### PR DESCRIPTION
Introduces the `useValidator` hook which allows a validation function to be registered and run every time that function, or more specifically its dependencies, change. The date field uses this hook to ensure the validations for the time field are synchronised with the `showTime` property.