### PR TITLE
MOS-1328 Save buttons

### DIFF
--- a/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
+++ b/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
@@ -400,6 +400,7 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 			onClick: onSubmit,
 			color: "yellow",
 			variant: "contained",
+			type: "submit",
 		},
 	], [handleClose, onSubmit]);
 

--- a/src/components/Field/FormFieldMapCoordinates/MapCoordinatesDrawer/MapCoordinatesDrawer.tsx
+++ b/src/components/Field/FormFieldMapCoordinates/MapCoordinatesDrawer/MapCoordinatesDrawer.tsx
@@ -219,8 +219,9 @@ const MapCoordinatesDrawer = (props: MapCoordinatesDrawerProps): ReactElement =>
 			variant: "outlined",
 		},
 		{
-			label: "Save Coordinates",
+			label: "Save",
 			onClick: onSubmit,
+			type: "submit",
 			color: "yellow",
 			variant: "contained",
 			disabled: !latLng,


### PR DESCRIPTION
Brings standardisation to the fields that use drawers as an input method:

- Amends the address field's drawer save button to use the `submit` button type.
- Amends the map coordinate field's drawer save button to use the `submit` button type and "Save" text.