### PR TITLE
MOS-1394

### DIFF
--- a/containers/e2e-tests/pages/FormFields/FormFieldChips/FormFieldChipsPage.ts
+++ b/containers/e2e-tests/pages/FormFields/FormFieldChips/FormFieldChipsPage.ts
@@ -21,7 +21,7 @@ export class FormFieldChipsPage extends BasePage {
 		this.disabledChipSingleSelectDiv = page.locator("#chipDisable");
 		this.requiredChipSingleSelectDiv = page.locator("[data-testid='field-test-id']").nth(2);
 		this.fromDBOptionsChipSingleSelectDiv = page.locator("[data-testid='field-test-id']").nth(3);
-		this.optionButton = "[role='button']";
+		this.optionButton = "[role='option']";
 		this.fromDBOptionDiv = page.locator("//*[@id='3']/div/div/div/div/div/div[2]");
 	}
 

--- a/containers/mosaic/src/__tests__/components/Field/FormFieldChips/FormFieldChips.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldChips/FormFieldChips.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useMemo, ReactElement } from "react";
-import { render, cleanup, screen, waitFor } from "@testing-library/react";
+import { render, cleanup, screen, waitFor, fireEvent } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
 import "@testing-library/jest-dom/extend-expect";
 
@@ -12,7 +12,7 @@ import { getOptions } from "@root/utils/getOptions";
 
 afterEach(cleanup);
 
-const { getByText } = screen;
+const { getByText, getAllByRole } = screen;
 
 const FormFieldChipsExample = (props:{ fromDB: boolean }): ReactElement => {
 	const controller = useForm();
@@ -93,6 +93,26 @@ describe("FormFieldChips component", () => {
 		expect(getByText("Option 1")).toBeTruthy();
 		expect(getByText("Option 2")).toBeTruthy();
 		expect(getByText("Option 3")).toBeTruthy();
+	});
+
+	it("should select a Chip when clicked once and deselect it when clicked again", async () => {
+		const [chip1, chip2, chip3] = getAllByRole("option");
+
+		expect(chip1).not.toHaveAttribute("aria-selected");
+		expect(chip2).not.toHaveAttribute("aria-selected");
+		expect(chip3).not.toHaveAttribute("aria-selected");
+
+		await act(async () => {
+			await fireEvent.click(chip1);
+		});
+
+		expect(chip1).toHaveAttribute("aria-selected", "true");
+
+		await act(async () => {
+			await fireEvent.click(chip1);
+		});
+
+		expect(chip1).toHaveAttribute("aria-selected", "false");
 	});
 });
 

--- a/containers/mosaic/src/components/Chip/Chip.tsx
+++ b/containers/mosaic/src/components/Chip/Chip.tsx
@@ -32,6 +32,7 @@ const Chip = (props: ChipsProps & HTMLAttributes<HTMLDivElement>): ReactElement 
 			ref={ref}
 			disabled={disabled}
 			$selected={selected}
+			aria-selected={selected}
 			onClick={onClick}
 			data-testid="chip-testid"
 		/>

--- a/containers/mosaic/src/components/Field/FormFieldChips/FormFieldChips.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldChips/FormFieldChips.tsx
@@ -99,6 +99,7 @@ const FormFieldChips = (props: MosaicFieldProps<"chip", FormFieldChipsInputSetti
 		<StyledChipGroup
 			$error={errorWithMessage || (errorWithMessage && required)}
 			onBlur={onBlur}
+			role="listbox"
 		>
 			{internalOptions.map((option) => (
 				<Chip
@@ -107,6 +108,7 @@ const FormFieldChips = (props: MosaicFieldProps<"chip", FormFieldChipsInputSetti
 					disabled={disabled}
 					selected={option.selected}
 					onClick={() => updateSelectedOption(option)}
+					role="option"
 				/>
 			))}
 		</StyledChipGroup>


### PR DESCRIPTION
# [MOS-1394](https://simpleviewtools.atlassian.net/browse/MOS-1394)

## Description
- Gives chip container the listbox role and each chip an option role.
- Gives selected chips the `aria-selected` attribute.

## Checklist
- [x] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1394]: https://simpleviewtools.atlassian.net/browse/MOS-1394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ