### PR TITLE
MOS-1314

### DIFF
--- a/containers/mosaic/src/components/DataView/DataViewPagerPopover/DataViewPagerPopover.tsx
+++ b/containers/mosaic/src/components/DataView/DataViewPagerPopover/DataViewPagerPopover.tsx
@@ -74,6 +74,7 @@ function DataViewPagerPopover(props: DataViewPagerPopoverProps) {
 			/>
 			<span>
 				of
+				{" "}
 				{props.totalPages}
 			</span>
 			<Button


### PR DESCRIPTION
# [MOS-1314](https://simpleviewtools.atlassian.net/browse/MOS-1314)

## Description
- (DataView) Forces a space between "of" keyword and number of pages in pager popover.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1314]: https://simpleviewtools.atlassian.net/browse/MOS-1314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ