### PR TITLE
MOS-1288 DataView types

### DIFF
--- a/src/components/DataView/DataView.tsx
+++ b/src/components/DataView/DataView.tsx
@@ -274,7 +274,7 @@ const DataView = forwardRef<HTMLDivElement, DataViewProps>(function DataView (pr
 
 		const rows = props.data.reduce<DataViewRowActions>((acc, curr) => ({
 			...acc,
-			[curr.id as string]: {
+			[curr.id]: {
 				// First, run through every row item and make it invisible
 				// if it should not be shown.
 				primary: primaryActions.map(action => ({

--- a/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRowTypes.ts
+++ b/src/components/DataView/DataViewActionsButtonRow/DataViewActionsButtonRowTypes.ts
@@ -1,5 +1,4 @@
 import { DataViewAction, DataViewAdditionalAction, DataViewProps } from "../DataViewTypes";
-import { MosaicObject } from "../../../types";
 
 export type DataViewControlViewOption = "list" | "grid";
 
@@ -8,6 +7,6 @@ export interface DataViewActionsButtonRowProps {
 	additionalActions: DataViewAdditionalAction[];
 	actionsHidden?: boolean;
 	disabled?: DataViewProps["disabled"];
-	originalRowData: MosaicObject;
+	originalRowData: DataViewProps["data"][number];
 	activeDisplay?: DataViewControlViewOption;
 }

--- a/src/components/DataView/DataViewActionsRow/DataViewActionsRowTypes.ts
+++ b/src/components/DataView/DataViewActionsRow/DataViewActionsRowTypes.ts
@@ -1,4 +1,3 @@
-import { MosaicObject } from "@root/types";
 import {
 	DataViewColumn,
 	DataViewOnSortChange,
@@ -23,7 +22,7 @@ export interface DataViewActionsRowProps {
 	allColumns?: DataViewProps["columns"];
 	onCheckAllClick?: () => void;
 	checkedAllPages?: DataViewProps["checkedAllPages"];
-	data?: MosaicObject[];
+	data?: DataViewProps["data"];
 	sort?: DataViewProps["sort"];
 	onSortChange?: DataViewOnSortChange;
 	columns?: DataViewColumn[];

--- a/src/components/DataView/DataViewBulkActionsButtonsRow/DataViewBulkActionsButtonsRowTypes.ts
+++ b/src/components/DataView/DataViewBulkActionsButtonsRow/DataViewBulkActionsButtonsRowTypes.ts
@@ -1,9 +1,8 @@
-import { MosaicObject } from "@root/types";
 import { DataViewBulkAction, DataViewProps } from "../DataViewTypes";
 
 export interface DataViewBulkActionsButtonsRowProps {
 	bulkActions: DataViewBulkAction[];
-	data: MosaicObject[];
+	data: DataViewProps["data"];
 	checked: DataViewProps["checked"];
 	checkedAllPages: DataViewProps["checkedAllPages"];
 }

--- a/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
+++ b/src/components/DataView/DataViewDisplayGrid/DataViewDisplayGrid.tsx
@@ -85,8 +85,8 @@ function DataViewDisplayGrid(props: DataViewDisplayGridProps) {
 									</div>
 									<div className="right">
 										<DataViewActionsButtonRow
-											primaryActions={props.rowActions?.[row.id as string]?.primary}
-											additionalActions={props.rowActions?.[row.id as string]?.additional}
+											primaryActions={props.rowActions?.[row.id]?.primary}
+											additionalActions={props.rowActions?.[row.id]?.additional}
 											actionsHidden={props.actionsHidden}
 											originalRowData={row}
 											activeDisplay="grid"

--- a/src/components/DataView/DataViewDisplayList/DataViewDisplayList.tsx
+++ b/src/components/DataView/DataViewDisplayList/DataViewDisplayList.tsx
@@ -93,7 +93,7 @@ function DataViewDisplayList(props: DataViewDisplayListProps) {
 			modifiers={[restrictToVerticalAxis, restrictToTBody]}
 		>
 			<SortableContext
-				items={transformedData.map(item => item.id as string)}
+				items={transformedData.map(item => item.id)}
 				strategy={verticalListSortingStrategy}
 			>
 				<StyledTable>

--- a/src/components/DataView/DataViewTBody/DataViewTBody.tsx
+++ b/src/components/DataView/DataViewTBody/DataViewTBody.tsx
@@ -30,11 +30,11 @@ const DataViewTBody = forwardRef<HTMLTableSectionElement, DataViewTBodyProps>((p
 	<StyledTBody ref={ref}>
 		{props.transformedData.map((row, i) => (
 			<DataViewTr
-				key={row.id as string}
+				key={row.id}
 				row={row}
 				originalRowData={props.data[i]}
-				primaryActions={props.rowActions?.[row.id as string]?.primary}
-				additionalActions={props.rowActions?.[row.id as string]?.additional}
+				primaryActions={props.rowActions?.[row.id]?.primary}
+				additionalActions={props.rowActions?.[row.id]?.additional}
 				actionsHidden={props.actionsHidden}
 				disabled={props.disabled}
 				onCheckboxClick={props.onCheckboxClick ? () => props.onCheckboxClick(i) : undefined}

--- a/src/components/DataView/DataViewTBody/DataViewTBodyTypes.ts
+++ b/src/components/DataView/DataViewTBody/DataViewTBodyTypes.ts
@@ -1,11 +1,10 @@
-import { MosaicObject } from "@root/types";
 import { DataViewProps, DataViewRowActions } from "../DataViewTypes";
 import { DataViewDisplayListProps } from "../DataViewDisplayList";
 
 export interface DataViewTBodyProps {
 	onReorder?: DataViewProps["onReorder"];
 	onCheckboxClick?: DataViewDisplayListProps["onCheckboxClick"];
-	transformedData: MosaicObject[];
+	transformedData: DataViewProps["data"];
 	data: DataViewProps["data"];
 	bulkActions?: DataViewProps["bulkActions"];
 	rowActions?: DataViewRowActions;

--- a/src/components/DataView/DataViewTr/DataViewTr.tsx
+++ b/src/components/DataView/DataViewTr/DataViewTr.tsx
@@ -99,7 +99,7 @@ export function DataViewTrSortable(props: DataViewTrDndProps) {
 		transform,
 		transition,
 		isDragging,
-	} = useSortable({ id: props.originalRowData.id as string });
+	} = useSortable({ id: props.originalRowData.id });
 
 	const style = {
 		transform: CSS.Translate.toString(transform),

--- a/src/components/DataView/DataViewTr/DataViewTrTypes.ts
+++ b/src/components/DataView/DataViewTr/DataViewTrTypes.ts
@@ -1,5 +1,4 @@
 import { CSSProperties } from "react";
-import { MosaicObject } from "@root/types";
 import { DataViewProps } from "../DataViewTypes";
 
 export interface DataViewTrProps {
@@ -11,7 +10,7 @@ export interface DataViewTrProps {
 	additionalActions?: DataViewProps["additionalActions"];
 	actionsHidden?: boolean;
 	disabled?: DataViewProps["disabled"];
-	originalRowData: MosaicObject;
+	originalRowData: DataViewProps["data"][number];
 	columns: DataViewProps["columns"];
 	row?: { [x: string]: any };
 	style?: CSSProperties;

--- a/src/components/DataView/DataViewTypes.ts
+++ b/src/components/DataView/DataViewTypes.ts
@@ -10,7 +10,7 @@ export interface DataViewColumnTransformArgs<T = unknown> {
 	/** The value of the specific column that is being transformed */
 	data: T;
 	/** The whole row as passed to the original DataView */
-	row?: MosaicObject;
+	row?: DataViewProps["data"][number];
 }
 
 export interface DataViewColumnTransform<T = unknown> {
@@ -71,7 +71,7 @@ export interface DataViewFilterProps {
 }
 
 interface DataViewActionOnClick {
-	({ data }: { data: MosaicObject }): void;
+	({ data }: { data: DataViewProps["data"][number] }): void;
 }
 
 export interface ActionAdditional {
@@ -85,7 +85,7 @@ export interface ActionAdditional {
 }
 
 interface DataViewBulkActionOnClick {
-	({ data }: { data: MosaicObject[] }): void;
+	({ data }: { data: DataViewProps["data"] }): void;
 }
 
 export type DataViewAction = Omit<ButtonProps, "onClick" | "attrs" | "show"> & ActionAdditional;
@@ -190,7 +190,11 @@ export interface DataViewFilterGetOptionsReturn {
 	hasMore?: boolean;
 }
 
-export interface DataViewProps {
+export interface DataViewRowData extends Record<string, unknown> {
+	id: string;
+}
+
+export interface DataViewProps<D extends DataViewRowData = DataViewRowData> {
 	attrs?: React.HTMLAttributes<HTMLDivElement> & Record<string, unknown>;
 	title?: string;
 	loading?: boolean;
@@ -212,7 +216,7 @@ export interface DataViewProps {
 	onReorder?: (rows: string[]) => void;
 	savedView?: SavedViewDef;
 	displayOptions?: string[];
-	data: MosaicObject[];
+	data: D[];
 	sort?: DataViewSort;
 	limitOptions?: number[];
 	gridColumnsMap?: MosaicObject;

--- a/src/utils/dataViewTools.test.ts
+++ b/src/utils/dataViewTools.test.ts
@@ -75,7 +75,7 @@ describe(__filename, function() {
 		];
 
 		testArray(tests, function(test) {
-			const result = transformColumn(test.data, test.column);
+			const result = transformColumn(test.data as any, test.column);
 			assert.strictEqual(result, test.result);
 		});
 	});
@@ -116,7 +116,7 @@ describe(__filename, function() {
 		];
 
 		testArray(tests, async function(test) {
-			const result = transformRows(test.data, test.columns);
+			const result = transformRows(test.data as any, test.columns);
 			assert.deepStrictEqual(result, test.result);
 		});
 	});

--- a/src/utils/dataViewTools.ts
+++ b/src/utils/dataViewTools.ts
@@ -1,7 +1,6 @@
-import { DataViewColumn } from "../components/DataView";
-import { MosaicObject } from "../types";
+import { DataViewColumn, DataViewProps } from "../components/DataView";
 
-export function transformColumn(row: MosaicObject, column: DataViewColumn): unknown {
+export function transformColumn(row: DataViewProps["data"][number], column: DataViewColumn): unknown {
 	let data = row[column.column || column.name];
 	if (data !== undefined && column.transforms !== undefined) {
 		for (const transform of column.transforms) {
@@ -14,7 +13,7 @@ export function transformColumn(row: MosaicObject, column: DataViewColumn): unkn
 	return data;
 }
 
-export function transformRows(rows: MosaicObject[], columns: DataViewColumn[]): MosaicObject[] {
+export function transformRows(rows: DataViewProps["data"], columns: DataViewColumn[]): DataViewProps["data"] {
 	const newRows = rows.map((row) => {
 		const newRow = {
 			...row,


### PR DESCRIPTION
Slightly improves the type of DataView's data property to avoid the need to use `as` when referencing row IDs.