### PR TITLE
MOS-1365

### DIFF
--- a/src/components/MenuBase/MenuBase.tsx
+++ b/src/components/MenuBase/MenuBase.tsx
@@ -8,7 +8,7 @@ export const MenuBaseContext = createContext<MenuBaseContextProps>(null);
 
 export default function MenuBase(props: MenuBaseProps): ReactElement {
 	return (
-		<StyledMenu anchorEl={props.anchorEl} open={props.open} onClose={props.onClose} disablePortal={true}>
+		<StyledMenu anchorEl={props.anchorEl} open={props.open} onClose={props.onClose}>
 			<MenuBaseContext.Provider value={{ onClose : props.onClose }}>
 				{props.children}
 			</MenuBaseContext.Provider>


### PR DESCRIPTION
# [MOS-1365](https://simpleviewtools.atlassian.net/browse/MOS-1365)

## Description
Enable popper fixed strategy by removing the `disablePortal` property from MenuBase.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [X] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1365]: https://simpleviewtools.atlassian.net/browse/MOS-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ