### PR TITLE
MOS-1298

### DIFF
--- a/containers/mosaic/src/components/FieldWrapper/Label.tsx
+++ b/containers/mosaic/src/components/FieldWrapper/Label.tsx
@@ -107,6 +107,7 @@ const Label = (props: LabelProps): ReactElement => {
 				htmlFor={as === "label" && name ? `${name}-input` : undefined}
 				as={as === "label" ? InputLabel : InputLabelDiv}
 				data-testid={name && `${testIds.FORM_FIELD_LABEL}:${name}`}
+				title={typeof children === "string" ? children : undefined}
 			>
 				{children}
 				{required && <StyledRequiredIndicator>*</StyledRequiredIndicator>}


### PR DESCRIPTION
# [MOS-1298](https://simpleviewtools.atlassian.net/browse/MOS-1298)

## Description
- (Form) Adds title attributes to field labels to enable a native tooltip.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes