### PR TITLE
MOS-1427

### DIFF
--- a/containers/mosaic/src/__tests__/components/Field/FormFieldAddress/AddressDrawer.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldAddress/AddressDrawer.test.tsx
@@ -157,7 +157,7 @@ describe("Address drawer country postcode validation", () => {
 			fireEvent.blur(postcodeInput);
 		});
 
-		expect(screen.queryByText("This is not a valid postcode in the selected country")).toBeNull();
+		expect(screen.queryByText("This is not a valid postal code in the selected country")).toBeNull();
 	});
 
 	it("should not produce an error if a postcode is entered when an unsupported country is selected", async () => {
@@ -184,7 +184,7 @@ describe("Address drawer country postcode validation", () => {
 			fireEvent.blur(postcodeInput);
 		});
 
-		expect(screen.queryByText("This is not a valid postcode in the selected country")).toBeNull();
+		expect(screen.queryByText("This is not a valid postal code in the selected country")).toBeNull();
 	});
 
 	it("should produce an error if an invalid postcode is entered for the selected country", async () => {
@@ -216,6 +216,6 @@ describe("Address drawer country postcode validation", () => {
 			fireEvent.blur(postcodeInput);
 		});
 
-		expect(screen.queryByText("This is not a valid postcode in the selected country")).not.toBeNull();
+		expect(screen.queryByText("This is not a valid postal code in the selected country")).not.toBeNull();
 	});
 });

--- a/containers/mosaic/src/components/Form/validators.ts
+++ b/containers/mosaic/src/components/Form/validators.ts
@@ -258,7 +258,7 @@ export async function validatePostcode(value: string, data: any, { countryField 
 	}
 
 	if (!postcodeValidator(value, country)) {
-		return "This is not a valid postcode in the selected country";
+		return "This is not a valid postal code in the selected country";
 	}
 
 	return;


### PR DESCRIPTION
# [MOS-1427](https://simpleviewtools.atlassian.net/browse/MOS-1427)

## Description
- (AddressField) Updates the message given when an invalid postcode is provided to better reflect the label of the field.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1427]: https://simpleviewtools.atlassian.net/browse/MOS-1427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ