### PR TITLE
MOS-1296

### DIFF
--- a/containers/e2e-tests/pages/Components/DataView/DataViewFilterText.ts
+++ b/containers/e2e-tests/pages/Components/DataView/DataViewFilterText.ts
@@ -36,10 +36,10 @@ export class DataViewFilterTextComponent extends BasePage {
 		await this.menuItem.locator(":scope", { hasText: comparison }).first().click({ force: true });
 	}
 
-	async searchWithComparison(word: string, comparison: "Contains" | "Not Contains" | "Equals" | "Not Equal" | "Exists" | "Not Exists"): Promise<void> {
+	async searchWithComparison(word: string, comparison: "Contains..." | "Does not contain..." | "Equals..." | "Not equal to..." | "Exists" | "Not Exists"): Promise<void> {
 		await this.filterTextButton.click();
 		await this.selectComparison(comparison);
-		if (comparison == "Contains" || comparison == "Not Contains" || comparison == "Equals" || comparison == "Not Equal") {
+		if (comparison == "Contains..." || comparison == "Does not contain..." || comparison == "Equals..." || comparison == "Not equal to...") {
 			await this.inputLocator.fill(word);
 		}
 		await this.wait();
@@ -47,19 +47,19 @@ export class DataViewFilterTextComponent extends BasePage {
 		await this.filterTextButton.waitFor();
 	}
 
-	async visitPageWithDefaultComparison(comparison: "Equals" | "Not Equal" | "Contains" | "Not Contains" | "Exists" | "Not Exists" | string): Promise<void> {
+	async visitPageWithDefaultComparison(comparison: "Equals..." | "Not equal to..." | "Contains..." | "Does not contain..." | "Exists" | "Not Exists" | string): Promise<void> {
 		let comparisonOption: string;
 		switch (comparison) {
-		case "Equals":
+		case "Equals...":
 			comparisonOption = "equals";
 			break;
-		case "Not Equal":
+		case "Not equal to...":
 			comparisonOption = "not_equals";
 			break;
-		case "Contains":
+		case "Contains...":
 			comparisonOption = "contains";
 			break;
-		case "Not Contains":
+		case "Does not contain...":
 			comparisonOption = "not_contains";
 			break;
 		case "Exists":

--- a/containers/e2e-tests/tests/Components/DataView/AdvancedFilters.spec.ts
+++ b/containers/e2e-tests/tests/Components/DataView/AdvancedFilters.spec.ts
@@ -188,7 +188,7 @@ test.describe("Components - Data View - Advanced Filters", () => {
 		await advancedFilters.selectFilter("titleWithComparisons");
 		await advancedFilters.titleWithComparisonBtn.click();
 		await advancedFilters.searchForTitleComparison(advanced_filter_data.searchedTitle);
-		await advancedFilters.selectTitleComparisonOptionFromDropdown("Not Contains");
+		await advancedFilters.selectTitleComparisonOptionFromDropdown("Does not contain...");
 		await advancedFilters.applyBtn.click();
 		await pagination.selectResultOption(100);
 		const allTitlesOfRows = await _dataviewPage.getAllRowData("Title", 100);

--- a/containers/e2e-tests/tests/Components/DataView/DataViewFilterText.spec.ts
+++ b/containers/e2e-tests/tests/Components/DataView/DataViewFilterText.spec.ts
@@ -16,7 +16,7 @@ test.describe("Components - DataViewFilterText - Playground", () => {
 	test("Validate that the filter is displayed when searched.", async () => {
 		const expectedWord = filter_data.validKeywordFilter;
 		await dvFilterComponent.searchForWord(expectedWord);
-		expect(await dvFilterComponent.getOnlyStringWithLetters(await dvFilterComponent.wordFilterLocator.textContent())).toBe(expectedWord);
+		expect(await dvFilterComponent.getOnlyStringWithLetters(await dvFilterComponent.wordFilterLocator.textContent())).toBe(`is ${expectedWord}`);
 	});
 
 	test("Validate that the comparison button is displayed.", async () => {
@@ -30,15 +30,15 @@ test.describe("Components - DataViewFilterText - Playground", () => {
 		const searchWord = filter_data.validKeywordFilter;
 		await dvFilterComponent.visit(dvFilterComponent.page_path, [knob.knobComparison + "true"]);
 		await dvFilterComponent.searchWithComparison(searchWord, "Contains");
-		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain("~");
+		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain("contains");
 		await dvFilterComponent.searchWithComparison(searchWord, "Not Contains");
-		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain("!~");
+		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain("does not contain");
 		await dvFilterComponent.searchWithComparison(searchWord, "Not Equal");
-		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain("!=");
+		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain("is not");
 		await dvFilterComponent.searchWithComparison(searchWord, ("Exists"));
-		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain(("Exists").toUpperCase());
+		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain(("exists"));
 		await dvFilterComponent.searchWithComparison(searchWord, "Not Exists");
-		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain(("Not Exists").toUpperCase());
+		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain(("does not exist"));
 	});
 
 	test("Validate that the text filter comparison logic is consistent.", async () => {

--- a/containers/e2e-tests/tests/Components/DataView/DataViewFilterText.spec.ts
+++ b/containers/e2e-tests/tests/Components/DataView/DataViewFilterText.spec.ts
@@ -29,11 +29,11 @@ test.describe("Components - DataViewFilterText - Playground", () => {
 	test("Validate that each comparison is displayed.", async () => {
 		const searchWord = filter_data.validKeywordFilter;
 		await dvFilterComponent.visit(dvFilterComponent.page_path, [knob.knobComparison + "true"]);
-		await dvFilterComponent.searchWithComparison(searchWord, "Contains");
+		await dvFilterComponent.searchWithComparison(searchWord, "Contains...");
 		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain("contains");
-		await dvFilterComponent.searchWithComparison(searchWord, "Not Contains");
+		await dvFilterComponent.searchWithComparison(searchWord, "Does not contain...");
 		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain("does not contain");
-		await dvFilterComponent.searchWithComparison(searchWord, "Not Equal");
+		await dvFilterComponent.searchWithComparison(searchWord, "Not equal to...");
 		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain("is not");
 		await dvFilterComponent.searchWithComparison(searchWord, ("Exists"));
 		expect(await dvFilterComponent.wordFilterLocator.textContent()).toContain(("exists"));
@@ -42,7 +42,7 @@ test.describe("Components - DataViewFilterText - Playground", () => {
 	});
 
 	test("Validate that the text filter comparison logic is consistent.", async () => {
-		const comparisonsToValidate = ["Equals", "Not Equal", "Contains", "Not Contains", "Exists", "Not Exists"];
+		const comparisonsToValidate = ["Equals...", "Not equal to...", "Contains...", "Does not contain...", "Exists", "Not Exists"];
 		for (let i = 0; i < comparisonsToValidate.length; i++) {
 			await dvFilterComponent.visitPageWithDefaultComparison(comparisonsToValidate[i]);
 			await dvFilterComponent.filterTextButton.waitFor();
@@ -58,10 +58,10 @@ test.describe("Components - DataViewFilterText - Playground", () => {
 			const expectedText = comparisonsToValidate[i];
 			expect(comparisonButtonText).toBe(expectedText);
 		}
-		dvFilterComponent.pressSpecificKeyInKeyboard("Escape");
 	});
 
 	test("Validate that the padding in the input row.", async () => {
+		await dvFilterComponent.visit(dvFilterComponent.page_path);
 		const expectedPadding = "16px 16px 0px";
 		await dvFilterComponent.filterTextButton.click();
 		expect(await dvFilterComponent.getSpecificPaddingFromElement(dvFilterComponent.inputRowLocator, "all")).toBe(expectedPadding);

--- a/containers/e2e-tests/tests/Components/DataView/Filter.spec.ts
+++ b/containers/e2e-tests/tests/Components/DataView/Filter.spec.ts
@@ -29,7 +29,7 @@ test.describe("Components - Data View - Filter", () => {
 		const titles = await filter._dataviewPage.getAllRowData("Title");
 		expect(titles).toContain(filter_data.validKeywordFilter.toLowerCase());
 		expect(await filter._dataviewPage.paginationComponent.paginationValue.textContent()).toBe(`1-${filter_data.expectedKeywordFilterNumber} of ${filter_data.expectedKeywordFilterNumber}`);
-		expect(await filter._dataviewPage.getFilterText(filter.keywordBtn)).toBe(filter_data.validKeywordFilter);
+		expect(await filter._dataviewPage.getFilterText(filter.keywordBtn)).toBe(`is ${filter_data.validKeywordFilter}`);
 	});
 
 	test("Filter title with a valid keyword and several results", async () => {
@@ -38,13 +38,13 @@ test.describe("Components - Data View - Filter", () => {
 		const titles = await filter._dataviewPage.getAllRowData("Title");
 		await filter._dataviewPage.validateContainsKeyword(titles, filter_data.validKeywordFilterSeveralResults);
 		expect(await filter._dataviewPage.paginationComponent.paginationValue.textContent()).toBe(`1-${filter_data.expectedKeywordFilterNumberSeveralResults} of ${filter_data.expectedKeywordFilterNumberSeveralResults}`);
-		expect(await filter._dataviewPage.getFilterText(filter.keywordBtn)).toBe(filter_data.validKeywordFilterSeveralResults);
+		expect(await filter._dataviewPage.getFilterText(filter.keywordBtn)).toBe(`is ${filter_data.validKeywordFilterSeveralResults}`);
 	});
 
 	test("Filter title with a valid keyword and no results", async () => {
 		await filter.searchForTerm("keyword", filter_data.keywordNoResultsFilter);
 		await expect(filter._dataviewPage.noResults).toBeVisible();
-		expect(await filter._dataviewPage.getFilterText(filter.keywordBtn)).toBe(filter_data.keywordNoResultsFilter);
+		expect(await filter._dataviewPage.getFilterText(filter.keywordBtn)).toBe(`is ${filter_data.keywordNoResultsFilter}`);
 	});
 
 	test("Filter title with a special character", async () => {
@@ -57,7 +57,7 @@ test.describe("Components - Data View - Filter", () => {
 		expect(await (await filter._dataviewPage.getTableRows()).count()).toBe(filter_data.upperCaseFilterNumber);
 		const titles = await filter._dataviewPage.getAllRowData("Title");
 		await filter._dataviewPage.validateContainsKeyword(titles, filter_data.upperCaseKeywordFilter);
-		expect(await filter._dataviewPage.getFilterText(filter.keywordBtn)).toBe(filter_data.upperCaseKeywordFilter);
+		expect(await filter._dataviewPage.getFilterText(filter.keywordBtn)).toBe(`is ${filter_data.upperCaseKeywordFilter}`);
 	});
 
 	test("Filter the title with a Lowercase keyword.", async () => {
@@ -65,7 +65,7 @@ test.describe("Components - Data View - Filter", () => {
 		expect(await (await filter._dataviewPage.getTableRows()).count()).toBe(filter_data.lowerCaseFilterNumber);
 		const titles = await filter._dataviewPage.getAllRowData("Title");
 		await filter._dataviewPage.validateContainsKeyword(titles, filter_data.lowerCaseKeywordFilter);
-		expect(await filter._dataviewPage.getFilterText(filter.keywordBtn)).toBe(filter_data.lowerCaseKeywordFilter);
+		expect(await filter._dataviewPage.getFilterText(filter.keywordBtn)).toBe(`is ${filter_data.lowerCaseKeywordFilter}`);
 		await filter.validateKeywordFilterIsVisible(false);
 	});
 

--- a/containers/mosaic/src/__tests__/components/DataView/DataView.test.tsx
+++ b/containers/mosaic/src/__tests__/components/DataView/DataView.test.tsx
@@ -48,7 +48,7 @@ describe("DataViewFilterText component", () => {
 		);
 		const titleWithComparisonsButton = screen.getByText("Title with Comparisons:");
 		fireEvent.click(titleWithComparisonsButton);
-		const filter = await screen.findByText("Equals");
+		const filter = await screen.findByText("Equals...");
 		expect(filter).toBeTruthy();
 	});
 
@@ -67,7 +67,7 @@ describe("DataViewFilterText component", () => {
 		);
 		const titleWithComparisonsButton = screen.getByText("Title with Comparisons:");
 		fireEvent.click(titleWithComparisonsButton);
-		const filter = await screen.findByText("Not Equal");
+		const filter = await screen.findByText("Not equal to...");
 		expect(filter).toBeTruthy();
 	});
 
@@ -85,7 +85,7 @@ describe("DataViewFilterText component", () => {
 		);
 		const titleWithComparisonsButton = screen.getByText("Title with Comparisons:");
 		fireEvent.click(titleWithComparisonsButton);
-		const filter = await screen.findByText("Equals");
+		const filter = await screen.findByText("Equals...");
 		expect(filter).toBeTruthy();
 	});
 

--- a/containers/mosaic/src/components/DataViewFilterText/DataViewFilterText.tsx
+++ b/containers/mosaic/src/components/DataViewFilterText/DataViewFilterText.tsx
@@ -9,7 +9,7 @@ const validComparisons: { label: string; value: FilterTextComparison }[] = [
 	{ label : "Contains...", value : "contains" },
 	{ label : "Does not contain...", value : "not_contains" },
 	{ label : "Equals...", value : "equals" },
-	{ label : "Does not equal...", value : "not_equals" },
+	{ label : "Not equal to...", value : "not_equals" },
 	{ label : "Exists", value : "exists" },
 	{ label : "Not Exists", value : "not_exists" },
 ];

--- a/containers/mosaic/src/components/DataViewFilterText/DataViewFilterText.tsx
+++ b/containers/mosaic/src/components/DataViewFilterText/DataViewFilterText.tsx
@@ -15,10 +15,10 @@ const validComparisons: { label: string; value: FilterTextComparison }[] = [
 ];
 
 const comparisonMap = {
-	equals : "",
-	not_equals : "!=",
-	contains : "~",
-	not_contains : "!~",
+	equals : "is",
+	not_equals : "is not",
+	contains : "contains",
+	not_contains : "does not contain",
 };
 
 function DataViewFilterText(props: DataViewFilterTextProps) {
@@ -60,9 +60,9 @@ function DataViewFilterText(props: DataViewFilterTextProps) {
 	// based on the state lets figure out what our value should be
 	let valueString: string;
 	if (comparison === "exists") {
-		valueString = "EXISTS";
+		valueString = "exists";
 	} else if (comparison === "not_exists") {
-		valueString = "NOT EXISTS";
+		valueString = "does not exist";
 	} else if (value === "") {
 		valueString = "";
 	} else {

--- a/containers/mosaic/src/components/DataViewFilterText/DataViewFilterText.tsx
+++ b/containers/mosaic/src/components/DataViewFilterText/DataViewFilterText.tsx
@@ -6,10 +6,10 @@ import DataViewFilterDropdown from "../DataViewFilterDropdown";
 import { DataViewFilterTextProps, FilterTextComparison } from "./DataViewFilterTextTypes";
 
 const validComparisons: { label: string; value: FilterTextComparison }[] = [
-	{ label : "Contains", value : "contains" },
-	{ label : "Not Contains", value : "not_contains" },
-	{ label : "Equals", value : "equals" },
-	{ label : "Not Equal", value : "not_equals" },
+	{ label : "Contains...", value : "contains" },
+	{ label : "Does not contain...", value : "not_contains" },
+	{ label : "Equals...", value : "equals" },
+	{ label : "Does not equal...", value : "not_equals" },
 	{ label : "Exists", value : "exists" },
 	{ label : "Not Exists", value : "not_exists" },
 ];


### PR DESCRIPTION
# [MOS-1296](https://simpleviewtools.atlassian.net/browse/MOS-1296)

## Description
- (DataViewTextFilter) Use english verbiage for the comparison description labels instead of technical operators.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1296]: https://simpleviewtools.atlassian.net/browse/MOS-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ