### PR TITLE
MOS-1323, MOS-1330, MOS-1339 - Text editor field

### DIFF
--- a/src/components/Field/FormFieldTextEditor/JoditEditor.tsx
+++ b/src/components/Field/FormFieldTextEditor/JoditEditor.tsx
@@ -1,11 +1,10 @@
 import * as React from "react";
 import { memo, ReactElement, useEffect, useRef, useMemo } from "react";
 import { MosaicFieldProps } from "@root/components/Field";
-import { EditorWrapper, StyledSkeletonWrapper } from "./FormFieldTextEditor.styled";
+import { EditorWrapper } from "./FormFieldTextEditor.styled";
 import { Jodit } from "jodit";
 import "jodit/build/jodit.min.css";
 import { TextEditorData, TextEditorInputSettings } from "./FormFieldTextEditorTypes";
-import { Skeleton } from "@mui/material";
 
 const buttonList = [
 	"source",
@@ -37,7 +36,7 @@ const buttonList = [
 const JoditEditor = (
 	props: MosaicFieldProps<"textEditor", TextEditorInputSettings, TextEditorData>,
 ): ReactElement => {
-	const { fieldDef, onBlur, onChange, value, disabled, error, inputRef, skeleton, id } = props;
+	const { fieldDef, onBlur, onChange, value, disabled, error, inputRef, id } = props;
 
 	const {
 		inputSettings = {},
@@ -70,6 +69,11 @@ const JoditEditor = (
 		language,
 		limitChars: maxCharacters,
 		tabIndex: 0,
+		disablePlugins: [
+			"add-new-line",
+			"powered-by-jodit",
+			"stat",
+		],
 	}), [
 		disabled,
 		spellcheck,
@@ -118,23 +122,6 @@ const JoditEditor = (
 		hasSetValue.current = true;
 		jodit.current.value = value;
 	}, [value]);
-
-	if (skeleton) {
-		return (
-			<StyledSkeletonWrapper>
-				<Skeleton
-					variant="rectangular"
-					width={620}
-					height={78}
-				/>
-				<Skeleton
-					variant="rectangular"
-					width={620}
-					height={154}
-				/>
-			</StyledSkeletonWrapper>
-		);
-	}
 
 	return (
 		<EditorWrapper $error={!!error} data-testid="text-editor-testid" id={id}>

--- a/src/components/Field/FormFieldTextEditor/JoditEditor.tsx
+++ b/src/components/Field/FormFieldTextEditor/JoditEditor.tsx
@@ -46,7 +46,6 @@ const JoditEditor = (
 		spellcheck = false,
 		direction = "ltr",
 		language = "en",
-		maxCharacters,
 	} = inputSettings;
 
 	const textArea = useRef(null);
@@ -67,7 +66,6 @@ const JoditEditor = (
 		spellcheck,
 		direction,
 		language,
-		limitChars: maxCharacters,
 		tabIndex: 0,
 		disablePlugins: [
 			"add-new-line",
@@ -79,7 +77,6 @@ const JoditEditor = (
 		spellcheck,
 		direction,
 		language,
-		maxCharacters,
 	]);
 
 	useEffect(() => {

--- a/src/components/FieldWrapper/FieldWrapper.tsx
+++ b/src/components/FieldWrapper/FieldWrapper.tsx
@@ -7,7 +7,7 @@ import { default as HelperText } from "./HelperText";
 import { default as InstructionText } from "./InstructionText";
 import { FieldDef, MosaicFieldProps } from "../Field";
 import { Skeleton } from "@mui/material";
-import { stripTags } from "@root/utils/dom/stripTags";
+import { getHtmlText } from "@root/utils/dom/getHtmlText";
 
 function getValueLimit(def: FieldDef): number | undefined {
 	if (!def || !def.inputSettings) {
@@ -30,7 +30,7 @@ function getValueLimit(def: FieldDef): number | undefined {
 function getValueLength(value: any, fieldDef: FieldDef): number {
 	if (typeof value === "string") {
 		if (fieldDef.type === "textEditor") {
-			return stripTags(value).length;
+			return getHtmlText(value).length;
 		}
 
 		return value.length;

--- a/src/components/Form/validators.ts
+++ b/src/components/Form/validators.ts
@@ -1,5 +1,5 @@
 import { DATE_FORMAT_FULL } from "@root/constants";
-import { stripTags } from "@root/utils/dom/stripTags";
+import { getHtmlText } from "@root/utils/dom/getHtmlText";
 import format from "date-fns/format";
 
 export const VALIDATE_EMAIL_TYPE = "validateEmail";
@@ -183,7 +183,7 @@ export function validateCharacterCount(value: string, data: any, options: { max?
 		return;
 	}
 
-	const sanitized = options.ignoreHTML ? stripTags(value) : value;
+	const sanitized = options.ignoreHTML ? getHtmlText(value) : value;
 
 	if (sanitized.length > options.max) {
 		return "You have exceeded the maximum number of characters";

--- a/src/utils/dom/getHtmlText.ts
+++ b/src/utils/dom/getHtmlText.ts
@@ -1,0 +1,66 @@
+function isTextNode(el: Node): el is Text {
+	return el.nodeType === Node.TEXT_NODE;
+}
+
+function isElement(el: Node): el is HTMLElement {
+	return el.nodeType === Node.ELEMENT_NODE;
+}
+
+function getElementTexts(el: Node): string[] {
+	const texts: string[] = [];
+	const children = Array.from(el.childNodes);
+
+	for (let i = 0; i < children.length; i++) {
+		const child = children[i];
+
+		if (isTextNode(child)) {
+			// Create a temporary container for the text node
+			// so that we don't lost HTML entities whilst
+			// collapsing white space.
+			const container = document.createElement("div");
+			container.appendChild(child.cloneNode());
+			const textContent = container.innerHTML
+				// Collapse whitespace to single spaces
+				.replace(/\s\s+/g, " ")
+				// Remove leading white space
+				.replace(/^\s+/g, "");
+
+			// Now we can parse any HTML entitites
+			container.innerHTML = textContent;
+
+			if (container.textContent) {
+				texts.push(container.textContent);
+			}
+
+			continue;
+		}
+
+		if (isElement(child)) {
+			if (child.tagName === "SCRIPT" || child.tagName === "STYLE") {
+				continue;
+			}
+
+			// Block level elements that are not first
+			// born are to be considered one character
+			// regardless of their content.
+			if (child.tagName !== "BODY" && i > 0) {
+				const styles = window.getComputedStyle(child, "");
+
+				if (styles && styles.display === "block") {
+					texts.push(" ");
+				}
+			}
+
+			texts.push(...getElementTexts(child));
+			continue;
+		}
+	}
+
+	return texts;
+}
+
+export function getHtmlText(html: string): string {
+	const doc = new DOMParser().parseFromString(html, "text/html");
+	const texts = getElementTexts(doc);
+	return texts.join("");
+}

--- a/src/utils/dom/stripTags.ts
+++ b/src/utils/dom/stripTags.ts
@@ -1,4 +1,0 @@
-export function stripTags(html: string) {
-	const doc = new DOMParser().parseFromString(html, "text/html");
-	return doc.body.textContent || "";
-}


### PR DESCRIPTION
Addresses a number of issues that existed for the text editor form field:

- MOS-1323
  - Removes the "add new line" plugin which rendered an incorrectly positioned new line button.
  - Removes the "powered by Jodit" text to reduce noise.
  - Removes the word and character counter which caused confusion due to the conflicts with Mosaic's character counter.
- MOS-1330
  - No longer passes the maximum characters property down to Jodit to avoid conflicts with Mosaic's preferred max character behaviour
- MOS-1339
  - Expand on the text editor character count helper to account for eccentricities of HTML whilst still supporting `script` and `style` tags.