### PR TITLE
MOS-1386

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldAdvancedSelection/AdvancedSelection.styled.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAdvancedSelection/AdvancedSelection.styled.tsx
@@ -7,11 +7,11 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { TransientProps } from "@root/types";
 import { ChipListPropsTypes } from "./AdvancedSelectionTypes";
 
-export const ChipsWrapper = styled.div<TransientProps<ChipListPropsTypes["fieldDef"]["inputSettings"], "isMobileView" | "isModalOpen">>`
+export const ChipsWrapper = styled.div<TransientProps<ChipListPropsTypes["fieldDef"]["inputSettings"], "isMobileView">>`
   display: flex;
   flex-wrap: wrap;
   row-gap: 12px;
-  width: ${({ $isMobileView, $isModalOpen }) => $isMobileView || !$isModalOpen ? "" : "620px"};
+  width: ${({ $isMobileView }) => $isMobileView ? "" : "620px"};
 
   & > :not(:last-child) {
     margin-right: 12px;
@@ -20,10 +20,6 @@ export const ChipsWrapper = styled.div<TransientProps<ChipListPropsTypes["fieldD
   & > * {
     margin-top: 8px;
   }
-`;
-
-export const OptionsCheckedModalWrapper = styled.div<TransientProps<ChipListPropsTypes["fieldDef"]["inputSettings"], "isModalOpen">>`
-  margin: ${({ $isModalOpen }) => ($isModalOpen ? "15px" : "")};
 `;
 
 export const ShowHideSpan = styled.span`

--- a/containers/mosaic/src/components/Field/FormFieldAdvancedSelection/AdvancedSelectionTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAdvancedSelection/AdvancedSelectionTypes.tsx
@@ -31,7 +31,6 @@ export type AdvancedSelectionInputSettings = AdvancedSelectionLocalOptions | Adv
 export interface ChipListPropsTypes {
 	fieldDef: {
 		inputSettings: {
-			isModalOpen: boolean;
 			isMobileView: boolean;
 			deleteSelectedOption: (options: MosaicLabelValue[]) => Promise<void>;
 		};

--- a/containers/mosaic/src/components/Field/FormFieldAdvancedSelection/ChipList.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAdvancedSelection/ChipList.tsx
@@ -9,7 +9,6 @@ import {
 import { ChipListPropsTypes } from ".";
 import {
 	ChipsWrapper,
-	OptionsCheckedModalWrapper,
 	ShowHideSpan,
 	StyledExpandLessIcon,
 	StyledExpandMoreIcon,
@@ -45,9 +44,8 @@ const ChipList = forwardRef<HTMLDivElement, ChipListPropsTypes>((props, ref): Re
 	};
 
 	return value?.length > 0 && (
-		<OptionsCheckedModalWrapper ref={ref} $isModalOpen={fieldDef?.inputSettings?.isModalOpen}>
+		<div ref={ref}>
 			<ChipsWrapper
-				$isModalOpen={fieldDef?.inputSettings?.isModalOpen}
 				$isMobileView={fieldDef?.inputSettings?.isMobileView}
 				data-testid="as-chiplist"
 			>
@@ -87,7 +85,7 @@ const ChipList = forwardRef<HTMLDivElement, ChipListPropsTypes>((props, ref): Re
 					)}
 				</div>
 			)}
-		</OptionsCheckedModalWrapper>
+		</div>
 	);
 });
 

--- a/containers/mosaic/src/components/Field/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAdvancedSelection/FormFieldAdvancedSelection.tsx
@@ -86,7 +86,7 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 
 	return (
 		<>
-			{value?.length > 0 && !isModalOpen ? (
+			{value?.length > 0 ? (
 				<AdvancedSelectionWrapper>
 					{(selectLimit < 0 || value?.length < selectLimit) && (
 						<Button
@@ -103,7 +103,6 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 						value={value}
 						fieldDef={{
 							inputSettings: {
-								isModalOpen,
 								isMobileView,
 								deleteSelectedOption,
 							},
@@ -122,7 +121,8 @@ const FormFieldAdvancedSelection = (props: MosaicFieldProps<"advancedSelection",
 			)}
 			<Drawer
 				open={isModalOpen}
-				onClose={handleClose} backdropCloseHandler={false}
+				onClose={handleClose}
+				backdropCloseHandler={false}
 			>
 				<AdvancedSelectionDrawer
 					value={value ?? []}


### PR DESCRIPTION
# [MOS-1386](https://simpleviewtools.atlassian.net/browse/MOS-1386)

## Description
Have selected chips retain their rendered position whilst the selection draw is open instead of being hidden.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1386]: https://simpleviewtools.atlassian.net/browse/MOS-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ