### PR TITLE
MOS-1338 - Content row keys

### DIFF
--- a/src/components/Content/Content.tsx
+++ b/src/components/Content/Content.tsx
@@ -65,14 +65,14 @@ const Content = (props: ContentProps): ReactElement => {
 						className={cardVariant ? "card-row" : ""}
 						$columns={rows.length}
 					>
-						{rows.map(([field]) => field ? (
+						{rows.map(([field], rowIdx) => field ? (
 							<ContentField
 								{...field}
 								key={field.name}
 								value={data[field.column || field.name]}
 							/>
 						) : (
-							<FieldContainer key={idx} data-testid={testIds.CONTENT_FIELD} />
+							<FieldContainer key={rowIdx} data-testid={testIds.CONTENT_FIELD} />
 						))}
 					</ContentRowWrapper>
 				))}


### PR DESCRIPTION
Corrects the field container's key to use the row's index instead of the section's index to prevent duplicate keys in the same parent.