### PR TITLE
MOS-1396

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
@@ -108,7 +108,9 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 			onChange({
 				...value,
 				time,
-				validTime: true,
+				// An empty field is still an acceptable input as far as
+				// the time field goes, but it doesn't mean it's a valid time.
+				validTime: Boolean(time),
 			});
 		}
 	};


### PR DESCRIPTION
# [MOS-1396](https://simpleviewtools.atlassian.net/browse/MOS-1396)

## Description
- (DateField) Ensures that an empty input (nullish time) - even though it is an acceptable input - is not considered a valid time.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1396]: https://simpleviewtools.atlassian.net/browse/MOS-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ