### PR TITLE
MOS-1351

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./types";
-export * from "./utils";
 
 export { default as Form } from "./components/Form";
 export * from "./components/Form";


### PR DESCRIPTION
# [MOS-1351](https://simpleviewtools.atlassian.net/browse/MOS-1351)

## Description
Stops exporting Mosaic utility functions from the root export. Utilities imported using `@simpleview/sv-mosaic/*` must now be imported using `@simpleview/sv-mosaic/utils/*`

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [x] This contains breaking changes

[MOS-1351]: https://simpleviewtools.atlassian.net/browse/MOS-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ