### PR TITLE
MOS-1327

### DIFF
--- a/src/components/FieldWrapper/FieldWrapper.tsx
+++ b/src/components/FieldWrapper/FieldWrapper.tsx
@@ -100,7 +100,7 @@ const FieldWrapper = ({
 		fieldDef?.instructionText;
 
 	useEffect(() => {
-		if (!mountField || !fieldDef?.name) {
+		if (!mountField || !fieldDef?.name || skeleton) {
 			return;
 		}
 
@@ -111,7 +111,7 @@ const FieldWrapper = ({
 		});
 
 		return unmount;
-	}, [mountField, fieldDef.name, inputRef]);
+	}, [mountField, fieldDef.name, inputRef, skeleton]);
 
 	const hasRealLabel = useRealLabel || typesWithRealLabel.includes(fieldDef?.type);
 

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -114,7 +114,13 @@ const Form = (props: FormProps) => {
 		scrollTo({
 			target: mount.fieldRef,
 		});
-	}, [errors, moveToError, scrollTo, stable.fields, stable.mounted]);
+	}, [
+		errors,
+		moveToError,
+		scrollTo,
+		stable.fields,
+		stable.mounted,
+	]);
 
 	const doneAutoFocus = useRef(false);
 
@@ -239,8 +245,8 @@ const Form = (props: FormProps) => {
 	const skeleton = providedSkeleton || loadingInitial;
 
 	useEffect(() => {
-		init({ fields });
-	}, [init, fields]);
+		init({ fields, sections });
+	}, [init, fields, sections]);
 
 	useEffect(() => {
 		(async () => {

--- a/src/components/Form/stories/QuickSubmitForm.stories.tsx
+++ b/src/components/Form/stories/QuickSubmitForm.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { ReactElement, useEffect, useMemo } from "react";
+import { withKnobs, boolean } from "@storybook/addon-knobs";
 
 // Utils
-import { useForm } from "@root/components/Form";
+import { SectionDef, useForm } from "@root/components/Form";
 
 // Components
 import Form from "../Form";
@@ -15,9 +16,28 @@ import { ButtonProps } from "@root/components/Button";
 
 export default {
 	title: "Components/Form",
+	decorators: [withKnobs],
 };
 
+const sections: SectionDef[] = [
+	{
+		title: "Other",
+		fields: [
+			[["age"]],
+		],
+	},
+	{
+		title: "Name",
+		fields: [
+			[["lastName"]],
+			[["firstName"]],
+		],
+	},
+];
+
 export const QuickSubmit = (): ReactElement => {
+	const useSections = boolean("Use Sections", false);
+
 	const controller = useForm();
 	const { handleSubmit } = controller;
 
@@ -40,6 +60,11 @@ export const QuickSubmit = (): ReactElement => {
 				{
 					name: "lastName",
 					label: "Last Name",
+					type: "text",
+				},
+				{
+					name: "age",
+					label: "Age",
 					type: "text",
 				},
 			],
@@ -66,6 +91,7 @@ export const QuickSubmit = (): ReactElement => {
 				buttons={buttons}
 				title="Quick Submit"
 				fields={fields}
+				sections={useSections ? sections : undefined}
 				onSubmit={onSubmit}
 				autoFocus
 			/>

--- a/src/components/Form/useForm/types.ts
+++ b/src/components/Form/useForm/types.ts
@@ -1,5 +1,5 @@
 import { MosaicObject } from "@root/types";
-import { FieldDef } from "../FormTypes";
+import { FieldDef, SectionDef } from "../FormTypes";
 import { FieldDefSanitized } from "@root/components/Field";
 
 export type ActionTypes =
@@ -187,6 +187,7 @@ export type AddValidator = (params: AddValidatorParams) => AddValidatorResult;
 
 export type FormInitParams = {
 	fields: FieldDef[];
+	sections?: SectionDef[];
 };
 
 export type FormInit = (params: FormInitParams) => void;

--- a/src/components/Form/useForm/useForm.ts
+++ b/src/components/Form/useForm/useForm.ts
@@ -193,7 +193,10 @@ export function useForm(): UseFormReturn {
 
 	const init = useCallback<FormInit>(({
 		fields,
+		sections,
 	}) => {
+		const fieldsBySection = sections && sections.map(({ fields }) => fields).flat(3);
+
 		stable.current.fields = fields.reduce<Record<string, FieldDefSanitized>>((prev, field, index) => {
 			const fieldConfig = getFieldConfig(field.type);
 			const valueResolver = field.getResolvedValue || fieldConfig.getResolvedValue;
@@ -202,7 +205,7 @@ export function useForm(): UseFormReturn {
 				...field,
 				validateOn: field.validateOn || fieldConfig.validate,
 				getResolvedValue: (value) => valueResolver(value, field),
-				order: index + 1,
+				order: (fieldsBySection ? fieldsBySection.indexOf(field.name) : index) + 1,
 			};
 
 			return {


### PR DESCRIPTION
Allows the form initialisation function to accept sections so that field order can be calculated based on where they appear if applicable. If no sections are provided, the order will fallback to that of the fields array.