### PR TITLE
MOS-1302

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldAddress/FormFieldAddress.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAddress/FormFieldAddress.tsx
@@ -77,7 +77,7 @@ const FormFieldAddress = (props: MosaicFieldProps<"address", AddressFieldInputSe
 				return address.types.map(({ value }) => value).includes(type.value);
 			});
 
-			if (valuesOfType.length >= limits[type.value]) {
+			if (limits[type.value] > -1 && valuesOfType.length >= limits[type.value]) {
 				return false;
 			}
 

--- a/containers/sb-8/stories/components/Field/FormFieldAddress/Address.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldAddress/Address.stories.tsx
@@ -17,6 +17,7 @@ const amountOptions = [
 	3,
 	4,
 	5,
+	-1,
 ];
 
 const commonInputSettings = {


### PR DESCRIPTION
# [MOS-1302](https://simpleviewtools.atlassian.net/browse/MOS-1302)

## Description
- (AddressField) Adds support to set no limit on the number of addresses that can be added for each or all types

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1302]: https://simpleviewtools.atlassian.net/browse/MOS-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ