### PR TITLE
MOS-1366

### DIFF
--- a/src/components/ButtonRow/ButtonRowTypes.ts
+++ b/src/components/ButtonRow/ButtonRowTypes.ts
@@ -21,10 +21,6 @@ export interface ButtonRowProps {
 	children?: React.ReactNode;
 	className?: string;
 	separator?: boolean;
-	/**
-	 * @deprecated
-	 */
-	gap?: "small" | "large";
 	wrap?: boolean;
 	skeleton?: boolean;
 }

--- a/src/components/Field/FieldTypes.tsx
+++ b/src/components/Field/FieldTypes.tsx
@@ -144,17 +144,6 @@ export interface FieldDefBase<Type, T = any> {
 	 */
 	type: Type;
 	/**
-	 * Object that defines the position of the current field in the
-	 * form layout.
-	 *
-	 * @deprecated
-	 */
-	layout?: {
-		section?: number;
-		row?: number;
-		col?: number;
-	};
-	/**
 	 * Array of validators to be executed by the form when on blur or
 	 * when submitted.
 	 */

--- a/src/components/Field/FormFieldMapCoordinates/FormFieldMapCoordinates.tsx
+++ b/src/components/Field/FormFieldMapCoordinates/FormFieldMapCoordinates.tsx
@@ -49,7 +49,7 @@ const FormFieldMapCoordinates = (props: MosaicFieldProps<"mapCoordinates", MapCo
 	const latLng = useMemo(() => isValidLatLng(value) ? value : undefined, [value]);
 
 	// Supports legacy mapPosition
-	const initialCenter = fieldDef?.inputSettings?.initialCenter || fieldDef?.inputSettings?.mapPosition;
+	const initialCenter = fieldDef?.inputSettings?.initialCenter;
 
 	// State variables
 	const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/components/Field/FormFieldMapCoordinates/MapCoordinatesTypes.ts
+++ b/src/components/Field/FormFieldMapCoordinates/MapCoordinatesTypes.ts
@@ -22,11 +22,6 @@ export type MapPosition = { lat: number; lng: number };
 
 export type MapCoordinatesInputSettings = Pick<MapProps, "initialCenter"> & {
 	/**
-	 * Latitude and longitude object.
-	 * @deprecated Use initialCenter instead
-	 */
-	mapPosition?: MapPosition;
-	/**
 	 * Where to center the map initially and when
 	 * the reset button is clicked. Defaults to
 	 * Simpleview HQ in Tucson if not provided

--- a/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
+++ b/src/components/Field/FormFieldUpload/FormFieldUpload.tsx
@@ -216,7 +216,6 @@ const FormFieldUpload = (props: MosaicFieldProps<"upload", UploadFieldInputSetti
 					file: item?.rawData,
 					onChunkComplete: ({ percent }) => onChunkComplete({ uuid: item.id, percent }),
 					onUploadComplete: (data) => onUploadComplete({ uuid: item.id, data }),
-					onError: (message) => onError({ uuid: item.id, message }),
 				});
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);

--- a/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
+++ b/src/components/Field/FormFieldUpload/FormFieldUploadTypes.ts
@@ -62,16 +62,10 @@ type OnFileDeleteData = {
 
 export type OnFileDelete = (deletedData: OnFileDeleteData) => Promise<void>;
 
-type OnError = (message: string) => Promise<void>;
-
 type OnFileAddData = {
 	file: File;
 	onChunkComplete: (data: { percent: number }) => Promise<void>;
 	onUploadComplete: (data: UploadData) => Promise<void>;
-	/**
-	 * @deprecated - Throw an error within `onFileAdd` callback instead.
-	 */
-	onError: OnError;
 };
 
 export type OnFileAdd = (addedData: OnFileAddData) => Promise<void>;

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -14,8 +14,7 @@ const defaultTagMap: Record<TypographyVariant, TypographyTag> = {
 export default function Typography({
 	children,
 	attrs = {},
-	as,
-	tag: providedTag = as,
+	tag: providedTag,
 	variant = "none",
 	maxLines,
 	color,

--- a/src/components/Typography/TypographyTypes.ts
+++ b/src/components/Typography/TypographyTypes.ts
@@ -13,10 +13,6 @@ export interface TypographyProps {
 	 */
 	variant?: TypographyVariant;
 	/**
-	 * @deprecated Use "tag" prop instead
-	 */
-	as?: TypographyTag;
-	/**
 	 * The HTML element to use.
 	 */
 	tag?: TypographyTag;
@@ -32,10 +28,6 @@ export interface TypographyProps {
 	 * Utilises "word-break: break-all" - useful for displaying long strings with no breaking characters like URLs
 	 */
 	breakAll?: boolean;
-	/**
-	 * @deprecated use attrs
-	 */
-	style?: MosaicObject;
 	/**
 	 * The content, usually text, of the Typography component
 	 */


### PR DESCRIPTION
# [MOS-1366](https://simpleviewtools.atlassian.net/browse/MOS-1366)

## Description
Remove the following deprecations:

- `gap` from `ButtonRowProps` (no longer used)
- `layout` from `FieldDefBase` (use the `sections` property on `FormProps` instead)
- `mapPosition` from `MapCoordinatesInputSettings` (use `initialCenter` instead)
- `onError` from `OnFileAddData` (throw an error within `onFileAdd` instead)
- `as` from `TypographyProps` (use `tag` instead)
- `style` from `TypographyProps` (Use a style property on an object provided to `attrs` instead)

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [x] This contains breaking changes

[MOS-1366]: https://simpleviewtools.atlassian.net/browse/MOS-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ