### PR TITLE
MOS-1392

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldText/FormFieldText.styled.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldText/FormFieldText.styled.tsx
@@ -27,6 +27,11 @@ export const StyledTextField = styled(({ fieldSize, ...rest }) => (
 		}
 	}
 
+	& .MuiInputBase-root{
+		overflow: hidden;
+		border-radius: 0;
+	}
+
 	fieldset {
 		border-radius: 0px;
 		border-color: ${theme.newColors.simplyGrey["100"]};
@@ -60,6 +65,10 @@ export const StyledTextField = styled(({ fieldSize, ...rest }) => (
 		word-break: break-all;
 	}
 
+	.MuiTypography-root {
+		font-family: ${theme.fontFamily};
+	}
+
 	.MuiFormHelperText-root.Mui-error {
 		color: ${theme.newColors.darkRed["100"]}
 	}
@@ -78,5 +87,13 @@ export const StyledTextField = styled(({ fieldSize, ...rest }) => (
 
 	.MuiOutlinedInput-root.Mui-error .MuiOutlinedInput-notchedOutline {
 		border-color: ${pr => pr.error ? theme.newColors.darkRed["100"] : "transparent"};
+	}
+
+	& .MuiInputBase-adornedStart .MuiInputBase-input {
+		padding-left: 0;
+	}
+
+	& .MuiInputBase-adornedEnd .MuiInputBase-input {
+		padding-right: 0;
 	}
 `;


### PR DESCRIPTION
# [MOS-1392](https://simpleviewtools.atlassian.net/browse/MOS-1392)

## Description
Hides overflowing text field content to prevent oversized prefixes or suffixes (or both) from spilling out of the container.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1392]: https://simpleviewtools.atlassian.net/browse/MOS-1392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ