### PR TITLE
MOS-1309

### DIFF
--- a/containers/mosaic/src/components/DataView/example/rawData.json
+++ b/containers/mosaic/src/components/DataView/example/rawData.json
@@ -30,7 +30,7 @@
 				"bytes": 14013844,
 				"type": "upload",
 				"etag": "065cd5aa9da1b184c55d2bc6e692ccd4",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434723041/clients/grandrapids/CVB-Runners-Beach-852_2bbfa8b9-d45a-4590-8571-b6f06d39f9b9.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434723041/clients/grandrapids/CVB-Runners-Beach-852_2bbfa8b9-d45a-4590-8571-b6f06d39f9b9.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434723041/clients/grandrapids/CVB-Runners-Beach-852_2bbfa8b9-d45a-4590-8571-b6f06d39f9b9.jpg",
 				"original_filename": "file"
 			},
@@ -94,7 +94,7 @@
 				"bytes": 1235051,
 				"type": "upload",
 				"etag": "ac4ffd6b0ec708452d9b3e8983c8c2d0",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434925582/clients/grandrapids/John%20Ball%20Zoo%2020_70aa697e-f0a8-4741-8497-9b2baad425b0.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434925582/clients/grandrapids/John%20Ball%20Zoo%2020_70aa697e-f0a8-4741-8497-9b2baad425b0.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434925582/clients/grandrapids/John%20Ball%20Zoo%2020_70aa697e-f0a8-4741-8497-9b2baad425b0.jpg",
 				"original_filename": "file"
 			},
@@ -158,7 +158,7 @@
 				"bytes": 1369697,
 				"type": "upload",
 				"etag": "d6e93330195f946df31caaa6b028045d",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434724538/clients/grandrapids/Calder%20Stage_4f447391-b5ec-4fb1-98f9-97cc86ea010e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434724538/clients/grandrapids/Calder%20Stage_4f447391-b5ec-4fb1-98f9-97cc86ea010e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434724538/clients/grandrapids/Calder%20Stage_4f447391-b5ec-4fb1-98f9-97cc86ea010e.jpg",
 				"original_filename": "file"
 			},
@@ -227,7 +227,7 @@
 				"type": "upload",
 				"etag": "f44b13ce05dd5eb36e670e87a90dc497",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1539006875/clients/grandrapids/042_3_8964_jpeg_d980ecbf-0dfb-48d0-97cb-3ef4f03d3f5c.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1539006875/clients/grandrapids/042_3_8964_jpeg_d980ecbf-0dfb-48d0-97cb-3ef4f03d3f5c.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1539006875/clients/grandrapids/042_3_8964_jpeg_d980ecbf-0dfb-48d0-97cb-3ef4f03d3f5c.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -343,7 +343,7 @@
 				"bytes": 6140518,
 				"type": "upload",
 				"etag": "468c6e0af24095378e9b09236ba76617",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434724347/clients/grandrapids/RN1_1987_ceb2916c-8258-4b30-bcbe-d2527f35f170.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434724347/clients/grandrapids/RN1_1987_ceb2916c-8258-4b30-bcbe-d2527f35f170.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434724347/clients/grandrapids/RN1_1987_ceb2916c-8258-4b30-bcbe-d2527f35f170.jpg",
 				"original_filename": "file"
 			},
@@ -416,7 +416,7 @@
 				"bytes": 5960751,
 				"type": "upload",
 				"etag": "ffec260205dec9f8b9873876081a1460",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434726973/clients/grandrapids/GRAM_05f44299-99aa-478c-9325-ec0302767c62.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434726973/clients/grandrapids/GRAM_05f44299-99aa-478c-9325-ec0302767c62.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434726973/clients/grandrapids/GRAM_05f44299-99aa-478c-9325-ec0302767c62.jpg",
 				"original_filename": "file"
 			},
@@ -493,7 +493,7 @@
 				"type": "upload",
 				"etag": "c779671d249d038099803ddb00bcc588",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1540561411/clients/grandrapids/IMG_2247_45a80aaf-b103-415c-a261-bb244a3cb741.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1540561411/clients/grandrapids/IMG_2247_45a80aaf-b103-415c-a261-bb244a3cb741.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1540561411/clients/grandrapids/IMG_2247_45a80aaf-b103-415c-a261-bb244a3cb741.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -592,7 +592,7 @@
 				"bytes": 1710144,
 				"type": "upload",
 				"etag": "027304f47789ebca8bcfded13d4c1630",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435178584/clients/grandrapids/ArtPrize2010-Vision_5e368f38-0cb3-4dee-a7aa-5ead20fb8b8c.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435178584/clients/grandrapids/ArtPrize2010-Vision_5e368f38-0cb3-4dee-a7aa-5ead20fb8b8c.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435178584/clients/grandrapids/ArtPrize2010-Vision_5e368f38-0cb3-4dee-a7aa-5ead20fb8b8c.jpg",
 				"original_filename": "file"
 			},
@@ -653,7 +653,7 @@
 				"bytes": 1540068,
 				"type": "upload",
 				"etag": "492280b7848d4c7170f7ade717c93797",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435247801/clients/grandrapids/Aerial%20of%20Grand%20Rapids_e617e364-0615-43c6-8344-700c91b2ce6f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435247801/clients/grandrapids/Aerial%20of%20Grand%20Rapids_e617e364-0615-43c6-8344-700c91b2ce6f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435247801/clients/grandrapids/Aerial%20of%20Grand%20Rapids_e617e364-0615-43c6-8344-700c91b2ce6f.jpg",
 				"original_filename": "file"
 			},
@@ -718,7 +718,7 @@
 				"bytes": 1417823,
 				"type": "upload",
 				"etag": "caa06010be7b9715028dea123d0bfb56",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435075122/clients/grandrapids/windmill_island_0007_3b82a84a-8ae2-4950-a1bc-d5a905075c85.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435075122/clients/grandrapids/windmill_island_0007_3b82a84a-8ae2-4950-a1bc-d5a905075c85.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435075122/clients/grandrapids/windmill_island_0007_3b82a84a-8ae2-4950-a1bc-d5a905075c85.jpg",
 				"original_filename": "file"
 			},
@@ -783,7 +783,7 @@
 				"type": "upload",
 				"etag": "58087b14b0f7e3defacedfefb99de621",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565894381/clients/grandrapids/042_3_9267_jpeg_d6cafd08-73bf-4cff-8c5b-fce2c3051835.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565894381/clients/grandrapids/042_3_9267_jpeg_d6cafd08-73bf-4cff-8c5b-fce2c3051835.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565894381/clients/grandrapids/042_3_9267_jpeg_d6cafd08-73bf-4cff-8c5b-fce2c3051835.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -909,7 +909,7 @@
 				"bytes": 2043817,
 				"type": "upload",
 				"etag": "0fda6c9856241ecd1a60589a341bc813",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435689432/clients/grandrapids/Motorcoach%2C%20Lubbers%20Family%20Farm%20Group%20Tour_1e8a5b67-c6ff-4cdb-8c48-a3536fe0e8d0.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435689432/clients/grandrapids/Motorcoach%2C%20Lubbers%20Family%20Farm%20Group%20Tour_1e8a5b67-c6ff-4cdb-8c48-a3536fe0e8d0.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435689432/clients/grandrapids/Motorcoach%2C%20Lubbers%20Family%20Farm%20Group%20Tour_1e8a5b67-c6ff-4cdb-8c48-a3536fe0e8d0.jpg",
 				"original_filename": "file"
 			},
@@ -971,7 +971,7 @@
 				"bytes": 11937622,
 				"type": "upload",
 				"etag": "590e94f8afb11d8910f7ac200217ac95",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434659252/clients/grandrapids/Roses%203376_45fd986c-d409-42ea-b7a4-3d0f9dcdec1d.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434659252/clients/grandrapids/Roses%203376_45fd986c-d409-42ea-b7a4-3d0f9dcdec1d.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434659252/clients/grandrapids/Roses%203376_45fd986c-d409-42ea-b7a4-3d0f9dcdec1d.jpg",
 				"original_filename": "file"
 			},
@@ -1030,7 +1030,7 @@
 				"bytes": 1627828,
 				"type": "upload",
 				"etag": "544987843c5b52be5d429bf1401dbb15",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434931248/clients/grandrapids/Runner%20in%20Grand%20Rapids%201_83601441-26e2-4e31-b536-d409ff1e7617.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434931248/clients/grandrapids/Runner%20in%20Grand%20Rapids%201_83601441-26e2-4e31-b536-d409ff1e7617.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434931248/clients/grandrapids/Runner%20in%20Grand%20Rapids%201_83601441-26e2-4e31-b536-d409ff1e7617.jpg",
 				"original_filename": "file"
 			},
@@ -1100,7 +1100,7 @@
 				"bytes": 17313993,
 				"type": "upload",
 				"etag": "884848cf5c63bfa161b370b57dceb786",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434724739/clients/grandrapids/Ex%20Grand%20Rapids_Founders8670_ac26e944-36fb-47e1-946b-ce1f7380820a.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434724739/clients/grandrapids/Ex%20Grand%20Rapids_Founders8670_ac26e944-36fb-47e1-946b-ce1f7380820a.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434724739/clients/grandrapids/Ex%20Grand%20Rapids_Founders8670_ac26e944-36fb-47e1-946b-ce1f7380820a.jpg",
 				"original_filename": "file"
 			},
@@ -1169,7 +1169,7 @@
 				"bytes": 2195759,
 				"type": "upload",
 				"etag": "17820276616850351770b52c9149dda9",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435609202/clients/grandrapids/Downtown%20Market_23e5d557-3791-4ea7-a46e-c8d35956c75a.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435609202/clients/grandrapids/Downtown%20Market_23e5d557-3791-4ea7-a46e-c8d35956c75a.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435609202/clients/grandrapids/Downtown%20Market_23e5d557-3791-4ea7-a46e-c8d35956c75a.jpg",
 				"original_filename": "file"
 			},
@@ -1232,7 +1232,7 @@
 				"bytes": 2851850,
 				"type": "upload",
 				"etag": "2661164abef3f0d70169f75e33eda80f",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435611585/clients/grandrapids/Main%20from%20Park_d0239bfa-74fe-4a74-9312-65ac068f953d.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435611585/clients/grandrapids/Main%20from%20Park_d0239bfa-74fe-4a74-9312-65ac068f953d.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435611585/clients/grandrapids/Main%20from%20Park_d0239bfa-74fe-4a74-9312-65ac068f953d.jpg",
 				"original_filename": "file"
 			},
@@ -1300,7 +1300,7 @@
 				"bytes": 1496662,
 				"type": "upload",
 				"etag": "c72680ddec4aba7b7f68482bd872e21c",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434931532/clients/grandrapids/Kayak%20Riverside%20Park%202_5e260b24-bf36-495f-b9d5-b60a450bc0dc.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434931532/clients/grandrapids/Kayak%20Riverside%20Park%202_5e260b24-bf36-495f-b9d5-b60a450bc0dc.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434931532/clients/grandrapids/Kayak%20Riverside%20Park%202_5e260b24-bf36-495f-b9d5-b60a450bc0dc.jpg",
 				"original_filename": "file"
 			},
@@ -1368,7 +1368,7 @@
 				"bytes": 1219542,
 				"type": "upload",
 				"etag": "23637e6560c8f98d8a450355c845dfcf",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435177762/clients/grandrapids/Night%20Dancing%20at%20Rosa%20Parks%20Circle-%20SWalker_6409065a-2636-42e2-b6cb-a953a9b24017.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435177762/clients/grandrapids/Night%20Dancing%20at%20Rosa%20Parks%20Circle-%20SWalker_6409065a-2636-42e2-b6cb-a953a9b24017.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435177762/clients/grandrapids/Night%20Dancing%20at%20Rosa%20Parks%20Circle-%20SWalker_6409065a-2636-42e2-b6cb-a953a9b24017.jpg",
 				"original_filename": "file"
 			},
@@ -1434,7 +1434,7 @@
 				"bytes": 1348694,
 				"type": "upload",
 				"etag": "54222e591c4e8b183b2b5dbe11376f4b",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435072399/clients/grandrapids/Frederik%20Meijer%20Gardens%2038_9e3d111d-e721-4957-b624-b02b521f583a.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435072399/clients/grandrapids/Frederik%20Meijer%20Gardens%2038_9e3d111d-e721-4957-b624-b02b521f583a.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435072399/clients/grandrapids/Frederik%20Meijer%20Gardens%2038_9e3d111d-e721-4957-b624-b02b521f583a.jpg",
 				"original_filename": "file"
 			},
@@ -1494,7 +1494,7 @@
 				"bytes": 1510306,
 				"type": "upload",
 				"etag": "dd9ade0d24b5977532add50b37eaf3c2",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435610101/clients/grandrapids/FMG%20-%20Winter%20carriage_ec40aab8-a3c2-434d-9e00-7d186ae6c422.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435610101/clients/grandrapids/FMG%20-%20Winter%20carriage_ec40aab8-a3c2-434d-9e00-7d186ae6c422.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435610101/clients/grandrapids/FMG%20-%20Winter%20carriage_ec40aab8-a3c2-434d-9e00-7d186ae6c422.jpg",
 				"original_filename": "file"
 			},
@@ -1557,7 +1557,7 @@
 				"bytes": 1053356,
 				"type": "upload",
 				"etag": "b7c9b6288b82c465d1eb5330477192da",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435688886/clients/grandrapids/Burger_f49c37e1-5241-42a5-a342-c3effd7d96f9.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435688886/clients/grandrapids/Burger_f49c37e1-5241-42a5-a342-c3effd7d96f9.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435688886/clients/grandrapids/Burger_f49c37e1-5241-42a5-a342-c3effd7d96f9.jpg",
 				"original_filename": "file"
 			},
@@ -1619,7 +1619,7 @@
 				"type": "upload",
 				"etag": "3b30e846254a2fd48955c323eb0b5606",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565892057/clients/grandrapids/042_3_9276_jpeg_7dd50718-e627-46d5-a9ba-a812ac92e394.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565892057/clients/grandrapids/042_3_9276_jpeg_7dd50718-e627-46d5-a9ba-a812ac92e394.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565892057/clients/grandrapids/042_3_9276_jpeg_7dd50718-e627-46d5-a9ba-a812ac92e394.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -1734,7 +1734,7 @@
 				"bytes": 295279,
 				"type": "upload",
 				"etag": "067a6ecaf4355b458ff687634aeba40c",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434936513/clients/grandrapids/JW%20Marriott%2023_529a065b-b323-4ba5-889a-d27a4c622329.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434936513/clients/grandrapids/JW%20Marriott%2023_529a065b-b323-4ba5-889a-d27a4c622329.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434936513/clients/grandrapids/JW%20Marriott%2023_529a065b-b323-4ba5-889a-d27a4c622329.jpg",
 				"original_filename": "file"
 			},
@@ -1804,7 +1804,7 @@
 				"type": "upload",
 				"etag": "7acdbb3823724f58e6979c015a049d47",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1545834582/clients/grandrapids/042_3_8928_jpeg_0ad788cb-ac32-4395-a94b-c0af281f9645.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1545834582/clients/grandrapids/042_3_8928_jpeg_0ad788cb-ac32-4395-a94b-c0af281f9645.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1545834582/clients/grandrapids/042_3_8928_jpeg_0ad788cb-ac32-4395-a94b-c0af281f9645.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -1898,7 +1898,7 @@
 				"bytes": 196772,
 				"type": "upload",
 				"etag": "406241475222ef433643d8a6f38f5f9b",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1430954210/clients/grandrapids/hero-1_70377f55-24ae-48f7-8410-4be33587b3f2.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1430954210/clients/grandrapids/hero-1_70377f55-24ae-48f7-8410-4be33587b3f2.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1430954210/clients/grandrapids/hero-1_70377f55-24ae-48f7-8410-4be33587b3f2.jpg"
 			},
 			"categories_ids": [
@@ -1963,7 +1963,7 @@
 				"bytes": 606317,
 				"type": "upload",
 				"etag": "14f6427f83cc81429f2c727ad8949b27",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434927713/clients/grandrapids/Fishing%205_4f58e85c-007d-4919-82ae-4f331816a099.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434927713/clients/grandrapids/Fishing%205_4f58e85c-007d-4919-82ae-4f331816a099.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434927713/clients/grandrapids/Fishing%205_4f58e85c-007d-4919-82ae-4f331816a099.jpg",
 				"original_filename": "file"
 			},
@@ -2027,7 +2027,7 @@
 				"bytes": 2061191,
 				"type": "upload",
 				"etag": "56086211b28d08503d5981b7762084f3",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434886665/clients/grandrapids/Golf%2010_7f59d2ff-4c6b-4098-aeb5-0542c3b74667.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434886665/clients/grandrapids/Golf%2010_7f59d2ff-4c6b-4098-aeb5-0542c3b74667.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434886665/clients/grandrapids/Golf%2010_7f59d2ff-4c6b-4098-aeb5-0542c3b74667.jpg",
 				"original_filename": "file"
 			},
@@ -2087,7 +2087,7 @@
 				"bytes": 26268,
 				"type": "upload",
 				"etag": "acece82d5c8c88338f964a46432e79e2",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435168197/clients/grandrapids/Art-Museum_de3a3693-1f93-4ea2-b7e6-6528adcd56b8.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435168197/clients/grandrapids/Art-Museum_de3a3693-1f93-4ea2-b7e6-6528adcd56b8.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435168197/clients/grandrapids/Art-Museum_de3a3693-1f93-4ea2-b7e6-6528adcd56b8.jpg",
 				"original_filename": "file"
 			},
@@ -2143,7 +2143,7 @@
 				"bytes": 3029857,
 				"type": "upload",
 				"etag": "59054792fa110dcfa242e5cd9fc95390",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436498159/clients/grandrapids/ArtPrize2012-LightsNight_b9ec0f51-861e-4c3f-9093-1ed39885be57.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436498159/clients/grandrapids/ArtPrize2012-LightsNight_b9ec0f51-861e-4c3f-9093-1ed39885be57.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436498159/clients/grandrapids/ArtPrize2012-LightsNight_b9ec0f51-861e-4c3f-9093-1ed39885be57.jpg",
 				"exif": {
 					"ApertureValue": "4/1",
@@ -2244,7 +2244,7 @@
 				"bytes": 2029989,
 				"type": "upload",
 				"etag": "fcd6c620925ed3816d19411a1fcb33ec",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434927325/clients/grandrapids/West%20Michigan%20Baseball%201-1_64e1f179-9cf0-4106-a56e-a7b97c4c5cf5.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434927325/clients/grandrapids/West%20Michigan%20Baseball%201-1_64e1f179-9cf0-4106-a56e-a7b97c4c5cf5.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434927325/clients/grandrapids/West%20Michigan%20Baseball%201-1_64e1f179-9cf0-4106-a56e-a7b97c4c5cf5.jpg",
 				"original_filename": "file"
 			},
@@ -2312,7 +2312,7 @@
 				"type": "upload",
 				"etag": "1455087c594a1d0992f927abcfa71b7b",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1523969592/clients/grandrapids/042_3_8871_jpeg_fbbf1f00-5af8-416f-a540-828ad92890eb.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1523969592/clients/grandrapids/042_3_8871_jpeg_fbbf1f00-5af8-416f-a540-828ad92890eb.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1523969592/clients/grandrapids/042_3_8871_jpeg_fbbf1f00-5af8-416f-a540-828ad92890eb.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -2416,7 +2416,7 @@
 				"bytes": 1906542,
 				"type": "upload",
 				"etag": "e9da118e1374d6c671ea16498cf9b5d2",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434939603/clients/grandrapids/Michigan%27s%20Adventure%201_344fbbbe-44b2-412a-babf-883d84d12c50.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434939603/clients/grandrapids/Michigan%27s%20Adventure%201_344fbbbe-44b2-412a-babf-883d84d12c50.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434939603/clients/grandrapids/Michigan%27s%20Adventure%201_344fbbbe-44b2-412a-babf-883d84d12c50.jpg",
 				"original_filename": "file"
 			},
@@ -2483,7 +2483,7 @@
 				"bytes": 1088709,
 				"type": "upload",
 				"etag": "3ccd30098dbfbeb65f1b72a46008d61f",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435081745/clients/grandrapids/Sunset%20at%20Pier%20Muskegon%202_77c0f296-7465-4a73-9164-fbb4e27c1795.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435081745/clients/grandrapids/Sunset%20at%20Pier%20Muskegon%202_77c0f296-7465-4a73-9164-fbb4e27c1795.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435081745/clients/grandrapids/Sunset%20at%20Pier%20Muskegon%202_77c0f296-7465-4a73-9164-fbb4e27c1795.jpg",
 				"original_filename": "file"
 			},
@@ -2555,7 +2555,7 @@
 				"type": "upload",
 				"etag": "1ca3ba8d6bcfd3a612acf174d9b3c511",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565921936/clients/grandrapids/042_3_9298_jpeg_47bce4d8-30ae-44fb-ae99-a602b4d392b7.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565921936/clients/grandrapids/042_3_9298_jpeg_47bce4d8-30ae-44fb-ae99-a602b4d392b7.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565921936/clients/grandrapids/042_3_9298_jpeg_47bce4d8-30ae-44fb-ae99-a602b4d392b7.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -2685,7 +2685,7 @@
 				"type": "upload",
 				"etag": "7c38c55bd8fd724757b7fb0df6edea21",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565897393/clients/grandrapids/042_3_9265_jpeg_4ae65ff5-c289-4eed-beea-c2b7578f12bb.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565897393/clients/grandrapids/042_3_9265_jpeg_4ae65ff5-c289-4eed-beea-c2b7578f12bb.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565897393/clients/grandrapids/042_3_9265_jpeg_4ae65ff5-c289-4eed-beea-c2b7578f12bb.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -2813,7 +2813,7 @@
 				"bytes": 361328,
 				"type": "upload",
 				"etag": "2a466a4c3d0e9d3a1f68fd8a059332b9",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434038011/clients/grandrapids/blog_9b595af0-d35f-4d92-a72c-50111b007649.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434038011/clients/grandrapids/blog_9b595af0-d35f-4d92-a72c-50111b007649.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434038011/clients/grandrapids/blog_9b595af0-d35f-4d92-a72c-50111b007649.jpg",
 				"original_filename": "file"
 			},
@@ -2879,7 +2879,7 @@
 				"type": "upload",
 				"etag": "213e7a5d29a5e000dbdf8ece088c505b",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1546026003/clients/grandrapids/042_3_9008_jpeg_65bae54d-3ecd-4454-95f9-90a4cf712a77.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1546026003/clients/grandrapids/042_3_9008_jpeg_65bae54d-3ecd-4454-95f9-90a4cf712a77.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1546026003/clients/grandrapids/042_3_9008_jpeg_65bae54d-3ecd-4454-95f9-90a4cf712a77.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -2996,7 +2996,7 @@
 				"bytes": 1551852,
 				"type": "upload",
 				"etag": "0da1a43e8e20377ed5c62c1a2165e10a",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434936251/clients/grandrapids/Fenn%20Valley%20Winery%203_33729538-3823-41cd-8859-d52f9317ecff.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434936251/clients/grandrapids/Fenn%20Valley%20Winery%203_33729538-3823-41cd-8859-d52f9317ecff.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434936251/clients/grandrapids/Fenn%20Valley%20Winery%203_33729538-3823-41cd-8859-d52f9317ecff.jpg",
 				"original_filename": "file"
 			},
@@ -3062,7 +3062,7 @@
 				"bytes": 142528,
 				"type": "upload",
 				"etag": "470a1e85352b6dc03ff9246e6b19d141",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434746901/clients/grandrapids/ford-museum_65c6d694-466b-451c-9d45-c7b84f9967ac.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434746901/clients/grandrapids/ford-museum_65c6d694-466b-451c-9d45-c7b84f9967ac.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434746901/clients/grandrapids/ford-museum_65c6d694-466b-451c-9d45-c7b84f9967ac.jpg",
 				"original_filename": "file"
 			},
@@ -3117,7 +3117,7 @@
 				"bytes": 1084068,
 				"type": "upload",
 				"etag": "539c99ba63e034ed261f94d766ebc3d3",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435073690/clients/grandrapids/Downtown%20Market%206_c340dfb7-b47b-403e-9780-df500600ac2a.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435073690/clients/grandrapids/Downtown%20Market%206_c340dfb7-b47b-403e-9780-df500600ac2a.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435073690/clients/grandrapids/Downtown%20Market%206_c340dfb7-b47b-403e-9780-df500600ac2a.jpg",
 				"original_filename": "file"
 			},
@@ -3178,7 +3178,7 @@
 				"bytes": 5290543,
 				"type": "upload",
 				"etag": "cc9c88e918f18bb2ec2057f64d4085c7",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1485887727/clients/grandrapids/BKP_Accidentals_Frame_Grabs_5_0db6e62e-f2b7-4aa7-99b0-f798aa95dc11.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1485887727/clients/grandrapids/BKP_Accidentals_Frame_Grabs_5_0db6e62e-f2b7-4aa7-99b0-f798aa95dc11.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1485887727/clients/grandrapids/BKP_Accidentals_Frame_Grabs_5_0db6e62e-f2b7-4aa7-99b0-f798aa95dc11.jpg",
 				"exif": {
 					"Artist": "Brian Kelly",
@@ -3279,7 +3279,7 @@
 				"type": "upload",
 				"etag": "3ca442c59170af929ddd43450ee791b9",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1527257392/clients/grandrapids/IMG_6028_1__35170b82-7ac1-43e2-9b5c-1cbdf5a887e6.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1527257392/clients/grandrapids/IMG_6028_1__35170b82-7ac1-43e2-9b5c-1cbdf5a887e6.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1527257392/clients/grandrapids/IMG_6028_1__35170b82-7ac1-43e2-9b5c-1cbdf5a887e6.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -3372,7 +3372,7 @@
 				"bytes": 12806923,
 				"type": "upload",
 				"etag": "8bb04232b4c52494eb482fa1d24a8edd",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1433954130/clients/grandrapids/East%20Grand%20Rapids_68f13491-4fa9-4e71-813a-48977407532a.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1433954130/clients/grandrapids/East%20Grand%20Rapids_68f13491-4fa9-4e71-813a-48977407532a.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1433954130/clients/grandrapids/East%20Grand%20Rapids_68f13491-4fa9-4e71-813a-48977407532a.jpg",
 				"original_filename": "file"
 			},
@@ -3430,7 +3430,7 @@
 				"type": "upload",
 				"etag": "c6245c71ca3f702fc00c2999d5e08574",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1528228428/clients/grandrapids/ExperienceGR_2017_0865_hi_5638593a-0a9c-40d8-8d05-a696911adc5e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1528228428/clients/grandrapids/ExperienceGR_2017_0865_hi_5638593a-0a9c-40d8-8d05-a696911adc5e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1528228428/clients/grandrapids/ExperienceGR_2017_0865_hi_5638593a-0a9c-40d8-8d05-a696911adc5e.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -3526,7 +3526,7 @@
 				"bytes": 2379713,
 				"type": "upload",
 				"etag": "b2a1f42b999271f6f8d8dfadcece3a05",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435072871/clients/grandrapids/Zoo%20Ropes_f79a1945-b9e6-4b0e-a3a7-abd18fb24d92.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435072871/clients/grandrapids/Zoo%20Ropes_f79a1945-b9e6-4b0e-a3a7-abd18fb24d92.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435072871/clients/grandrapids/Zoo%20Ropes_f79a1945-b9e6-4b0e-a3a7-abd18fb24d92.jpg",
 				"original_filename": "file"
 			},
@@ -3592,7 +3592,7 @@
 				"bytes": 1417823,
 				"type": "upload",
 				"etag": "caa06010be7b9715028dea123d0bfb56",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435075122/clients/grandrapids/windmill_island_0007_3b82a84a-8ae2-4950-a1bc-d5a905075c85.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435075122/clients/grandrapids/windmill_island_0007_3b82a84a-8ae2-4950-a1bc-d5a905075c85.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435075122/clients/grandrapids/windmill_island_0007_3b82a84a-8ae2-4950-a1bc-d5a905075c85.jpg",
 				"original_filename": "file"
 			},
@@ -3657,7 +3657,7 @@
 				"bytes": 10252327,
 				"type": "upload",
 				"etag": "55102071ede1b30a01bdbe87b76a6b0d",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435332898/clients/grandrapids/beer%20with%20menu_1f4542c5-4cb6-4a38-8915-f94416a5cc4f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435332898/clients/grandrapids/beer%20with%20menu_1f4542c5-4cb6-4a38-8915-f94416a5cc4f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435332898/clients/grandrapids/beer%20with%20menu_1f4542c5-4cb6-4a38-8915-f94416a5cc4f.jpg",
 				"original_filename": "file"
 			},
@@ -3725,7 +3725,7 @@
 				"type": "upload",
 				"etag": "34fc082dbffda3f2d8f27f14ad278f92",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565921847/clients/grandrapids/042_3_9335_jpeg_08fe83bb-965d-415a-a960-057c1870fb95.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565921847/clients/grandrapids/042_3_9335_jpeg_08fe83bb-965d-415a-a960-057c1870fb95.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565921847/clients/grandrapids/042_3_9335_jpeg_08fe83bb-965d-415a-a960-057c1870fb95.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -3854,7 +3854,7 @@
 				"bytes": 1955722,
 				"type": "upload",
 				"etag": "d51ad873c2609dc63e3a1122c32728a5",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1433954183/clients/grandrapids/Heartside_579f7893-f200-41b4-9a64-18071b7a18ac.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1433954183/clients/grandrapids/Heartside_579f7893-f200-41b4-9a64-18071b7a18ac.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1433954183/clients/grandrapids/Heartside_579f7893-f200-41b4-9a64-18071b7a18ac.jpg",
 				"original_filename": "file"
 			},
@@ -3907,7 +3907,7 @@
 				"bytes": 22988614,
 				"type": "upload",
 				"etag": "110c69c666d8a18a9bd4a59b9736eb45",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1433954530/clients/grandrapids/Southtown_c2680d7c-ec98-492f-81fc-b46f3736511f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1433954530/clients/grandrapids/Southtown_c2680d7c-ec98-492f-81fc-b46f3736511f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1433954530/clients/grandrapids/Southtown_c2680d7c-ec98-492f-81fc-b46f3736511f.jpg",
 				"original_filename": "file"
 			},
@@ -3970,7 +3970,7 @@
 				"type": "upload",
 				"etag": "806d0bd9ddcaf9c233d8263bed87e495",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1554904500/clients/grandrapids/042_3_9004_jpeg_44588efe-8a06-44fc-bbee-189af0ba4ba0.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1554904500/clients/grandrapids/042_3_9004_jpeg_44588efe-8a06-44fc-bbee-189af0ba4ba0.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1554904500/clients/grandrapids/042_3_9004_jpeg_44588efe-8a06-44fc-bbee-189af0ba4ba0.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -4051,7 +4051,7 @@
 				"bytes": 36103553,
 				"type": "upload",
 				"etag": "50029cd6072b1ff22c7b7faccf67960b",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1499973794/clients/grandrapids/06152016_ExGR_Wagner3542_92b39178-81b4-4af8-b607-9e8cdbb93929.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1499973794/clients/grandrapids/06152016_ExGR_Wagner3542_92b39178-81b4-4af8-b607-9e8cdbb93929.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1499973794/clients/grandrapids/06152016_ExGR_Wagner3542_92b39178-81b4-4af8-b607-9e8cdbb93929.jpg",
 				"exif": {
 					"BitsPerSample": "8, 8, 8",
@@ -4130,7 +4130,7 @@
 				"bytes": 23718749,
 				"type": "upload",
 				"etag": "38bf1490b7c741f3f755e0f5d8714636",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1433954378/clients/grandrapids/Medical%20Mile_b268cff6-22d2-4331-a566-aecf39ab0d7d.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1433954378/clients/grandrapids/Medical%20Mile_b268cff6-22d2-4331-a566-aecf39ab0d7d.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1433954378/clients/grandrapids/Medical%20Mile_b268cff6-22d2-4331-a566-aecf39ab0d7d.jpg",
 				"original_filename": "file"
 			},
@@ -4192,7 +4192,7 @@
 				"bytes": 1731640,
 				"type": "upload",
 				"etag": "0d07fe046ddb19f6dda8177ed58458aa",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435080958/clients/grandrapids/Grand%20Haven%20Lighthouse-%20SWalker_3ab0d46a-959b-427d-924d-653f848b7b8b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435080958/clients/grandrapids/Grand%20Haven%20Lighthouse-%20SWalker_3ab0d46a-959b-427d-924d-653f848b7b8b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435080958/clients/grandrapids/Grand%20Haven%20Lighthouse-%20SWalker_3ab0d46a-959b-427d-924d-653f848b7b8b.jpg",
 				"original_filename": "file"
 			},
@@ -4256,7 +4256,7 @@
 				"type": "upload",
 				"etag": "a576ba1b2334f88722a4a70c06dc0533",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565900215/clients/grandrapids/042_3_9313_jpeg_9de961dc-1ef8-4769-917a-1df2db2737b1.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565900215/clients/grandrapids/042_3_9313_jpeg_9de961dc-1ef8-4769-917a-1df2db2737b1.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565900215/clients/grandrapids/042_3_9313_jpeg_9de961dc-1ef8-4769-917a-1df2db2737b1.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -4384,7 +4384,7 @@
 				"bytes": 9250178,
 				"type": "upload",
 				"etag": "2239adc7c363520142f1a3acac07c81c",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1433953988/clients/grandrapids/Downtown_eb44cd0a-0944-441a-a1a7-0db8de2da12d.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1433953988/clients/grandrapids/Downtown_eb44cd0a-0944-441a-a1a7-0db8de2da12d.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1433953988/clients/grandrapids/Downtown_eb44cd0a-0944-441a-a1a7-0db8de2da12d.jpg",
 				"original_filename": "file"
 			},
@@ -4448,7 +4448,7 @@
 				"bytes": 2631876,
 				"type": "upload",
 				"etag": "e6b62b6054ac3c3a5fc4471c028e3418",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
 				"original_filename": "file"
 			},
@@ -4516,7 +4516,7 @@
 				"bytes": 1261504,
 				"type": "upload",
 				"etag": "0c9b867b98d72174f13fb85a87420697",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435074408/clients/grandrapids/CVBChildMuseum_2_95664f73-2141-4c6a-9c60-f6a75c8baccb.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435074408/clients/grandrapids/CVBChildMuseum_2_95664f73-2141-4c6a-9c60-f6a75c8baccb.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435074408/clients/grandrapids/CVBChildMuseum_2_95664f73-2141-4c6a-9c60-f6a75c8baccb.jpg",
 				"original_filename": "file"
 			},
@@ -4588,7 +4588,7 @@
 				"type": "upload",
 				"etag": "9c8920f86605465361f16a1c1d80fe2c",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1525706786/clients/grandrapids/IMG_4156_7a1894a8-6c36-43fa-87c2-f9593a9ccef2.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1525706786/clients/grandrapids/IMG_4156_7a1894a8-6c36-43fa-87c2-f9593a9ccef2.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1525706786/clients/grandrapids/IMG_4156_7a1894a8-6c36-43fa-87c2-f9593a9ccef2.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -4686,7 +4686,7 @@
 				"type": "upload",
 				"etag": "e9f673f882bbe600d3954ceb72a87d97",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1539006664/clients/grandrapids/042_3_8974_jpeg_d96aa30e-3ca4-48df-8356-718c1f015603.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1539006664/clients/grandrapids/042_3_8974_jpeg_d96aa30e-3ca4-48df-8356-718c1f015603.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1539006664/clients/grandrapids/042_3_8974_jpeg_d96aa30e-3ca4-48df-8356-718c1f015603.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -4810,7 +4810,7 @@
 				"type": "upload",
 				"etag": "39aea29ecb1cd98c9e4c2646aea4b8bc",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1542310107/clients/grandrapids/_OD_0130_0e6a803b-a1f5-47ec-819b-dfbbba7330d8.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1542310107/clients/grandrapids/_OD_0130_0e6a803b-a1f5-47ec-819b-dfbbba7330d8.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1542310107/clients/grandrapids/_OD_0130_0e6a803b-a1f5-47ec-819b-dfbbba7330d8.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -4922,7 +4922,7 @@
 				"bytes": 333976,
 				"type": "upload",
 				"etag": "b3b3dc061270186568a210bbc308759b",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1430954398/clients/grandrapids/hero-events_0ede7bb1-e471-45b9-a1a4-36620df7385e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1430954398/clients/grandrapids/hero-events_0ede7bb1-e471-45b9-a1a4-36620df7385e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1430954398/clients/grandrapids/hero-events_0ede7bb1-e471-45b9-a1a4-36620df7385e.jpg"
 			},
 			"categories_ids": [
@@ -4980,7 +4980,7 @@
 				"bytes": 1372557,
 				"type": "upload",
 				"etag": "1d22798759096bea2d544dfd649373d6",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435539430/clients/grandrapids/Fenn%20Valley%20Winery%204_a19eb3fc-b3a9-4b0b-9a76-b87f9d574c61.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435539430/clients/grandrapids/Fenn%20Valley%20Winery%204_a19eb3fc-b3a9-4b0b-9a76-b87f9d574c61.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435539430/clients/grandrapids/Fenn%20Valley%20Winery%204_a19eb3fc-b3a9-4b0b-9a76-b87f9d574c61.jpg",
 				"original_filename": "file"
 			},
@@ -5051,7 +5051,7 @@
 				"type": "upload",
 				"etag": "451e5c2091a221629495a723ffdcd65f",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565901617/clients/grandrapids/042_3_9328_jpeg_1e8e19cd-0113-4520-9250-fe6aec15c637.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565901617/clients/grandrapids/042_3_9328_jpeg_1e8e19cd-0113-4520-9250-fe6aec15c637.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565901617/clients/grandrapids/042_3_9328_jpeg_1e8e19cd-0113-4520-9250-fe6aec15c637.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -5174,7 +5174,7 @@
 				"bytes": 2856408,
 				"type": "upload",
 				"etag": "925c2f87f2b30cfe0cf19167a9aaf77a",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1437666323/clients/grandrapids/TheOldGoat_61c477d3-5e41-4583-9baa-3f83a53b7fd8.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1437666323/clients/grandrapids/TheOldGoat_61c477d3-5e41-4583-9baa-3f83a53b7fd8.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1437666323/clients/grandrapids/TheOldGoat_61c477d3-5e41-4583-9baa-3f83a53b7fd8.jpg",
 				"exif": {
 					"ApertureValue": "4/1",
@@ -5287,7 +5287,7 @@
 				"bytes": 1957726,
 				"type": "upload",
 				"etag": "e8f3b351f7a9c2ae6d6a9fa03055ddb1",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434886825/clients/grandrapids/Couple%20walking%20Grand%20Haven%20Beach_ef1d0f35-a0b8-4256-8dae-c4b9b811180f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434886825/clients/grandrapids/Couple%20walking%20Grand%20Haven%20Beach_ef1d0f35-a0b8-4256-8dae-c4b9b811180f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434886825/clients/grandrapids/Couple%20walking%20Grand%20Haven%20Beach_ef1d0f35-a0b8-4256-8dae-c4b9b811180f.jpg",
 				"original_filename": "file"
 			},
@@ -5363,7 +5363,7 @@
 				"bytes": 28769,
 				"type": "upload",
 				"etag": "56ea986a4fe6e271631780f5d931392d",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1446562995/clients/grandrapids/laughfest_c0bf5b58-cb25-44c5-a330-e9649241a57f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1446562995/clients/grandrapids/laughfest_c0bf5b58-cb25-44c5-a330-e9649241a57f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1446562995/clients/grandrapids/laughfest_c0bf5b58-cb25-44c5-a330-e9649241a57f.jpg",
 				"original_filename": "file"
 			},
@@ -5421,7 +5421,7 @@
 				"bytes": 150371,
 				"type": "upload",
 				"etag": "49b5e0fd09c7941ba369657acbe3c8a9",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1443214593/clients/grandrapids/rowster3Kaitlynn%20Broadbooks._52885b98-ec49-408c-98d3-949a4d8f843c.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1443214593/clients/grandrapids/rowster3Kaitlynn%20Broadbooks._52885b98-ec49-408c-98d3-949a4d8f843c.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1443214593/clients/grandrapids/rowster3Kaitlynn%20Broadbooks._52885b98-ec49-408c-98d3-949a4d8f843c.jpg",
 				"exif": {
 					"ApertureValue": "196608/65536",
@@ -5532,7 +5532,7 @@
 				"bytes": 18543793,
 				"type": "upload",
 				"etag": "9b5e43ef1eaa43d659834b2f6777e2bc",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1474050313/clients/grandrapids/06152016_ExGR_Wagner3082_75969927-915f-4327-9a9b-e6164b7dd88e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1474050313/clients/grandrapids/06152016_ExGR_Wagner3082_75969927-915f-4327-9a9b-e6164b7dd88e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1474050313/clients/grandrapids/06152016_ExGR_Wagner3082_75969927-915f-4327-9a9b-e6164b7dd88e.jpg",
 				"exif": {
 					"Compression": "6",
@@ -5604,7 +5604,7 @@
 				"bytes": 2292830,
 				"type": "upload",
 				"etag": "00247beb48e2d41d2c1735ea54869fd1",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1489505159/clients/grandrapids/WAVE_Nominees_e3d1e135-f9fd-40be-b621-194a0aa902ea.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1489505159/clients/grandrapids/WAVE_Nominees_e3d1e135-f9fd-40be-b621-194a0aa902ea.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1489505159/clients/grandrapids/WAVE_Nominees_e3d1e135-f9fd-40be-b621-194a0aa902ea.jpg",
 				"exif": {
 					"ApertureValue": "361471/100000",
@@ -5712,7 +5712,7 @@
 				"bytes": 1174995,
 				"type": "upload",
 				"etag": "1580be03b495910f7f59140382b659f2",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1499794075/clients/grandrapids/Justus_Wise_cba0345a-5e4e-43be-a6ae-cf9421250cf2.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1499794075/clients/grandrapids/Justus_Wise_cba0345a-5e4e-43be-a6ae-cf9421250cf2.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1499794075/clients/grandrapids/Justus_Wise_cba0345a-5e4e-43be-a6ae-cf9421250cf2.jpg",
 				"exif": {
 					"ApertureValue": "2970854/1000000",
@@ -5814,7 +5814,7 @@
 				"type": "upload",
 				"etag": "931bd0b152272dd88c63bcfac38c92a2",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1521127909/clients/grandrapids/The_Rapid_Exchange_large_5ed7eda6-19f0-4618-a06a-4c84df3ec596.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1521127909/clients/grandrapids/The_Rapid_Exchange_large_5ed7eda6-19f0-4618-a06a-4c84df3ec596.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1521127909/clients/grandrapids/The_Rapid_Exchange_large_5ed7eda6-19f0-4618-a06a-4c84df3ec596.png",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -5875,7 +5875,7 @@
 				"type": "upload",
 				"etag": "326f5941da39c831e7d75a76264cf96c",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1528910159/clients/grandrapids/IMG_4030_a803756f-dcd5-4698-b3ed-0c431c760c5f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1528910159/clients/grandrapids/IMG_4030_a803756f-dcd5-4698-b3ed-0c431c760c5f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1528910159/clients/grandrapids/IMG_4030_a803756f-dcd5-4698-b3ed-0c431c760c5f.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -5972,7 +5972,7 @@
 				"type": "upload",
 				"etag": "a10ab1e9179f37affa8e91eb0cbbcf51",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1536081958/clients/grandrapids/042_3_7913_jpeg_a661cbd0-5b76-4d7d-bf32-e71306cfb015.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1536081958/clients/grandrapids/042_3_7913_jpeg_a661cbd0-5b76-4d7d-bf32-e71306cfb015.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1536081958/clients/grandrapids/042_3_7913_jpeg_a661cbd0-5b76-4d7d-bf32-e71306cfb015.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -6083,7 +6083,7 @@
 				"type": "upload",
 				"etag": "9c51103f3d32dee10f75edb83aad0dce",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1525120825/clients/grandrapids/IMG_7490_ef362758-f740-4033-8e06-80163390ffc3.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1525120825/clients/grandrapids/IMG_7490_ef362758-f740-4033-8e06-80163390ffc3.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1525120825/clients/grandrapids/IMG_7490_ef362758-f740-4033-8e06-80163390ffc3.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -6188,7 +6188,7 @@
 				"type": "upload",
 				"etag": "1ef1a4c516292631de843ddb37a27c45",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1548728660/clients/grandrapids/042_3_9068_jpeg_65c1035d-65a0-4168-b613-c81865ccdbe2.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1548728660/clients/grandrapids/042_3_9068_jpeg_65c1035d-65a0-4168-b613-c81865ccdbe2.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1548728660/clients/grandrapids/042_3_9068_jpeg_65c1035d-65a0-4168-b613-c81865ccdbe2.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -6292,7 +6292,7 @@
 				"bytes": 109576,
 				"type": "upload",
 				"etag": "1f1407e9b0fb0912f6fb1b011564323d",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1437486558/clients/grandrapids/Art-Outdoor-Link-Banner_cfb1ba05-eb5c-4b63-915d-c5893a44cffd.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1437486558/clients/grandrapids/Art-Outdoor-Link-Banner_cfb1ba05-eb5c-4b63-915d-c5893a44cffd.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1437486558/clients/grandrapids/Art-Outdoor-Link-Banner_cfb1ba05-eb5c-4b63-915d-c5893a44cffd.png",
 				"original_filename": "file"
 			},
@@ -6350,7 +6350,7 @@
 				"bytes": 2245792,
 				"type": "upload",
 				"etag": "3b0895ad8ec554d981a83d8faa187305",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436756520/clients/grandrapids/FMG%20Sunset_d429b4fe-2b16-486b-ba09-3a8aa271f857.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436756520/clients/grandrapids/FMG%20Sunset_d429b4fe-2b16-486b-ba09-3a8aa271f857.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436756520/clients/grandrapids/FMG%20Sunset_d429b4fe-2b16-486b-ba09-3a8aa271f857.jpg",
 				"exif": {
 					"BitsPerSample": "8, 8, 8",
@@ -6445,7 +6445,7 @@
 				"bytes": 813427,
 				"type": "upload",
 				"etag": "525a1cfa1276648192e6bb153a131a3f",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1447080683/clients/grandrapids/unwraptheseason_b54e50bf-0775-449e-9b78-c1d3299fcf35.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1447080683/clients/grandrapids/unwraptheseason_b54e50bf-0775-449e-9b78-c1d3299fcf35.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1447080683/clients/grandrapids/unwraptheseason_b54e50bf-0775-449e-9b78-c1d3299fcf35.jpg",
 				"exif": {
 					"BitsPerSample": "8, 8, 8",
@@ -6533,7 +6533,7 @@
 				"bytes": 1459790,
 				"type": "upload",
 				"etag": "127c8878f1096af226768ee9ca1d5f13",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1466626295/clients/grandrapids/mural_in_Grand_Rapids_0d3706d5-0158-4e17-96a6-68a364218fbb.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1466626295/clients/grandrapids/mural_in_Grand_Rapids_0d3706d5-0158-4e17-96a6-68a364218fbb.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1466626295/clients/grandrapids/mural_in_Grand_Rapids_0d3706d5-0158-4e17-96a6-68a364218fbb.jpg",
 				"exif": {
 					"ApertureValue": "6/1",
@@ -6652,7 +6652,7 @@
 				"bytes": 4547787,
 				"type": "upload",
 				"etag": "2839f2d009584476f198b51ea238cc42",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1466776246/clients/grandrapids/Elec_Cheetah_Cookie_1_6b1f71a4-602e-4cd4-8588-fddc344e1159.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1466776246/clients/grandrapids/Elec_Cheetah_Cookie_1_6b1f71a4-602e-4cd4-8588-fddc344e1159.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1466776246/clients/grandrapids/Elec_Cheetah_Cookie_1_6b1f71a4-602e-4cd4-8588-fddc344e1159.jpg",
 				"exif": {
 					"BitsPerSample": "8, 8, 8",
@@ -6740,7 +6740,7 @@
 				"bytes": 830444,
 				"type": "upload",
 				"etag": "e4a2962f619dd9669f39d36927e638ff",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434887054/clients/grandrapids/Eve%20at%20The%20BOB%2014_0645adef-2dfa-4380-be17-3b230170cd05.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434887054/clients/grandrapids/Eve%20at%20The%20BOB%2014_0645adef-2dfa-4380-be17-3b230170cd05.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434887054/clients/grandrapids/Eve%20at%20The%20BOB%2014_0645adef-2dfa-4380-be17-3b230170cd05.jpg",
 				"original_filename": "file"
 			},
@@ -6807,7 +6807,7 @@
 				"bytes": 16292495,
 				"type": "upload",
 				"etag": "0e713478c97277e13b6d458c5de21b12",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1493218774/clients/grandrapids/042_3_8750_jpeg_78974598-65e7-49a5-94ce-28b644bfc79c.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1493218774/clients/grandrapids/042_3_8750_jpeg_78974598-65e7-49a5-94ce-28b644bfc79c.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1493218774/clients/grandrapids/042_3_8750_jpeg_78974598-65e7-49a5-94ce-28b644bfc79c.jpg",
 				"exif": {
 					"ApertureValue": "5655638/1000000",
@@ -6930,7 +6930,7 @@
 				"bytes": 15243467,
 				"type": "upload",
 				"etag": "f3cda23b7559257b444b0ddb7bb644bb",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1502477715/clients/grandrapids/042_3_8787_jpeg_24ac6fe0-47c1-4dd0-a455-f99519a1ee4e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1502477715/clients/grandrapids/042_3_8787_jpeg_24ac6fe0-47c1-4dd0-a455-f99519a1ee4e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1502477715/clients/grandrapids/042_3_8787_jpeg_24ac6fe0-47c1-4dd0-a455-f99519a1ee4e.jpg",
 				"exif": {
 					"ApertureValue": "2/1",
@@ -7062,7 +7062,7 @@
 				"type": "upload",
 				"etag": "0fcb7317ead2474193d651b8baf21932",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1513871143/clients/grandrapids/042_3_8819_jpeg_ffd8c40e-4d50-472b-acf7-cec5e11d0208.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1513871143/clients/grandrapids/042_3_8819_jpeg_ffd8c40e-4d50-472b-acf7-cec5e11d0208.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1513871143/clients/grandrapids/042_3_8819_jpeg_ffd8c40e-4d50-472b-acf7-cec5e11d0208.jpg",
 				"exif": {
 					"ApertureValue": "66/25",
@@ -7198,7 +7198,7 @@
 				"type": "upload",
 				"etag": "632b258d3fc94492bd799bde560744c1",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1534864219/clients/grandrapids/DiscoverTourism_Partners_69b5cad4-fd4c-4f3d-a9c9-573349a6e737.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1534864219/clients/grandrapids/DiscoverTourism_Partners_69b5cad4-fd4c-4f3d-a9c9-573349a6e737.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1534864219/clients/grandrapids/DiscoverTourism_Partners_69b5cad4-fd4c-4f3d-a9c9-573349a6e737.png",
 				"access_mode": "public",
 				"original_filename": "file",
@@ -7243,7 +7243,7 @@
 				"type": "upload",
 				"etag": "4b65cbdad96252ff781cc32197ccf51e",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1532010733/clients/grandrapids/JSDShoot_16_ca3db003-a36a-4930-9e1e-e62998279d26.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1532010733/clients/grandrapids/JSDShoot_16_ca3db003-a36a-4930-9e1e-e62998279d26.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1532010733/clients/grandrapids/JSDShoot_16_ca3db003-a36a-4930-9e1e-e62998279d26.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -7359,7 +7359,7 @@
 				"bytes": 33887519,
 				"type": "upload",
 				"etag": "888f60120cc8e5358c1ba16f89f1e5ba",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1475265445/clients/grandrapids/06152016_ExGR_Wagner3122_830a39d9-d2e4-411c-acb9-1e7afffccb64.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1475265445/clients/grandrapids/06152016_ExGR_Wagner3122_830a39d9-d2e4-411c-acb9-1e7afffccb64.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1475265445/clients/grandrapids/06152016_ExGR_Wagner3122_830a39d9-d2e4-411c-acb9-1e7afffccb64.jpg",
 				"exif": {
 					"BitsPerSample": "8, 8, 8",
@@ -7446,7 +7446,7 @@
 				"type": "upload",
 				"etag": "806d0bd9ddcaf9c233d8263bed87e495",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1539697695/clients/grandrapids/BKP_Calder2018_6414_final_5cb066f9-9779-4578-aec1-be8519ed4334.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1539697695/clients/grandrapids/BKP_Calder2018_6414_final_5cb066f9-9779-4578-aec1-be8519ed4334.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1539697695/clients/grandrapids/BKP_Calder2018_6414_final_5cb066f9-9779-4578-aec1-be8519ed4334.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -7521,7 +7521,7 @@
 				"type": "upload",
 				"etag": "d6d8d207b4a3c5becbbd798da54cf762",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1537465436/clients/grandrapids/1c4cf635_1f00_41d4_808b_227cecb56960_977eacaa-a483-43ff-9aca-df08d1c5460d.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1537465436/clients/grandrapids/1c4cf635_1f00_41d4_808b_227cecb56960_977eacaa-a483-43ff-9aca-df08d1c5460d.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1537465436/clients/grandrapids/1c4cf635_1f00_41d4_808b_227cecb56960_977eacaa-a483-43ff-9aca-df08d1c5460d.jpg",
 				"access_mode": "public",
 				"original_filename": "1c4cf635-1f00-41d4-808b-227cecb56960"
@@ -7596,7 +7596,7 @@
 				"type": "upload",
 				"etag": "8e87772520efe3bae7da602122c33717",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1534864713/clients/grandrapids/042_3_8788_jpeg_0bb413ba-d82e-4d44-be7c-de4b03c14285.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1534864713/clients/grandrapids/042_3_8788_jpeg_0bb413ba-d82e-4d44-be7c-de4b03c14285.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1534864713/clients/grandrapids/042_3_8788_jpeg_0bb413ba-d82e-4d44-be7c-de4b03c14285.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -7726,7 +7726,7 @@
 				"type": "upload",
 				"etag": "12ad53ab99101bbfccbc4d936a3479b4",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1550691211/clients/grandrapids/Host_AB_Header_c893483e-78d0-418b-bff2-24c1982e2e2e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1550691211/clients/grandrapids/Host_AB_Header_c893483e-78d0-418b-bff2-24c1982e2e2e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1550691211/clients/grandrapids/Host_AB_Header_c893483e-78d0-418b-bff2-24c1982e2e2e.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -7812,7 +7812,7 @@
 				"bytes": 15755284,
 				"type": "upload",
 				"etag": "ea99a4ee6f3cc8c762d20a1bc5f55c03",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1499434395/clients/grandrapids/IMG_4570_479e1351-1bda-4021-aad2-0a1411a64d67.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1499434395/clients/grandrapids/IMG_4570_479e1351-1bda-4021-aad2-0a1411a64d67.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1499434395/clients/grandrapids/IMG_4570_479e1351-1bda-4021-aad2-0a1411a64d67.jpg",
 				"exif": {
 					"ApertureValue": "2970854/1000000",
@@ -7924,7 +7924,7 @@
 				"type": "upload",
 				"etag": "cce45d60ddce748650b6eb455f9043c4",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565722565/clients/grandrapids/042_3_9245_jpeg_f6475363-b033-4685-9347-fd2bc453feb1.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565722565/clients/grandrapids/042_3_9245_jpeg_f6475363-b033-4685-9347-fd2bc453feb1.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565722565/clients/grandrapids/042_3_9245_jpeg_f6475363-b033-4685-9347-fd2bc453feb1.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -8027,7 +8027,7 @@
 				"type": "upload",
 				"etag": "cce45d60ddce748650b6eb455f9043c4",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565722565/clients/grandrapids/042_3_9245_jpeg_f6475363-b033-4685-9347-fd2bc453feb1.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565722565/clients/grandrapids/042_3_9245_jpeg_f6475363-b033-4685-9347-fd2bc453feb1.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565722565/clients/grandrapids/042_3_9245_jpeg_f6475363-b033-4685-9347-fd2bc453feb1.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -8153,7 +8153,7 @@
 				"bytes": 1082623,
 				"type": "upload",
 				"etag": "405c8d70dc6ffdfb2ab9e96947406c91",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436751066/clients/grandrapids/Gerald%20R.%20Ford%20Airport%2029_78a3ae98-4b70-44f4-b9b3-4e843a53f70d.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436751066/clients/grandrapids/Gerald%20R.%20Ford%20Airport%2029_78a3ae98-4b70-44f4-b9b3-4e843a53f70d.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436751066/clients/grandrapids/Gerald%20R.%20Ford%20Airport%2029_78a3ae98-4b70-44f4-b9b3-4e843a53f70d.jpg",
 				"exif": {
 					"Artist": "Charles McArdle",
@@ -8234,7 +8234,7 @@
 				"bytes": 2189022,
 				"type": "upload",
 				"etag": "01cb5f6c5afaed43232b1c1f13ae3281",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1437491889/clients/grandrapids/rivertown-crossings_fd7c1438-5073-4376-970f-693712fa2783.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1437491889/clients/grandrapids/rivertown-crossings_fd7c1438-5073-4376-970f-693712fa2783.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1437491889/clients/grandrapids/rivertown-crossings_fd7c1438-5073-4376-970f-693712fa2783.jpg",
 				"exif": {
 					"ApertureValue": "434176/65536",
@@ -8352,7 +8352,7 @@
 				"bytes": 1149173,
 				"type": "upload",
 				"etag": "85baa064776905ce5877419902215c35",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1438028842/clients/grandrapids/6C6A5192_3e1856f9-308a-4db2-a07c-ba0e191d1949.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1438028842/clients/grandrapids/6C6A5192_3e1856f9-308a-4db2-a07c-ba0e191d1949.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1438028842/clients/grandrapids/6C6A5192_3e1856f9-308a-4db2-a07c-ba0e191d1949.jpg",
 				"exif": {
 					"ApertureValue": "4/1",
@@ -8454,7 +8454,7 @@
 				"bytes": 81889,
 				"type": "upload",
 				"etag": "ef061b976cf1f1bbe8346439386cbc76",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1438970239/clients/grandrapids/Rendering_415ac20e-f523-4c69-bd5d-ed72988b934f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1438970239/clients/grandrapids/Rendering_415ac20e-f523-4c69-bd5d-ed72988b934f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1438970239/clients/grandrapids/Rendering_415ac20e-f523-4c69-bd5d-ed72988b934f.jpg",
 				"original_filename": "file"
 			},
@@ -8497,7 +8497,7 @@
 		"created": "2015-08-18T13:39:09.502Z",
 		"content_owner": "default",
 		"url_raw": {
-			"id": "http://www.experiencegr.com/restaurant-week/",
+			"id": "https://www.experiencegr.com/restaurant-week/",
 			"type": "plugins_nav_external_link"
 		},
 		"image": {
@@ -8515,7 +8515,7 @@
 				"bytes": 1044598,
 				"type": "upload",
 				"etag": "5fdf04dafa97aff992d79db6b366f208",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1439905241/clients/grandrapids/restaurant-week-home_d53214c5-5313-4b19-a895-43381948e3a8.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1439905241/clients/grandrapids/restaurant-week-home_d53214c5-5313-4b19-a895-43381948e3a8.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1439905241/clients/grandrapids/restaurant-week-home_d53214c5-5313-4b19-a895-43381948e3a8.jpg",
 				"exif": {
 					"BitsPerSample": "8, 8, 8",
@@ -8570,13 +8570,13 @@
 			"alt_text": "Restaurant Week SV"
 		},
 		"url": {
-			"id": "http://www.experiencegr.com/restaurant-week/",
-			"url": "http://www.experiencegr.com/restaurant-week/",
+			"id": "https://www.experiencegr.com/restaurant-week/",
+			"url": "https://www.experiencegr.com/restaurant-week/",
 			"valid": true,
 			"type": "plugins_nav_external_link",
 			"typeLabel": "Custom Link",
 			"target": "_blank",
-			"uniqueId": "plugins_nav_external_link_http://www.experiencegr.com/restaurant-week/"
+			"uniqueId": "plugins_nav_external_link_https://www.experiencegr.com/restaurant-week/"
 		},
 		"id": "55d335e52d7bd0375a85a488",
 		"categories_ids": [
@@ -8622,7 +8622,7 @@
 				"bytes": 2119866,
 				"type": "upload",
 				"etag": "c39837ee88c04bcb4bf711744465600a",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1482431921/clients/grandrapids/Tulip_Time_2016_2_b8943167-82bd-4415-8c13-60c8261aad6a.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1482431921/clients/grandrapids/Tulip_Time_2016_2_b8943167-82bd-4415-8c13-60c8261aad6a.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1482431921/clients/grandrapids/Tulip_Time_2016_2_b8943167-82bd-4415-8c13-60c8261aad6a.jpg",
 				"exif": {
 					"ApertureValue": "7983/3509",
@@ -8768,7 +8768,7 @@
 				"type": "upload",
 				"etag": "f3da43556e79af94e3b4cb14ad346156",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1540906460/clients/grandrapids/Cocktail_Week_GR_2018_131b077b-73e6-48e4-a421-c891aa1dcb5f.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1540906460/clients/grandrapids/Cocktail_Week_GR_2018_131b077b-73e6-48e4-a421-c891aa1dcb5f.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1540906460/clients/grandrapids/Cocktail_Week_GR_2018_131b077b-73e6-48e4-a421-c891aa1dcb5f.png",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -8810,7 +8810,7 @@
 				"type": "upload",
 				"etag": "f3da43556e79af94e3b4cb14ad346156",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1540906460/clients/grandrapids/Cocktail_Week_GR_2018_131b077b-73e6-48e4-a421-c891aa1dcb5f.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1540906460/clients/grandrapids/Cocktail_Week_GR_2018_131b077b-73e6-48e4-a421-c891aa1dcb5f.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1540906460/clients/grandrapids/Cocktail_Week_GR_2018_131b077b-73e6-48e4-a421-c891aa1dcb5f.png",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -8875,7 +8875,7 @@
 				"bytes": 4496854,
 				"type": "upload",
 				"etag": "6c7aca2c6b98ca8553027947aebb243f",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1461351459/clients/grandrapids/Music_Trail_Cover_cdb05392-c943-48bb-82cf-9ac56d77bcea.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1461351459/clients/grandrapids/Music_Trail_Cover_cdb05392-c943-48bb-82cf-9ac56d77bcea.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1461351459/clients/grandrapids/Music_Trail_Cover_cdb05392-c943-48bb-82cf-9ac56d77bcea.png",
 				"original_filename": "file"
 			},
@@ -8947,7 +8947,7 @@
 				"type": "upload",
 				"etag": "6aceb1556c53bfb932180101def77182",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1528812545/clients/grandrapids/ExperienceGR_2017_1890_hi_aa37af89-f87f-4826-9265-f4a465beade6.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1528812545/clients/grandrapids/ExperienceGR_2017_1890_hi_aa37af89-f87f-4826-9265-f4a465beade6.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1528812545/clients/grandrapids/ExperienceGR_2017_1890_hi_aa37af89-f87f-4826-9265-f4a465beade6.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -9066,7 +9066,7 @@
 				"bytes": 20524249,
 				"type": "upload",
 				"etag": "78f98a801476a6ae9cabc72bc4a551bc",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1488398201/clients/grandrapids/PorcleianCube2_Andy_Terzes_e9b4e668-5eb1-4928-a247-40d8f49bc385.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1488398201/clients/grandrapids/PorcleianCube2_Andy_Terzes_e9b4e668-5eb1-4928-a247-40d8f49bc385.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1488398201/clients/grandrapids/PorcleianCube2_Andy_Terzes_e9b4e668-5eb1-4928-a247-40d8f49bc385.jpg",
 				"exif": {
 					"ApertureValue": "4970854/1000000",
@@ -9161,7 +9161,7 @@
 				"bytes": 20524249,
 				"type": "upload",
 				"etag": "78f98a801476a6ae9cabc72bc4a551bc",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1488398201/clients/grandrapids/PorcleianCube2_Andy_Terzes_e9b4e668-5eb1-4928-a247-40d8f49bc385.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1488398201/clients/grandrapids/PorcleianCube2_Andy_Terzes_e9b4e668-5eb1-4928-a247-40d8f49bc385.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1488398201/clients/grandrapids/PorcleianCube2_Andy_Terzes_e9b4e668-5eb1-4928-a247-40d8f49bc385.jpg",
 				"exif": {
 					"ApertureValue": "4970854/1000000",
@@ -9273,7 +9273,7 @@
 				"bytes": 14935996,
 				"type": "upload",
 				"etag": "949736a26e42467de6ea17147f391443",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1464714000/clients/grandrapids/DeVosPl_0691_70771071-70be-4344-af72-7b279dbd361d.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1464714000/clients/grandrapids/DeVosPl_0691_70771071-70be-4344-af72-7b279dbd361d.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1464714000/clients/grandrapids/DeVosPl_0691_70771071-70be-4344-af72-7b279dbd361d.jpg",
 				"exif": {
 					"ApertureValue": "4/1",
@@ -9397,7 +9397,7 @@
 				"type": "upload",
 				"etag": "67fff574ce040fa9f4c53816de340d6c",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1512663274/clients/grandrapids/ExpGr_Beer_Month_Facebook_Header_2018_no_date_ec94b4ef-bffd-499d-9fa7-0515fee5a50c.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1512663274/clients/grandrapids/ExpGr_Beer_Month_Facebook_Header_2018_no_date_ec94b4ef-bffd-499d-9fa7-0515fee5a50c.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1512663274/clients/grandrapids/ExpGr_Beer_Month_Facebook_Header_2018_no_date_ec94b4ef-bffd-499d-9fa7-0515fee5a50c.png",
 				"original_filename": "file"
 			},
@@ -9442,7 +9442,7 @@
 				"type": "upload",
 				"etag": "273af0a602c783988b15179af03f6656",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1512663316/clients/grandrapids/042_3_8772_jpeg_07106bda-5785-4713-a194-d72bcc2a8751.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1512663316/clients/grandrapids/042_3_8772_jpeg_07106bda-5785-4713-a194-d72bcc2a8751.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1512663316/clients/grandrapids/042_3_8772_jpeg_07106bda-5785-4713-a194-d72bcc2a8751.jpg",
 				"exif": {
 					"Artist": "Craig Vander Lende",
@@ -9560,7 +9560,7 @@
 				"type": "upload",
 				"etag": "558c69acc27a79b21597ce1e3e39c3df",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1546025079/clients/grandrapids/042_3_9032_jpeg_04b3d073-0284-4319-b16e-5058b8542441.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1546025079/clients/grandrapids/042_3_9032_jpeg_04b3d073-0284-4319-b16e-5058b8542441.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1546025079/clients/grandrapids/042_3_9032_jpeg_04b3d073-0284-4319-b16e-5058b8542441.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -9672,7 +9672,7 @@
 				"type": "upload",
 				"etag": "d258a821b71979a8bc05717d8e460d8a",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1538158830/clients/grandrapids/Lindsey_Blake_78_819cb5d7-62f4-44de-a0be-a23676c92384.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1538158830/clients/grandrapids/Lindsey_Blake_78_819cb5d7-62f4-44de-a0be-a23676c92384.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1538158830/clients/grandrapids/Lindsey_Blake_78_819cb5d7-62f4-44de-a0be-a23676c92384.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -9776,7 +9776,7 @@
 				"type": "upload",
 				"etag": "53390f6a1b75a6e94e59e03693cd11f9",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1521646048/clients/grandrapids/042_3_8777_jpeg_db9ffaa5-c012-455b-83ce-054295dc60b4.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1521646048/clients/grandrapids/042_3_8777_jpeg_db9ffaa5-c012-455b-83ce-054295dc60b4.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1521646048/clients/grandrapids/042_3_8777_jpeg_db9ffaa5-c012-455b-83ce-054295dc60b4.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -9889,7 +9889,7 @@
 				"type": "upload",
 				"etag": "6307fb771cc311a6242372bd6886b39b",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1538488552/clients/grandrapids/shutterstock_250505101_cb7080d0-f4b4-426f-b2de-80c332ab39ed.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1538488552/clients/grandrapids/shutterstock_250505101_cb7080d0-f4b4-426f-b2de-80c332ab39ed.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1538488552/clients/grandrapids/shutterstock_250505101_cb7080d0-f4b4-426f-b2de-80c332ab39ed.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -9982,7 +9982,7 @@
 				"type": "upload",
 				"etag": "6fc495fe064090c75a2a22b515fa56d3",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1540388925/clients/grandrapids/042_3_8930_jpeg_d57aed01-f0b9-4fbe-9da1-5a139e1a9f91.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1540388925/clients/grandrapids/042_3_8930_jpeg_d57aed01-f0b9-4fbe-9da1-5a139e1a9f91.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1540388925/clients/grandrapids/042_3_8930_jpeg_d57aed01-f0b9-4fbe-9da1-5a139e1a9f91.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -10077,7 +10077,7 @@
 				"type": "upload",
 				"etag": "ba17bc5c7ed6f4eb1688346e82717a43",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1552334709/clients/grandrapids/temp_b55bdffd-81dc-4691-94b2-ad708a6236f9.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1552334709/clients/grandrapids/temp_b55bdffd-81dc-4691-94b2-ad708a6236f9.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1552334709/clients/grandrapids/temp_b55bdffd-81dc-4691-94b2-ad708a6236f9.jpg",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -10153,7 +10153,7 @@
 				"type": "upload",
 				"etag": "7acdbb3823724f58e6979c015a049d47",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1545834582/clients/grandrapids/042_3_8928_jpeg_0ad788cb-ac32-4395-a94b-c0af281f9645.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1545834582/clients/grandrapids/042_3_8928_jpeg_0ad788cb-ac32-4395-a94b-c0af281f9645.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1545834582/clients/grandrapids/042_3_8928_jpeg_0ad788cb-ac32-4395-a94b-c0af281f9645.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -10230,7 +10230,7 @@
 				"type": "upload",
 				"etag": "db9d54059478f6d209df441bf2d5d506",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1557325487/clients/grandrapids/042_3_9128_jpeg_44a50a73-5c93-4d55-a7ef-a49ab3cf3c4e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1557325487/clients/grandrapids/042_3_9128_jpeg_44a50a73-5c93-4d55-a7ef-a49ab3cf3c4e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1557325487/clients/grandrapids/042_3_9128_jpeg_44a50a73-5c93-4d55-a7ef-a49ab3cf3c4e.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -10346,7 +10346,7 @@
 				"type": "upload",
 				"etag": "9551d97777eb292e3f67f7b957d1e9a8",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565812868/clients/grandrapids/focalTest_d48357c2-10d7-4c2d-89fb-6ed1c849e9ec.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565812868/clients/grandrapids/focalTest_d48357c2-10d7-4c2d-89fb-6ed1c849e9ec.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565812868/clients/grandrapids/focalTest_d48357c2-10d7-4c2d-89fb-6ed1c849e9ec.png",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -10419,7 +10419,7 @@
 				"type": "upload",
 				"etag": "0fe4f8da0be1496625427e913cec74ca",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565921292/clients/grandrapids/042_3_9332_jpeg_053959a2-3164-4d83-9bb1-6d1a9e5ac1c1.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565921292/clients/grandrapids/042_3_9332_jpeg_053959a2-3164-4d83-9bb1-6d1a9e5ac1c1.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565921292/clients/grandrapids/042_3_9332_jpeg_053959a2-3164-4d83-9bb1-6d1a9e5ac1c1.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -10551,7 +10551,7 @@
 				"type": "upload",
 				"etag": "dfe7b4ae443c60ed7c0d8e7a5af2582d",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565901899/clients/grandrapids/042_3_9249_jpeg_5c1c9c58-2ccd-40a4-9017-fece6d83c4d8.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565901899/clients/grandrapids/042_3_9249_jpeg_5c1c9c58-2ccd-40a4-9017-fece6d83c4d8.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565901899/clients/grandrapids/042_3_9249_jpeg_5c1c9c58-2ccd-40a4-9017-fece6d83c4d8.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -10666,7 +10666,7 @@
 				"bytes": 1117303,
 				"type": "upload",
 				"etag": "f2a01a9ff3b2b3ad860b2eed880f8835",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436972726/clients/grandrapids/Family%20with%20John%20Ball%20Statue%20-%20West%20Side_69958844-5a68-449f-b07b-242048d0bf0b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436972726/clients/grandrapids/Family%20with%20John%20Ball%20Statue%20-%20West%20Side_69958844-5a68-449f-b07b-242048d0bf0b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436972726/clients/grandrapids/Family%20with%20John%20Ball%20Statue%20-%20West%20Side_69958844-5a68-449f-b07b-242048d0bf0b.jpg",
 				"exif": {
 					"ApertureValue": "4/1",
@@ -10771,7 +10771,7 @@
 				"bytes": 4584172,
 				"type": "upload",
 				"etag": "17c50c6b595127a86119511b072429f0",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1439322304/clients/grandrapids/Doubletree_GR_2015_Med_03_112d5cf4-4919-4e6a-8efd-d1235d539d25.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1439322304/clients/grandrapids/Doubletree_GR_2015_Med_03_112d5cf4-4919-4e6a-8efd-d1235d539d25.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1439322304/clients/grandrapids/Doubletree_GR_2015_Med_03_112d5cf4-4919-4e6a-8efd-d1235d539d25.jpg",
 				"exif": {
 					"ApertureValue": "6918863/1000000",
@@ -10781,7 +10781,7 @@
 					"ColorSpace": "65535",
 					"Compression": "5",
 					"Contrast": "0",
-					"Copyright": "http://www.ppt-photographics.com",
+					"Copyright": "https://www.ppt-photographics.com",
 					"CustomRendered": "0",
 					"DateTime": "2015:04:16 19:07:28",
 					"DateTimeDigitized": "2015:04:13 12:36:10",
@@ -10880,7 +10880,7 @@
 				"bytes": 105067,
 				"type": "upload",
 				"etag": "8695e29801a0a3d8778a688f2ae935e9",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1439403321/clients/grandrapids/Congratulations%21_4d0e3064-6046-488a-928e-20eef613de70.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1439403321/clients/grandrapids/Congratulations%21_4d0e3064-6046-488a-928e-20eef613de70.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1439403321/clients/grandrapids/Congratulations%21_4d0e3064-6046-488a-928e-20eef613de70.jpg",
 				"original_filename": "file"
 			},
@@ -10941,7 +10941,7 @@
 				"bytes": 2878315,
 				"type": "upload",
 				"etag": "17ce708ef212ae9c32b9d08ccb262099",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1448375250/clients/grandrapids/holiday%20photo_641f82b3-b5a7-43c4-9a80-ee5c774da6cb.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1448375250/clients/grandrapids/holiday%20photo_641f82b3-b5a7-43c4-9a80-ee5c774da6cb.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1448375250/clients/grandrapids/holiday%20photo_641f82b3-b5a7-43c4-9a80-ee5c774da6cb.jpg",
 				"done": true
 			},
@@ -11015,7 +11015,7 @@
 				"bytes": 2177196,
 				"type": "upload",
 				"etag": "7910441b5e82c9940e2213096a01a083",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1449522781/clients/grandrapids/Beer%20Week%20Facebook%20Header_0bc3edcd-6068-4997-8597-4c815e1ef7cc.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1449522781/clients/grandrapids/Beer%20Week%20Facebook%20Header_0bc3edcd-6068-4997-8597-4c815e1ef7cc.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1449522781/clients/grandrapids/Beer%20Week%20Facebook%20Header_0bc3edcd-6068-4997-8597-4c815e1ef7cc.jpg",
 				"done": true
 			},
@@ -11079,7 +11079,7 @@
 				"bytes": 11686173,
 				"type": "upload",
 				"etag": "8432ee40f03b6c15084d8c591192efb6",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1489504540/clients/grandrapids/WAVE_Awards_Service_18e0ee06-d5e4-45b0-a0c9-33362d5254d3.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1489504540/clients/grandrapids/WAVE_Awards_Service_18e0ee06-d5e4-45b0-a0c9-33362d5254d3.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1489504540/clients/grandrapids/WAVE_Awards_Service_18e0ee06-d5e4-45b0-a0c9-33362d5254d3.jpg",
 				"exif": {
 					"ApertureValue": "51501/11867",
@@ -11199,7 +11199,7 @@
 				"bytes": 5117700,
 				"type": "upload",
 				"etag": "5d2f1cfbf01bedae396d7e188370ab4a",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1499355929/clients/grandrapids/042_3_8768_jpeg_d3cded1f-d846-4bbd-9319-4094d2504931.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1499355929/clients/grandrapids/042_3_8768_jpeg_d3cded1f-d846-4bbd-9319-4094d2504931.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1499355929/clients/grandrapids/042_3_8768_jpeg_d3cded1f-d846-4bbd-9319-4094d2504931.jpg",
 				"exif": {
 					"Artist": "Craig Vander Lende",
@@ -11325,7 +11325,7 @@
 				"bytes": 13912900,
 				"type": "upload",
 				"etag": "75930ce57860df6a762df97e8ababe89",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1500669527/clients/grandrapids/IMG_5406_204405b2-2987-4213-8acf-3cd9b02d8d2d.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1500669527/clients/grandrapids/IMG_5406_204405b2-2987-4213-8acf-3cd9b02d8d2d.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1500669527/clients/grandrapids/IMG_5406_204405b2-2987-4213-8acf-3cd9b02d8d2d.jpg",
 				"exif": {
 					"ApertureValue": "1695994/1000000",
@@ -11448,7 +11448,7 @@
 				"type": "upload",
 				"etag": "aca1034c30d34e76b8753ea7cbff70be",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565901372/clients/grandrapids/042_3_9260_jpeg_2ae214d2-b745-4eaa-9d5b-9fe00b547231.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565901372/clients/grandrapids/042_3_9260_jpeg_2ae214d2-b745-4eaa-9d5b-9fe00b547231.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565901372/clients/grandrapids/042_3_9260_jpeg_2ae214d2-b745-4eaa-9d5b-9fe00b547231.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -11570,7 +11570,7 @@
 				"type": "upload",
 				"etag": "1523d711c4390005aa1902f15f3d9b31",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1509376765/clients/grandrapids/Old_Fashioned_Drink_01f2be05-3d90-4b9c-86c3-d32d7727971a.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1509376765/clients/grandrapids/Old_Fashioned_Drink_01f2be05-3d90-4b9c-86c3-d32d7727971a.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1509376765/clients/grandrapids/Old_Fashioned_Drink_01f2be05-3d90-4b9c-86c3-d32d7727971a.jpg",
 				"exif": {
 					"Artist": "Craig Vander Lende",
@@ -11674,7 +11674,7 @@
 				"type": "upload",
 				"etag": "271fd116eb9473664325a8b5c20f4741",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1531338577/clients/grandrapids/79ab4d4d_98f6_4fa3_b860_a6bf9e0816a3_a6aa80ae-85f4-4438-b450-753ec6e28012.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1531338577/clients/grandrapids/79ab4d4d_98f6_4fa3_b860_a6bf9e0816a3_a6aa80ae-85f4-4438-b450-753ec6e28012.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1531338577/clients/grandrapids/79ab4d4d_98f6_4fa3_b860_a6bf9e0816a3_a6aa80ae-85f4-4438-b450-753ec6e28012.jpg",
 				"access_mode": "public",
 				"original_filename": "79ab4d4d-98f6-4fa3-b860-a6bf9e0816a3"
@@ -11734,7 +11734,7 @@
 				"type": "upload",
 				"etag": "e7175621260896b8fd13acbdbbc0cde7",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1524183409/clients/grandrapids/beach_b57ea63a_fa8c_4c20_b2ec_8c12babb09cb_dcd099e0-9a01-47bd-91dc-0dcfa6341e58.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1524183409/clients/grandrapids/beach_b57ea63a_fa8c_4c20_b2ec_8c12babb09cb_dcd099e0-9a01-47bd-91dc-0dcfa6341e58.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1524183409/clients/grandrapids/beach_b57ea63a_fa8c_4c20_b2ec_8c12babb09cb_dcd099e0-9a01-47bd-91dc-0dcfa6341e58.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -11815,7 +11815,7 @@
 				"type": "upload",
 				"etag": "a4f96a0d44a9a05b092b7dbb99746462",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1525361464/clients/grandrapids/042_3_7454_jpeg_f54ee958-f69e-4294-8d03-1389c8c97e63.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1525361464/clients/grandrapids/042_3_7454_jpeg_f54ee958-f69e-4294-8d03-1389c8c97e63.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1525361464/clients/grandrapids/042_3_7454_jpeg_f54ee958-f69e-4294-8d03-1389c8c97e63.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -11933,7 +11933,7 @@
 				"type": "upload",
 				"etag": "7acdbb3823724f58e6979c015a049d47",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1545834582/clients/grandrapids/042_3_8928_jpeg_0ad788cb-ac32-4395-a94b-c0af281f9645.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1545834582/clients/grandrapids/042_3_8928_jpeg_0ad788cb-ac32-4395-a94b-c0af281f9645.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1545834582/clients/grandrapids/042_3_8928_jpeg_0ad788cb-ac32-4395-a94b-c0af281f9645.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -12011,7 +12011,7 @@
 				"type": "upload",
 				"etag": "23add5a4bfce12b9dfe7f975ebab34ca",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565805197/clients/grandrapids/FallintheCity_hdr_ae6c459b-30a2-46f8-8d8a-87e398d8b014.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565805197/clients/grandrapids/FallintheCity_hdr_ae6c459b-30a2-46f8-8d8a-87e398d8b014.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565805197/clients/grandrapids/FallintheCity_hdr_ae6c459b-30a2-46f8-8d8a-87e398d8b014.png",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -12080,7 +12080,7 @@
 				"type": "upload",
 				"etag": "a48067ab24210eae7fe165ce601aec73",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1520526117/clients/grandrapids/042_3_8866_jpeg_1fbe2f41-60c9-4748-8d84-477a98b02b23.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1520526117/clients/grandrapids/042_3_8866_jpeg_1fbe2f41-60c9-4748-8d84-477a98b02b23.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1520526117/clients/grandrapids/042_3_8866_jpeg_1fbe2f41-60c9-4748-8d84-477a98b02b23.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -12184,7 +12184,7 @@
 				"bytes": 944283,
 				"type": "upload",
 				"etag": "fb9ba8ce57aeab1848db5de7e32d2202",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436552823/clients/grandrapids/Jack%20the%20Ripper%20ballet_6564a5db-363b-4b16-a251-8e9d90c177fa.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436552823/clients/grandrapids/Jack%20the%20Ripper%20ballet_6564a5db-363b-4b16-a251-8e9d90c177fa.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436552823/clients/grandrapids/Jack%20the%20Ripper%20ballet_6564a5db-363b-4b16-a251-8e9d90c177fa.jpg",
 				"exif": {
 					"ApertureValue": "4/1",
@@ -12290,7 +12290,7 @@
 				"bytes": 753480,
 				"type": "upload",
 				"etag": "0108a2722717e2ee26c17a8735daf506",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1445441862/clients/grandrapids/oldgrandrapidscropped_c3189a1d-2d9f-4e4e-9245-6d19421eabda.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1445441862/clients/grandrapids/oldgrandrapidscropped_c3189a1d-2d9f-4e4e-9245-6d19421eabda.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1445441862/clients/grandrapids/oldgrandrapidscropped_c3189a1d-2d9f-4e4e-9245-6d19421eabda.jpg",
 				"exif": {
 					"BitsPerSample": "8, 8, 8",
@@ -12369,7 +12369,7 @@
 				"bytes": 4201633,
 				"type": "upload",
 				"etag": "958fd5e3a38c194a7989966b017e5d77",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1454010697/clients/grandrapids/Beer_Week_Header_1cf1aa28-7c8b-4fc0-bf6f-9e494aaa53d8.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1454010697/clients/grandrapids/Beer_Week_Header_1cf1aa28-7c8b-4fc0-bf6f-9e494aaa53d8.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1454010697/clients/grandrapids/Beer_Week_Header_1cf1aa28-7c8b-4fc0-bf6f-9e494aaa53d8.png",
 				"original_filename": "file"
 			},
@@ -12442,7 +12442,7 @@
 				"bytes": 686902,
 				"type": "upload",
 				"etag": "d13a43653e0eb91033d3801393266aad",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1495635485/clients/grandrapids/DeVosPL_0890_50f02513-1afe-412d-bba6-620a5c7db1f2.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1495635485/clients/grandrapids/DeVosPL_0890_50f02513-1afe-412d-bba6-620a5c7db1f2.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1495635485/clients/grandrapids/DeVosPL_0890_50f02513-1afe-412d-bba6-620a5c7db1f2.jpg",
 				"exif": {
 					"ApertureValue": "49471/10653",
@@ -12563,7 +12563,7 @@
 				"bytes": 15243467,
 				"type": "upload",
 				"etag": "f3cda23b7559257b444b0ddb7bb644bb",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1502477715/clients/grandrapids/042_3_8787_jpeg_24ac6fe0-47c1-4dd0-a455-f99519a1ee4e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1502477715/clients/grandrapids/042_3_8787_jpeg_24ac6fe0-47c1-4dd0-a455-f99519a1ee4e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1502477715/clients/grandrapids/042_3_8787_jpeg_24ac6fe0-47c1-4dd0-a455-f99519a1ee4e.jpg",
 				"exif": {
 					"ApertureValue": "2/1",
@@ -12701,7 +12701,7 @@
 				"type": "upload",
 				"etag": "666083a84c1c0630bac8422afafda45a",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1511362089/clients/grandrapids/042_3_8795_jpeg_76a9abf3-ee41-4aae-a671-1d28c18c8c14.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1511362089/clients/grandrapids/042_3_8795_jpeg_76a9abf3-ee41-4aae-a671-1d28c18c8c14.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1511362089/clients/grandrapids/042_3_8795_jpeg_76a9abf3-ee41-4aae-a671-1d28c18c8c14.jpg",
 				"exif": {
 					"ApertureValue": "4970854/1000000",
@@ -12810,7 +12810,7 @@
 				"type": "upload",
 				"etag": "a48067ab24210eae7fe165ce601aec73",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1520526117/clients/grandrapids/042_3_8866_jpeg_1fbe2f41-60c9-4748-8d84-477a98b02b23.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1520526117/clients/grandrapids/042_3_8866_jpeg_1fbe2f41-60c9-4748-8d84-477a98b02b23.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1520526117/clients/grandrapids/042_3_8866_jpeg_1fbe2f41-60c9-4748-8d84-477a98b02b23.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -12920,7 +12920,7 @@
 				"type": "upload",
 				"etag": "cf487f136ffe8c2c61c44dc6262033f7",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1566582470/clients/grandrapids/042_3_9283_jpeg_8c260b37-f483-4627-b984-9bd63329f8ce.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1566582470/clients/grandrapids/042_3_9283_jpeg_8c260b37-f483-4627-b984-9bd63329f8ce.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1566582470/clients/grandrapids/042_3_9283_jpeg_8c260b37-f483-4627-b984-9bd63329f8ce.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -13051,7 +13051,7 @@
 				"type": "upload",
 				"etag": "8cc1b07ae7781f03cbe493dc7022547d",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1533845834/clients/grandrapids/_OD_0202_5158e4ad-b768-415f-8402-e250b97c1c58.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1533845834/clients/grandrapids/_OD_0202_5158e4ad-b768-415f-8402-e250b97c1c58.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1533845834/clients/grandrapids/_OD_0202_5158e4ad-b768-415f-8402-e250b97c1c58.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -13161,7 +13161,7 @@
 				"type": "upload",
 				"etag": "14637b0c6f287b983c6f73be13981def",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1544108225/clients/grandrapids/042_3_8995_jpeg_dc53138c-6844-40cf-bb70-cc2f9a2a86a4.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1544108225/clients/grandrapids/042_3_8995_jpeg_dc53138c-6844-40cf-bb70-cc2f9a2a86a4.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1544108225/clients/grandrapids/042_3_8995_jpeg_dc53138c-6844-40cf-bb70-cc2f9a2a86a4.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -13251,7 +13251,7 @@
 				"bytes": 1563538,
 				"type": "upload",
 				"etag": "fc2bb05bbb0fcb1c70a9869ab62433da",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436816736/clients/grandrapids/BettyFord_fec29a62-c304-4a59-8c00-cb2095947de3.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436816736/clients/grandrapids/BettyFord_fec29a62-c304-4a59-8c00-cb2095947de3.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436816736/clients/grandrapids/BettyFord_fec29a62-c304-4a59-8c00-cb2095947de3.jpg",
 				"exif": {
 					"ApertureValue": "458752/65536",
@@ -13363,7 +13363,7 @@
 				"bytes": 3054831,
 				"type": "upload",
 				"etag": "f02c08bce8fbb03663b331e42d073913",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436978857/clients/grandrapids/Peaches_ec914a14-1432-42b6-a725-9326818a6d7a.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436978857/clients/grandrapids/Peaches_ec914a14-1432-42b6-a725-9326818a6d7a.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436978857/clients/grandrapids/Peaches_ec914a14-1432-42b6-a725-9326818a6d7a.jpg",
 				"exif": {
 					"ApertureValue": "95/32",
@@ -13469,7 +13469,7 @@
 				"bytes": 1773535,
 				"type": "upload",
 				"etag": "da297933e443bb08476d87400f3d4990",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436990499/clients/grandrapids/Gerald%20R.%20Ford%20Airport%2012_b6060e20-31c5-47fe-9741-c4ee3db1e699.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436990499/clients/grandrapids/Gerald%20R.%20Ford%20Airport%2012_b6060e20-31c5-47fe-9741-c4ee3db1e699.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436990499/clients/grandrapids/Gerald%20R.%20Ford%20Airport%2012_b6060e20-31c5-47fe-9741-c4ee3db1e699.jpg",
 				"exif": {
 					"ApertureValue": "5310704/1000000",
@@ -13575,7 +13575,7 @@
 				"bytes": 825076,
 				"type": "upload",
 				"etag": "397f610a64d6d1b7046d6ac08287f16d",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1438969525/clients/grandrapids/6C6A0203_c2c5304f-5ae8-4416-8f69-24600c3f6521.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1438969525/clients/grandrapids/6C6A0203_c2c5304f-5ae8-4416-8f69-24600c3f6521.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1438969525/clients/grandrapids/6C6A0203_c2c5304f-5ae8-4416-8f69-24600c3f6521.jpg",
 				"exif": {
 					"ApertureValue": "361471/100000",
@@ -13681,7 +13681,7 @@
 				"bytes": 183714,
 				"type": "upload",
 				"etag": "569415e4f01988f2cdf91b99f2d1d16c",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1439213693/clients/grandrapids/Nutcracker_2c859e18-5cb6-4a4e-a926-48a6ba3642ea.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1439213693/clients/grandrapids/Nutcracker_2c859e18-5cb6-4a4e-a926-48a6ba3642ea.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1439213693/clients/grandrapids/Nutcracker_2c859e18-5cb6-4a4e-a926-48a6ba3642ea.jpg",
 				"original_filename": "file"
 			},
@@ -13753,7 +13753,7 @@
 				"bytes": 3311584,
 				"type": "upload",
 				"etag": "0bb07e9177450986d4a5f933b9583e45",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1442414778/clients/grandrapids/Fall%20Downtown%20Skyline_9d7808b8-990e-4ae2-8bac-d8fb00ab0fb7.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1442414778/clients/grandrapids/Fall%20Downtown%20Skyline_9d7808b8-990e-4ae2-8bac-d8fb00ab0fb7.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1442414778/clients/grandrapids/Fall%20Downtown%20Skyline_9d7808b8-990e-4ae2-8bac-d8fb00ab0fb7.jpg",
 				"exif": {
 					"ApertureValue": "70777/10653",
@@ -13878,7 +13878,7 @@
 				"type": "upload",
 				"etag": "944af344025a622bb4686b24cbce0566",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1566571208/clients/grandrapids/042_3_9274_jpeg_7231a87b-4de9-4e32-95f7-3b820bdce774.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1566571208/clients/grandrapids/042_3_9274_jpeg_7231a87b-4de9-4e32-95f7-3b820bdce774.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1566571208/clients/grandrapids/042_3_9274_jpeg_7231a87b-4de9-4e32-95f7-3b820bdce774.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -13994,7 +13994,7 @@
 				"bytes": 27786,
 				"type": "upload",
 				"etag": "d857e4cc32029ac42ca646f9bc478cfd",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436900668/clients/grandrapids/Covered%20bridge%20in%20Ada_19c2ee0d-a43b-4aab-b102-65a0db32288b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436900668/clients/grandrapids/Covered%20bridge%20in%20Ada_19c2ee0d-a43b-4aab-b102-65a0db32288b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436900668/clients/grandrapids/Covered%20bridge%20in%20Ada_19c2ee0d-a43b-4aab-b102-65a0db32288b.jpg",
 				"original_filename": "file"
 			},
@@ -14063,7 +14063,7 @@
 				"bytes": 2237446,
 				"type": "upload",
 				"etag": "223d6fe121a90a550689dafa37b6a2ef",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1497973987/clients/grandrapids/Indian_Manhattan2_236abc9f-7278-4ff8-b2d3-d0533181c662.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1497973987/clients/grandrapids/Indian_Manhattan2_236abc9f-7278-4ff8-b2d3-d0533181c662.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1497973987/clients/grandrapids/Indian_Manhattan2_236abc9f-7278-4ff8-b2d3-d0533181c662.jpg",
 				"exif": {
 					"Artist": "Craig Vander Lende",
@@ -14170,7 +14170,7 @@
 				"bytes": 2631876,
 				"type": "upload",
 				"etag": "e6b62b6054ac3c3a5fc4471c028e3418",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
 				"original_filename": "file"
 			},
@@ -14236,7 +14236,7 @@
 				"bytes": 1019119,
 				"type": "upload",
 				"etag": "ee5a8667aba6b20f95a96b07e4e8aa85",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1485786327/clients/grandrapids/Lyman_Parks_1_c9f87bb7-4e75-45dc-a04d-884e68b4f1f6.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1485786327/clients/grandrapids/Lyman_Parks_1_c9f87bb7-4e75-45dc-a04d-884e68b4f1f6.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1485786327/clients/grandrapids/Lyman_Parks_1_c9f87bb7-4e75-45dc-a04d-884e68b4f1f6.jpg",
 				"exif": {
 					"ApertureValue": "7892/3469",
@@ -14363,7 +14363,7 @@
 				"bytes": 20524249,
 				"type": "upload",
 				"etag": "78f98a801476a6ae9cabc72bc4a551bc",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1488398201/clients/grandrapids/PorcleianCube2_Andy_Terzes_e9b4e668-5eb1-4928-a247-40d8f49bc385.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1488398201/clients/grandrapids/PorcleianCube2_Andy_Terzes_e9b4e668-5eb1-4928-a247-40d8f49bc385.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1488398201/clients/grandrapids/PorcleianCube2_Andy_Terzes_e9b4e668-5eb1-4928-a247-40d8f49bc385.jpg",
 				"exif": {
 					"ApertureValue": "4970854/1000000",
@@ -14479,7 +14479,7 @@
 				"type": "upload",
 				"etag": "7a6339f0907a29fa57fbd1365bf6245c",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1554141680/clients/grandrapids/RW_2019_Logo_e62db1c2-f41c-4a38-b3ed-5d5822cdef8b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1554141680/clients/grandrapids/RW_2019_Logo_e62db1c2-f41c-4a38-b3ed-5d5822cdef8b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1554141680/clients/grandrapids/RW_2019_Logo_e62db1c2-f41c-4a38-b3ed-5d5822cdef8b.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -14561,7 +14561,7 @@
 				"type": "upload",
 				"etag": "3fa591a1098f16ead5e4fd729cb6680c",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565899761/clients/grandrapids/042_3_9270_jpeg_9b999920-d866-48b6-9ee1-38de27eb4d40.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565899761/clients/grandrapids/042_3_9270_jpeg_9b999920-d866-48b6-9ee1-38de27eb4d40.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565899761/clients/grandrapids/042_3_9270_jpeg_9b999920-d866-48b6-9ee1-38de27eb4d40.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -14682,7 +14682,7 @@
 				"type": "upload",
 				"etag": "4932f36512fe5967a068bcb03a72dd5e",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1511295761/clients/grandrapids/6C6A5150_118c2880-bc73-4e75-b2d0-5053464e573e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1511295761/clients/grandrapids/6C6A5150_118c2880-bc73-4e75-b2d0-5053464e573e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1511295761/clients/grandrapids/6C6A5150_118c2880-bc73-4e75-b2d0-5053464e573e.jpg",
 				"exif": {
 					"ApertureValue": "2970854/1000000",
@@ -14791,7 +14791,7 @@
 				"type": "upload",
 				"etag": "71449075aa09e6f09f8e5fd08149f3a1",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1517866654/clients/grandrapids/7c6e6b80_8e1f_4954_914f_841b7a8c9ab5_398cf605-5245-4ce4-a880-b1ad5679a189.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1517866654/clients/grandrapids/7c6e6b80_8e1f_4954_914f_841b7a8c9ab5_398cf605-5245-4ce4-a880-b1ad5679a189.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1517866654/clients/grandrapids/7c6e6b80_8e1f_4954_914f_841b7a8c9ab5_398cf605-5245-4ce4-a880-b1ad5679a189.png",
 				"access_mode": "public",
 				"original_filename": "7c6e6b80-8e1f-4954-914f-841b7a8c9ab5"
@@ -14841,7 +14841,7 @@
 				"type": "upload",
 				"etag": "273af0a602c783988b15179af03f6656",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1512663316/clients/grandrapids/042_3_8772_jpeg_07106bda-5785-4713-a194-d72bcc2a8751.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1512663316/clients/grandrapids/042_3_8772_jpeg_07106bda-5785-4713-a194-d72bcc2a8751.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1512663316/clients/grandrapids/042_3_8772_jpeg_07106bda-5785-4713-a194-d72bcc2a8751.jpg",
 				"exif": {
 					"Artist": "Craig Vander Lende",
@@ -14952,7 +14952,7 @@
 				"type": "upload",
 				"etag": "c12095dc91ede4263c11665b6b5e49af",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1534864034/clients/grandrapids/DiscoverTourism_Student_3a38f008-9a4d-4748-ad48-433738e5a500.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1534864034/clients/grandrapids/DiscoverTourism_Student_3a38f008-9a4d-4748-ad48-433738e5a500.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1534864034/clients/grandrapids/DiscoverTourism_Student_3a38f008-9a4d-4748-ad48-433738e5a500.png",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -14996,7 +14996,7 @@
 				"type": "upload",
 				"etag": "234fa0364030ba200eec47a4c8eadb9b",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1533846155/clients/grandrapids/_OD_0141_20c7004f-c955-47c1-a99b-32b6e8dd3afa.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1533846155/clients/grandrapids/_OD_0141_20c7004f-c955-47c1-a99b-32b6e8dd3afa.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1533846155/clients/grandrapids/_OD_0141_20c7004f-c955-47c1-a99b-32b6e8dd3afa.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -15105,7 +15105,7 @@
 				"type": "upload",
 				"etag": "da037bbc6e6c3ec4af2e01ed088a115f",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1535136514/clients/grandrapids/DiscoverTourism_Home_7c3502a7-924e-4bbd-9fd7-dd30ad17553f.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1535136514/clients/grandrapids/DiscoverTourism_Home_7c3502a7-924e-4bbd-9fd7-dd30ad17553f.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1535136514/clients/grandrapids/DiscoverTourism_Home_7c3502a7-924e-4bbd-9fd7-dd30ad17553f.png",
 				"access_mode": "public",
 				"original_filename": "file",
@@ -15148,7 +15148,7 @@
 				"type": "upload",
 				"etag": "da037bbc6e6c3ec4af2e01ed088a115f",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1535136514/clients/grandrapids/DiscoverTourism_Home_7c3502a7-924e-4bbd-9fd7-dd30ad17553f.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1535136514/clients/grandrapids/DiscoverTourism_Home_7c3502a7-924e-4bbd-9fd7-dd30ad17553f.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1535136514/clients/grandrapids/DiscoverTourism_Home_7c3502a7-924e-4bbd-9fd7-dd30ad17553f.png",
 				"access_mode": "public",
 				"original_filename": "file",
@@ -15209,7 +15209,7 @@
 				"type": "upload",
 				"etag": "c141e1c27c66d976336fb0c7d814c44c",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1535136595/clients/grandrapids/DiscoverTourism_Trip_bea22d23-7494-47c8-88e2-5220b66d1d2d.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1535136595/clients/grandrapids/DiscoverTourism_Trip_bea22d23-7494-47c8-88e2-5220b66d1d2d.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1535136595/clients/grandrapids/DiscoverTourism_Trip_bea22d23-7494-47c8-88e2-5220b66d1d2d.png",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -15252,7 +15252,7 @@
 				"type": "upload",
 				"etag": "a8ada6b63215deae7e52f9c36ee09395",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1532010470/clients/grandrapids/JSDShoot_6_98df969e-da2c-4a25-86d0-ce1e1e20eec3.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1532010470/clients/grandrapids/JSDShoot_6_98df969e-da2c-4a25-86d0-ce1e1e20eec3.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1532010470/clients/grandrapids/JSDShoot_6_98df969e-da2c-4a25-86d0-ce1e1e20eec3.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -15372,7 +15372,7 @@
 				"type": "upload",
 				"etag": "666083a84c1c0630bac8422afafda45a",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1511362089/clients/grandrapids/042_3_8795_jpeg_76a9abf3-ee41-4aae-a671-1d28c18c8c14.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1511362089/clients/grandrapids/042_3_8795_jpeg_76a9abf3-ee41-4aae-a671-1d28c18c8c14.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1511362089/clients/grandrapids/042_3_8795_jpeg_76a9abf3-ee41-4aae-a671-1d28c18c8c14.jpg",
 				"exif": {
 					"ApertureValue": "4970854/1000000",
@@ -15474,7 +15474,7 @@
 				"bytes": 795018,
 				"type": "upload",
 				"etag": "2452266bcc922dea0b8b02dcb1c8d964",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436817386/clients/grandrapids/President_Ford_4dfd3f8d-7193-4cf6-81ca-e1572d1ec1f7.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436817386/clients/grandrapids/President_Ford_4dfd3f8d-7193-4cf6-81ca-e1572d1ec1f7.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436817386/clients/grandrapids/President_Ford_4dfd3f8d-7193-4cf6-81ca-e1572d1ec1f7.jpg",
 				"original_filename": "file"
 			},
@@ -15538,7 +15538,7 @@
 				"bytes": 1773535,
 				"type": "upload",
 				"etag": "da297933e443bb08476d87400f3d4990",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436990499/clients/grandrapids/Gerald%20R.%20Ford%20Airport%2012_b6060e20-31c5-47fe-9741-c4ee3db1e699.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436990499/clients/grandrapids/Gerald%20R.%20Ford%20Airport%2012_b6060e20-31c5-47fe-9741-c4ee3db1e699.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436990499/clients/grandrapids/Gerald%20R.%20Ford%20Airport%2012_b6060e20-31c5-47fe-9741-c4ee3db1e699.jpg",
 				"exif": {
 					"ApertureValue": "5310704/1000000",
@@ -15645,7 +15645,7 @@
 				"bytes": 189840,
 				"type": "upload",
 				"etag": "1e5ec54fc8c5fc3198e76057dbb276bf",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436884171/clients/grandrapids/Meijer%20State%20Games%20VOlleyball_e1d6d71e-8b03-4c14-a9e5-fedd96b09055.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436884171/clients/grandrapids/Meijer%20State%20Games%20VOlleyball_e1d6d71e-8b03-4c14-a9e5-fedd96b09055.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436884171/clients/grandrapids/Meijer%20State%20Games%20VOlleyball_e1d6d71e-8b03-4c14-a9e5-fedd96b09055.jpg",
 				"original_filename": "file"
 			},
@@ -15704,7 +15704,7 @@
 				"type": "upload",
 				"etag": "eee1f8e712b21b75b9ecd54b1aa0641e",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1547219258/clients/grandrapids/042_3_8998_jpeg_e7ad5871-abd1-4d67-a18d-7bb88c3c42bb.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1547219258/clients/grandrapids/042_3_8998_jpeg_e7ad5871-abd1-4d67-a18d-7bb88c3c42bb.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1547219258/clients/grandrapids/042_3_8998_jpeg_e7ad5871-abd1-4d67-a18d-7bb88c3c42bb.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -15823,7 +15823,7 @@
 				"type": "upload",
 				"etag": "d81555a4ef16faca4b8b87beb7bc3ca4",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1535050413/clients/grandrapids/042_3_8835_jpeg_e613df65-21e6-48a9-ac79-2bede578fd66.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1535050413/clients/grandrapids/042_3_8835_jpeg_e613df65-21e6-48a9-ac79-2bede578fd66.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1535050413/clients/grandrapids/042_3_8835_jpeg_e613df65-21e6-48a9-ac79-2bede578fd66.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -15917,7 +15917,7 @@
 				"bytes": 477762,
 				"type": "upload",
 				"etag": "3ddc1bf72abe86fbbe31529da056ab34",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1455894441/clients/grandrapids/ArtOutdoor_BillboardLayout_Updated_adb00c45-e4f3-4bba-8f37-25ddf948363d.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1455894441/clients/grandrapids/ArtOutdoor_BillboardLayout_Updated_adb00c45-e4f3-4bba-8f37-25ddf948363d.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1455894441/clients/grandrapids/ArtOutdoor_BillboardLayout_Updated_adb00c45-e4f3-4bba-8f37-25ddf948363d.jpg",
 				"exif": {
 					"Artist": "James Ward",
@@ -15998,7 +15998,7 @@
 				"bytes": 14459002,
 				"type": "upload",
 				"etag": "81c4d157539de5f931e273905ee78619",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1470319832/clients/grandrapids/5214929812_91c3bcfb49_o_742b4ecd-d9dc-4b6c-a481-5ec3d3f8ab48.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1470319832/clients/grandrapids/5214929812_91c3bcfb49_o_742b4ecd-d9dc-4b6c-a481-5ec3d3f8ab48.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1470319832/clients/grandrapids/5214929812_91c3bcfb49_o_742b4ecd-d9dc-4b6c-a481-5ec3d3f8ab48.jpg",
 				"exif": {
 					"ApertureValue": "2956/995",
@@ -16109,7 +16109,7 @@
 				"bytes": 5038828,
 				"type": "upload",
 				"etag": "f294bd19987621e882a38c6753896277",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1499366248/clients/grandrapids/f66982b5_107f_4fd3_9519_fa3fbec3401c_82a6abd3-e005-49ab-a5c5-0e30c72d2b87.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1499366248/clients/grandrapids/f66982b5_107f_4fd3_9519_fa3fbec3401c_82a6abd3-e005-49ab-a5c5-0e30c72d2b87.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1499366248/clients/grandrapids/f66982b5_107f_4fd3_9519_fa3fbec3401c_82a6abd3-e005-49ab-a5c5-0e30c72d2b87.jpg",
 				"original_filename": "f66982b5-107f-4fd3-9519-fa3fbec3401c"
 			},
@@ -16174,7 +16174,7 @@
 				"type": "upload",
 				"etag": "271fd116eb9473664325a8b5c20f4741",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1531338577/clients/grandrapids/79ab4d4d_98f6_4fa3_b860_a6bf9e0816a3_a6aa80ae-85f4-4438-b450-753ec6e28012.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1531338577/clients/grandrapids/79ab4d4d_98f6_4fa3_b860_a6bf9e0816a3_a6aa80ae-85f4-4438-b450-753ec6e28012.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1531338577/clients/grandrapids/79ab4d4d_98f6_4fa3_b860_a6bf9e0816a3_a6aa80ae-85f4-4438-b450-753ec6e28012.jpg",
 				"access_mode": "public",
 				"original_filename": "79ab4d4d-98f6-4fa3-b860-a6bf9e0816a3"
@@ -16239,7 +16239,7 @@
 				"type": "upload",
 				"etag": "ffe60cea0288b676ee173d8a5ac3e838",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565901440/clients/grandrapids/042_3_9256_jpeg_63469fc1-87eb-4b90-8662-25974d7b3b5c.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565901440/clients/grandrapids/042_3_9256_jpeg_63469fc1-87eb-4b90-8662-25974d7b3b5c.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565901440/clients/grandrapids/042_3_9256_jpeg_63469fc1-87eb-4b90-8662-25974d7b3b5c.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -16363,7 +16363,7 @@
 				"type": "upload",
 				"etag": "58cb859a55a4dad2dd204735aeb6d776",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1539180088/clients/grandrapids/IMG_3735_e32de8bb-3fa5-4ddc-bbab-5c7731d17832.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1539180088/clients/grandrapids/IMG_3735_e32de8bb-3fa5-4ddc-bbab-5c7731d17832.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1539180088/clients/grandrapids/IMG_3735_e32de8bb-3fa5-4ddc-bbab-5c7731d17832.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -16469,7 +16469,7 @@
 				"type": "upload",
 				"etag": "7d390cfd92dc23024e6e8b298246b405",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1550863292/clients/grandrapids/042_3_9075_jpeg_245bf325-e5c6-413e-b15d-422aa8c459ce.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1550863292/clients/grandrapids/042_3_9075_jpeg_245bf325-e5c6-413e-b15d-422aa8c459ce.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1550863292/clients/grandrapids/042_3_9075_jpeg_245bf325-e5c6-413e-b15d-422aa8c459ce.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -16579,7 +16579,7 @@
 				"type": "upload",
 				"etag": "931bd0b152272dd88c63bcfac38c92a2",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1521127909/clients/grandrapids/The_Rapid_Exchange_large_5ed7eda6-19f0-4618-a06a-4c84df3ec596.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1521127909/clients/grandrapids/The_Rapid_Exchange_large_5ed7eda6-19f0-4618-a06a-4c84df3ec596.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1521127909/clients/grandrapids/The_Rapid_Exchange_large_5ed7eda6-19f0-4618-a06a-4c84df3ec596.png",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -16643,7 +16643,7 @@
 				"type": "upload",
 				"etag": "d36767772b01977ec25fff9adb98cb3b",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565921738/clients/grandrapids/042_3_9278_jpeg_4cd31a03-18a5-46a8-8219-0fb54b5cb150.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565921738/clients/grandrapids/042_3_9278_jpeg_4cd31a03-18a5-46a8-8219-0fb54b5cb150.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565921738/clients/grandrapids/042_3_9278_jpeg_4cd31a03-18a5-46a8-8219-0fb54b5cb150.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -16779,7 +16779,7 @@
 				"type": "upload",
 				"etag": "f362e8804d28893f0b4ff0b57bf6a14e",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565921655/clients/grandrapids/042_3_9321_jpeg_89c6027e-ee4d-4e6a-921f-3c032a8285f6.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565921655/clients/grandrapids/042_3_9321_jpeg_89c6027e-ee4d-4e6a-921f-3c032a8285f6.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565921655/clients/grandrapids/042_3_9321_jpeg_89c6027e-ee4d-4e6a-921f-3c032a8285f6.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -16906,7 +16906,7 @@
 				"type": "upload",
 				"etag": "6851f0c6e5d1c68b6b88f5035ff446f7",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565623649/clients/grandrapids/042_3_9253_jpeg_2b187f76-5ed9-4f69-9fc6-74b3adae6a7b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565623649/clients/grandrapids/042_3_9253_jpeg_2b187f76-5ed9-4f69-9fc6-74b3adae6a7b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565623649/clients/grandrapids/042_3_9253_jpeg_2b187f76-5ed9-4f69-9fc6-74b3adae6a7b.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -17016,7 +17016,7 @@
 				"bytes": 1423496,
 				"type": "upload",
 				"etag": "45b1cde1768b818859922fb97336cf25",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436556882/clients/grandrapids/ChefAngus-cooking-class_764614dc-bd1d-4e1e-850a-219513b516a7.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436556882/clients/grandrapids/ChefAngus-cooking-class_764614dc-bd1d-4e1e-850a-219513b516a7.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436556882/clients/grandrapids/ChefAngus-cooking-class_764614dc-bd1d-4e1e-850a-219513b516a7.jpg",
 				"exif": {
 					"ApertureValue": "5310704/1000000",
@@ -17128,7 +17128,7 @@
 				"bytes": 1725462,
 				"type": "upload",
 				"etag": "77e6659c17d8996620d8aa05f40ea29f",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1438024585/clients/grandrapids/CTA-Restaurant_37f9dbac-baf9-4f40-801b-fc6adaf61b18.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1438024585/clients/grandrapids/CTA-Restaurant_37f9dbac-baf9-4f40-801b-fc6adaf61b18.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1438024585/clients/grandrapids/CTA-Restaurant_37f9dbac-baf9-4f40-801b-fc6adaf61b18.jpg",
 				"exif": {
 					"ApertureValue": "5310704/1000000",
@@ -17235,7 +17235,7 @@
 				"bytes": 7799714,
 				"type": "upload",
 				"etag": "05436df08c27b4be6f22e6faf38dc504",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1444834863/clients/grandrapids/20150624_AGD0194_77527733-e5d9-49e0-9c39-c5102664ab01.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1444834863/clients/grandrapids/20150624_AGD0194_77527733-e5d9-49e0-9c39-c5102664ab01.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1444834863/clients/grandrapids/20150624_AGD0194_77527733-e5d9-49e0-9c39-c5102664ab01.jpg",
 				"exif": {
 					"ApertureValue": "2970854/1000000",
@@ -17365,7 +17365,7 @@
 				"bytes": 1592923,
 				"type": "upload",
 				"etag": "7b36f2bcf2c9444fc17bc54510f45f57",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1505919577/clients/grandrapids/ArtPrize2017_ecec9832-f0c8-48ae-a315-b108f5f1f9ed.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1505919577/clients/grandrapids/ArtPrize2017_ecec9832-f0c8-48ae-a315-b108f5f1f9ed.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1505919577/clients/grandrapids/ArtPrize2017_ecec9832-f0c8-48ae-a315-b108f5f1f9ed.png",
 				"original_filename": "file"
 			},
@@ -17410,7 +17410,7 @@
 				"bytes": 1618614,
 				"type": "upload",
 				"etag": "4e3f54fbb4a4d92a86014ae6ed790b2a",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1505919460/clients/grandrapids/ArtPrize17_c111f51c-1362-4f2a-98fb-ed4139d8ca09.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1505919460/clients/grandrapids/ArtPrize17_c111f51c-1362-4f2a-98fb-ed4139d8ca09.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1505919460/clients/grandrapids/ArtPrize17_c111f51c-1362-4f2a-98fb-ed4139d8ca09.png",
 				"original_filename": "file"
 			},
@@ -17490,7 +17490,7 @@
 				"type": "upload",
 				"etag": "6d7cd0a404f096833566272a68476134",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1547058720/clients/grandrapids/edit_DSC_0032_f234a589-b2cc-40f5-9a6e-5166eb64cf1e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1547058720/clients/grandrapids/edit_DSC_0032_f234a589-b2cc-40f5-9a6e-5166eb64cf1e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1547058720/clients/grandrapids/edit_DSC_0032_f234a589-b2cc-40f5-9a6e-5166eb64cf1e.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -17627,7 +17627,7 @@
 				"bytes": 100023,
 				"type": "upload",
 				"etag": "e2e1ad3eccb51666b6f4628aa2523c41",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1465829140/clients/grandrapids/lipdub_eb2304e4-e03d-4f7c-a23c-702ff3d3d93e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1465829140/clients/grandrapids/lipdub_eb2304e4-e03d-4f7c-a23c-702ff3d3d93e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1465829140/clients/grandrapids/lipdub_eb2304e4-e03d-4f7c-a23c-702ff3d3d93e.jpg",
 				"original_filename": "file"
 			},
@@ -17700,7 +17700,7 @@
 				"bytes": 5217850,
 				"type": "upload",
 				"etag": "42f3e9b941696640cc12beeac8c68f89",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1468616015/clients/grandrapids/ExpGR_Tours_Experience_Web_Banner_Image_9_e902429b-e14c-4173-8939-24819c9d360c.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1468616015/clients/grandrapids/ExpGR_Tours_Experience_Web_Banner_Image_9_e902429b-e14c-4173-8939-24819c9d360c.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1468616015/clients/grandrapids/ExpGR_Tours_Experience_Web_Banner_Image_9_e902429b-e14c-4173-8939-24819c9d360c.png",
 				"original_filename": "file"
 			},
@@ -17742,7 +17742,7 @@
 				"bytes": 18543793,
 				"type": "upload",
 				"etag": "9b5e43ef1eaa43d659834b2f6777e2bc",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1474050313/clients/grandrapids/06152016_ExGR_Wagner3082_75969927-915f-4327-9a9b-e6164b7dd88e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1474050313/clients/grandrapids/06152016_ExGR_Wagner3082_75969927-915f-4327-9a9b-e6164b7dd88e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1474050313/clients/grandrapids/06152016_ExGR_Wagner3082_75969927-915f-4327-9a9b-e6164b7dd88e.jpg",
 				"exif": {
 					"Compression": "6",
@@ -17832,7 +17832,7 @@
 				"type": "upload",
 				"etag": "023318d3ad5e2c4496b147a62363647b",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565901496/clients/grandrapids/042_3_9307_jpeg_96347986-03ef-4231-bf8b-b14e32e9ba7b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565901496/clients/grandrapids/042_3_9307_jpeg_96347986-03ef-4231-bf8b-b14e32e9ba7b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565901496/clients/grandrapids/042_3_9307_jpeg_96347986-03ef-4231-bf8b-b14e32e9ba7b.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -17957,7 +17957,7 @@
 				"bytes": 2655964,
 				"type": "upload",
 				"etag": "3bdbee4888d87b0bf7d60a5398120797",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1475608041/clients/grandrapids/042_3_0072_jpeg_431fd1d7-ff39-42e1-ae52-621bb4a83c3a.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1475608041/clients/grandrapids/042_3_0072_jpeg_431fd1d7-ff39-42e1-ae52-621bb4a83c3a.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1475608041/clients/grandrapids/042_3_0072_jpeg_431fd1d7-ff39-42e1-ae52-621bb4a83c3a.jpg",
 				"exif": {
 					"ApertureValue": "128/32",
@@ -18074,7 +18074,7 @@
 				"bytes": 10754655,
 				"type": "upload",
 				"etag": "b9c69c898cc6b3a631b7d9f195be8b8b",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1476823157/clients/grandrapids/042_3_7116_jpeg_6e5f5d16-5d0b-40f6-b03c-9115f7cd899e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1476823157/clients/grandrapids/042_3_7116_jpeg_6e5f5d16-5d0b-40f6-b03c-9115f7cd899e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1476823157/clients/grandrapids/042_3_7116_jpeg_6e5f5d16-5d0b-40f6-b03c-9115f7cd899e.jpg",
 				"exif": {
 					"ApertureValue": "5310704/1000000",
@@ -18188,7 +18188,7 @@
 				"bytes": 1530172,
 				"type": "upload",
 				"etag": "0bd50227b0cde4570f91ef81008b08bb",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1489505361/clients/grandrapids/WAVE_Ceremony_ba86a6fa-50c4-474d-9cf2-087b037861a1.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1489505361/clients/grandrapids/WAVE_Ceremony_ba86a6fa-50c4-474d-9cf2-087b037861a1.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1489505361/clients/grandrapids/WAVE_Ceremony_ba86a6fa-50c4-474d-9cf2-087b037861a1.jpg",
 				"exif": {
 					"ApertureValue": "2970854/1000000",
@@ -18296,7 +18296,7 @@
 				"type": "upload",
 				"etag": "8319ce7f91a9d4432577cb77edfc68b3",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1517431774/clients/grandrapids/ExpGr_Culture_Pass_2018_Web_Header_2801ce51-ac95-4da3-ae84-06f82af32755.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1517431774/clients/grandrapids/ExpGr_Culture_Pass_2018_Web_Header_2801ce51-ac95-4da3-ae84-06f82af32755.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1517431774/clients/grandrapids/ExpGr_Culture_Pass_2018_Web_Header_2801ce51-ac95-4da3-ae84-06f82af32755.png",
 				"original_filename": "file"
 			},
@@ -18368,7 +18368,7 @@
 				"type": "upload",
 				"etag": "6aceb1556c53bfb932180101def77182",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1528812545/clients/grandrapids/ExperienceGR_2017_1890_hi_aa37af89-f87f-4826-9265-f4a465beade6.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1528812545/clients/grandrapids/ExperienceGR_2017_1890_hi_aa37af89-f87f-4826-9265-f4a465beade6.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1528812545/clients/grandrapids/ExperienceGR_2017_1890_hi_aa37af89-f87f-4826-9265-f4a465beade6.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -18467,7 +18467,7 @@
 				"type": "upload",
 				"etag": "f94cbaece65fcee36cc87f94d40516b3",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1534864647/clients/grandrapids/DiscoverTourism_Atlanta_511aaead-11d9-4d37-8aac-321f25a34d41.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1534864647/clients/grandrapids/DiscoverTourism_Atlanta_511aaead-11d9-4d37-8aac-321f25a34d41.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1534864647/clients/grandrapids/DiscoverTourism_Atlanta_511aaead-11d9-4d37-8aac-321f25a34d41.png",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -18510,7 +18510,7 @@
 				"type": "upload",
 				"etag": "8e87772520efe3bae7da602122c33717",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1534864713/clients/grandrapids/042_3_8788_jpeg_0bb413ba-d82e-4d44-be7c-de4b03c14285.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1534864713/clients/grandrapids/042_3_8788_jpeg_0bb413ba-d82e-4d44-be7c-de4b03c14285.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1534864713/clients/grandrapids/042_3_8788_jpeg_0bb413ba-d82e-4d44-be7c-de4b03c14285.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -18641,7 +18641,7 @@
 				"bytes": 13912900,
 				"type": "upload",
 				"etag": "75930ce57860df6a762df97e8ababe89",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1500669527/clients/grandrapids/IMG_5406_204405b2-2987-4213-8acf-3cd9b02d8d2d.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1500669527/clients/grandrapids/IMG_5406_204405b2-2987-4213-8acf-3cd9b02d8d2d.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1500669527/clients/grandrapids/IMG_5406_204405b2-2987-4213-8acf-3cd9b02d8d2d.jpg",
 				"exif": {
 					"ApertureValue": "1695994/1000000",
@@ -18752,7 +18752,7 @@
 				"type": "upload",
 				"etag": "76ef98b04bea60fda4434bdbc58434fa",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565921534/clients/grandrapids/042_3_9317_jpeg_1e5c86fe-e45d-4af8-8889-290b64bd72ba.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565921534/clients/grandrapids/042_3_9317_jpeg_1e5c86fe-e45d-4af8-8889-290b64bd72ba.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565921534/clients/grandrapids/042_3_9317_jpeg_1e5c86fe-e45d-4af8-8889-290b64bd72ba.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -18876,7 +18876,7 @@
 				"bytes": 1423496,
 				"type": "upload",
 				"etag": "45b1cde1768b818859922fb97336cf25",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436556882/clients/grandrapids/ChefAngus-cooking-class_764614dc-bd1d-4e1e-850a-219513b516a7.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436556882/clients/grandrapids/ChefAngus-cooking-class_764614dc-bd1d-4e1e-850a-219513b516a7.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436556882/clients/grandrapids/ChefAngus-cooking-class_764614dc-bd1d-4e1e-850a-219513b516a7.jpg",
 				"exif": {
 					"ApertureValue": "5310704/1000000",
@@ -18992,7 +18992,7 @@
 				"bytes": 571264,
 				"type": "upload",
 				"etag": "226f6d8ea45964a398768e63c22cbc28",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1453231084/clients/grandrapids/Neighborhood_Downtown_Web_Header_1c27c2f0-167a-4232-8f9e-52bd12231750.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1453231084/clients/grandrapids/Neighborhood_Downtown_Web_Header_1c27c2f0-167a-4232-8f9e-52bd12231750.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1453231084/clients/grandrapids/Neighborhood_Downtown_Web_Header_1c27c2f0-167a-4232-8f9e-52bd12231750.png",
 				"original_filename": "file"
 			},
@@ -19053,7 +19053,7 @@
 				"bytes": 1174824,
 				"type": "upload",
 				"etag": "5b03a8191ade94fb2f5990fad13f2e35",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435688653/clients/grandrapids/Anna%20H%20Eggs%20Benedict_f8959a46-5189-4cf7-b28c-860089889232.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435688653/clients/grandrapids/Anna%20H%20Eggs%20Benedict_f8959a46-5189-4cf7-b28c-860089889232.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435688653/clients/grandrapids/Anna%20H%20Eggs%20Benedict_f8959a46-5189-4cf7-b28c-860089889232.jpg",
 				"original_filename": "file"
 			},
@@ -19121,7 +19121,7 @@
 				"bytes": 369628,
 				"type": "upload",
 				"etag": "33de386f8ea29983f9d33bb1a90448f1",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1455551336/clients/grandrapids/cool_brews_hot_eats_40478196-9c9a-42d0-960b-a9be32f85256.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1455551336/clients/grandrapids/cool_brews_hot_eats_40478196-9c9a-42d0-960b-a9be32f85256.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1455551336/clients/grandrapids/cool_brews_hot_eats_40478196-9c9a-42d0-960b-a9be32f85256.jpg",
 				"exif": {
 					"BitsPerSample": "8, 8, 8",
@@ -19215,7 +19215,7 @@
 				"bytes": 84671,
 				"type": "upload",
 				"etag": "572ebd211a89dc028f14957fb98b9057",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1439001994/clients/grandrapids/TangerKate_e1c51eb8-638f-4de0-9376-739f7bd83f46.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1439001994/clients/grandrapids/TangerKate_e1c51eb8-638f-4de0-9376-739f7bd83f46.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1439001994/clients/grandrapids/TangerKate_e1c51eb8-638f-4de0-9376-739f7bd83f46.jpg",
 				"original_filename": "file"
 			},
@@ -19282,7 +19282,7 @@
 				"bytes": 26818350,
 				"type": "upload",
 				"etag": "6e3b6635267481f7ebdea5372e898b25",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1475856436/clients/grandrapids/ExpGR_fambition_BrianKellyPhoto_0019_bb8f4eda-5eea-404d-b91b-93f56505a024.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1475856436/clients/grandrapids/ExpGR_fambition_BrianKellyPhoto_0019_bb8f4eda-5eea-404d-b91b-93f56505a024.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1475856436/clients/grandrapids/ExpGR_fambition_BrianKellyPhoto_0019_bb8f4eda-5eea-404d-b91b-93f56505a024.jpg",
 				"exif": {
 					"Artist": "Brian Kelly",
@@ -19365,7 +19365,7 @@
 				"bytes": 2256260,
 				"type": "upload",
 				"etag": "60489d7a14af8f1d634329432299359b",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1489505703/clients/grandrapids/WAVE_Sponors_767ff71d-c1b9-420b-9fd5-e4a7edb298fc.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1489505703/clients/grandrapids/WAVE_Sponors_767ff71d-c1b9-420b-9fd5-e4a7edb298fc.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1489505703/clients/grandrapids/WAVE_Sponors_767ff71d-c1b9-420b-9fd5-e4a7edb298fc.jpg",
 				"exif": {
 					"ApertureValue": "2970854/1000000",
@@ -19473,7 +19473,7 @@
 				"bytes": 7177073,
 				"type": "upload",
 				"etag": "a70319383661b4660cded106d3cbe5b7",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1493219092/clients/grandrapids/042_3_8748_jpeg_b2fed17f-ed97-4ce9-9cfe-91e56e76d689.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1493219092/clients/grandrapids/042_3_8748_jpeg_b2fed17f-ed97-4ce9-9cfe-91e56e76d689.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1493219092/clients/grandrapids/042_3_8748_jpeg_b2fed17f-ed97-4ce9-9cfe-91e56e76d689.jpg",
 				"exif": {
 					"ApertureValue": "2970854/1000000",
@@ -19581,7 +19581,7 @@
 				"bytes": 90543,
 				"type": "upload",
 				"etag": "9a4ae35400043ead7521f618972a9e89",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1503520728/clients/grandrapids/header_9971b5b9-822c-4c62-99e6-d1b1c0c3d726.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1503520728/clients/grandrapids/header_9971b5b9-822c-4c62-99e6-d1b1c0c3d726.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1503520728/clients/grandrapids/header_9971b5b9-822c-4c62-99e6-d1b1c0c3d726.png",
 				"original_filename": "file"
 			},
@@ -19647,7 +19647,7 @@
 				"type": "upload",
 				"etag": "d521132162c3d192eb425849929188e9",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1522868839/clients/grandrapids/042_3_8804_jpeg_5a897dd2-8f30-4b93-ad16-2e683f0064b2.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1522868839/clients/grandrapids/042_3_8804_jpeg_5a897dd2-8f30-4b93-ad16-2e683f0064b2.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1522868839/clients/grandrapids/042_3_8804_jpeg_5a897dd2-8f30-4b93-ad16-2e683f0064b2.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -19747,7 +19747,7 @@
 				"type": "upload",
 				"etag": "8cc1b07ae7781f03cbe493dc7022547d",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1533845834/clients/grandrapids/_OD_0202_5158e4ad-b768-415f-8402-e250b97c1c58.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1533845834/clients/grandrapids/_OD_0202_5158e4ad-b768-415f-8402-e250b97c1c58.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1533845834/clients/grandrapids/_OD_0202_5158e4ad-b768-415f-8402-e250b97c1c58.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -19856,7 +19856,7 @@
 				"type": "upload",
 				"etag": "0a867cbc7e40c5e00fbd0137cb92de23",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565921390/clients/grandrapids/042_3_9311_jpeg_7517c515-b1cc-4b5c-ac4f-8fcc4056bf9e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565921390/clients/grandrapids/042_3_9311_jpeg_7517c515-b1cc-4b5c-ac4f-8fcc4056bf9e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565921390/clients/grandrapids/042_3_9311_jpeg_7517c515-b1cc-4b5c-ac4f-8fcc4056bf9e.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -19979,7 +19979,7 @@
 				"type": "upload",
 				"etag": "253b7fcba66ab9c92fb9d674d152d51f",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565901721/clients/grandrapids/042_3_9303_jpeg_30228966-9155-4e9c-b5aa-7bd49ef6eeb4.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565901721/clients/grandrapids/042_3_9303_jpeg_30228966-9155-4e9c-b5aa-7bd49ef6eeb4.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565901721/clients/grandrapids/042_3_9303_jpeg_30228966-9155-4e9c-b5aa-7bd49ef6eeb4.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -20100,7 +20100,7 @@
 				"bytes": 2325745,
 				"type": "upload",
 				"etag": "8ca7273d96f40d5afb36e7eebdf8883a",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1437491636/clients/grandrapids/DeltaPlex_92b86820-4f40-43e8-a984-c884ae7f83aa.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1437491636/clients/grandrapids/DeltaPlex_92b86820-4f40-43e8-a984-c884ae7f83aa.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1437491636/clients/grandrapids/DeltaPlex_92b86820-4f40-43e8-a984-c884ae7f83aa.jpg",
 				"exif": {
 					"ApertureValue": "393216/65536",
@@ -20227,7 +20227,7 @@
 				"bytes": 2763128,
 				"type": "upload",
 				"etag": "a482fc68245f8dfc2429ed494f9d5ac0",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1437494178/clients/grandrapids/JapaneseGarden_ec6b409e-cd53-4dcb-ab6f-fc308454d256.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1437494178/clients/grandrapids/JapaneseGarden_ec6b409e-cd53-4dcb-ab6f-fc308454d256.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1437494178/clients/grandrapids/JapaneseGarden_ec6b409e-cd53-4dcb-ab6f-fc308454d256.jpg",
 				"exif": {
 					"ApertureValue": "286720/65536",
@@ -20344,7 +20344,7 @@
 				"type": "upload",
 				"etag": "b521a01ef17b10ed6a8d2111201d0aaf",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1513264307/clients/grandrapids/Experience_Pink_a0f73fd3-e919-4cde-8a89-f8b3d832f065.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1513264307/clients/grandrapids/Experience_Pink_a0f73fd3-e919-4cde-8a89-f8b3d832f065.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1513264307/clients/grandrapids/Experience_Pink_a0f73fd3-e919-4cde-8a89-f8b3d832f065.png",
 				"original_filename": "file"
 			},
@@ -20406,7 +20406,7 @@
 				"bytes": 1023109,
 				"type": "upload",
 				"etag": "1a4b4f1d781ee7019c45236140784ec7",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1457455306/clients/grandrapids/Butterflies_are_Blooming_302c22d5-42c7-4d90-946d-4af33ff94b13.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1457455306/clients/grandrapids/Butterflies_are_Blooming_302c22d5-42c7-4d90-946d-4af33ff94b13.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1457455306/clients/grandrapids/Butterflies_are_Blooming_302c22d5-42c7-4d90-946d-4af33ff94b13.jpg",
 				"exif": {
 					"ApertureValue": "4643856/1000000",
@@ -20544,7 +20544,7 @@
 				"type": "upload",
 				"etag": "0d07657ba8669a8a664759dbb616e2dd",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1523375250/clients/grandrapids/GRX_3188_2cb44dac-3f99-401f-83ca-48b153004914.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1523375250/clients/grandrapids/GRX_3188_2cb44dac-3f99-401f-83ca-48b153004914.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1523375250/clients/grandrapids/GRX_3188_2cb44dac-3f99-401f-83ca-48b153004914.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -20679,7 +20679,7 @@
 				"bytes": 17799100,
 				"type": "upload",
 				"etag": "045e471bc25672226e97dbc858ccceef",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1466705886/clients/grandrapids/05162016_ExGR2199_21766461-2e65-439b-802e-9dd2054f18ab.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1466705886/clients/grandrapids/05162016_ExGR2199_21766461-2e65-439b-802e-9dd2054f18ab.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1466705886/clients/grandrapids/05162016_ExGR2199_21766461-2e65-439b-802e-9dd2054f18ab.jpg",
 				"exif": {
 					"Compression": "6",
@@ -20757,7 +20757,7 @@
 				"type": "upload",
 				"etag": "f2635367fdd2f82d5e3b342ec814341c",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1516373618/clients/grandrapids/IMG_2924_dcfe71ac-2f6f-4a02-88b0-8f46287c747b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1516373618/clients/grandrapids/IMG_2924_dcfe71ac-2f6f-4a02-88b0-8f46287c747b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1516373618/clients/grandrapids/IMG_2924_dcfe71ac-2f6f-4a02-88b0-8f46287c747b.jpg",
 				"exif": {
 					"ApertureValue": "433985/100000",
@@ -20861,7 +20861,7 @@
 				"type": "upload",
 				"etag": "7a15acdc797dd07d52d68712feda7cbd",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1548724361/clients/grandrapids/Beer_Month_69aa727a-6fb2-44d8-af51-03de96d52603.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1548724361/clients/grandrapids/Beer_Month_69aa727a-6fb2-44d8-af51-03de96d52603.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1548724361/clients/grandrapids/Beer_Month_69aa727a-6fb2-44d8-af51-03de96d52603.png",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -20909,7 +20909,7 @@
 				"type": "upload",
 				"etag": "a812df51b03e306def7df6fb045169bf",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1547151986/clients/grandrapids/BeerMonthnologo_46e2cb22-31ad-4412-a335-5c284c2eed3d.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1547151986/clients/grandrapids/BeerMonthnologo_46e2cb22-31ad-4412-a335-5c284c2eed3d.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1547151986/clients/grandrapids/BeerMonthnologo_46e2cb22-31ad-4412-a335-5c284c2eed3d.png",
 				"access_mode": "public",
 				"original_filename": "file",
@@ -20985,7 +20985,7 @@
 				"bytes": 8263317,
 				"type": "upload",
 				"etag": "be7825140a3ed1269b74e3df25f912b4",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1481214146/clients/grandrapids/Ice_Skating_Rosa_Park_Circle_28b31049-f3e8-4d9a-876c-65b1c130599f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1481214146/clients/grandrapids/Ice_Skating_Rosa_Park_Circle_28b31049-f3e8-4d9a-876c-65b1c130599f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1481214146/clients/grandrapids/Ice_Skating_Rosa_Park_Circle_28b31049-f3e8-4d9a-876c-65b1c130599f.jpg",
 				"exif": {
 					"ApertureValue": "4/1",
@@ -21098,7 +21098,7 @@
 				"bytes": 13439012,
 				"type": "upload",
 				"etag": "f0de459136179a12a1a3e0501623b78c",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1496173188/clients/grandrapids/042_3_8759_jpeg_f93130d0-9f66-463e-a6e7-250586bf8c1c.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1496173188/clients/grandrapids/042_3_8759_jpeg_f93130d0-9f66-463e-a6e7-250586bf8c1c.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1496173188/clients/grandrapids/042_3_8759_jpeg_f93130d0-9f66-463e-a6e7-250586bf8c1c.jpg",
 				"exif": {
 					"ExifImageLength": "4811",
@@ -21181,7 +21181,7 @@
 				"bytes": 17452672,
 				"type": "upload",
 				"etag": "b46fc42c7bdc1f596d6d2b96af715386",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1502392373/clients/grandrapids/042_3_7357_jpeg_e3d495d1-7b80-4637-a1d9-a9dad9b88715.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1502392373/clients/grandrapids/042_3_7357_jpeg_e3d495d1-7b80-4637-a1d9-a9dad9b88715.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1502392373/clients/grandrapids/042_3_7357_jpeg_e3d495d1-7b80-4637-a1d9-a9dad9b88715.jpg",
 				"exif": {
 					"ApertureValue": "4/1",
@@ -21292,7 +21292,7 @@
 				"type": "upload",
 				"etag": "331b7314ac1a60b44e61e0aa7bd89d98",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1509632876/clients/grandrapids/042_3_6411_jpeg_f1c9704a-73c4-4039-852d-b921088eea66.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1509632876/clients/grandrapids/042_3_6411_jpeg_f1c9704a-73c4-4039-852d-b921088eea66.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1509632876/clients/grandrapids/042_3_6411_jpeg_f1c9704a-73c4-4039-852d-b921088eea66.jpg",
 				"exif": {
 					"BitsPerSample": "8, 8, 8",
@@ -21376,7 +21376,7 @@
 				"type": "upload",
 				"etag": "2de3f2a8b2a37013654d25df1d640106",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1528829475/clients/grandrapids/ExperienceGR_2017_1433_hi_28fb23c4-f853-476c-9e5e-591399e627d2.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1528829475/clients/grandrapids/ExperienceGR_2017_1433_hi_28fb23c4-f853-476c-9e5e-591399e627d2.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1528829475/clients/grandrapids/ExperienceGR_2017_1433_hi_28fb23c4-f853-476c-9e5e-591399e627d2.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -21489,7 +21489,7 @@
 				"type": "upload",
 				"etag": "d258a821b71979a8bc05717d8e460d8a",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1538158830/clients/grandrapids/Lindsey_Blake_78_819cb5d7-62f4-44de-a0be-a23676c92384.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1538158830/clients/grandrapids/Lindsey_Blake_78_819cb5d7-62f4-44de-a0be-a23676c92384.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1538158830/clients/grandrapids/Lindsey_Blake_78_819cb5d7-62f4-44de-a0be-a23676c92384.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -21588,7 +21588,7 @@
 				"type": "upload",
 				"etag": "ec0259272c6f7012970c66329d70f8bd",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1561146980/clients/grandrapids/SummerInTheCity_2edf5dc5-0172-4471-a417-5bc72992b262.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1561146980/clients/grandrapids/SummerInTheCity_2edf5dc5-0172-4471-a417-5bc72992b262.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1561146980/clients/grandrapids/SummerInTheCity_2edf5dc5-0172-4471-a417-5bc72992b262.png",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -21647,7 +21647,7 @@
 				"type": "upload",
 				"etag": "ea8ecd0ea2002d556e343136eaf938f0",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565723493/clients/grandrapids/042_3_9325_jpeg_455ac3a3-cbfe-4eef-a968-3043386f6f95.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565723493/clients/grandrapids/042_3_9325_jpeg_455ac3a3-cbfe-4eef-a968-3043386f6f95.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565723493/clients/grandrapids/042_3_9325_jpeg_455ac3a3-cbfe-4eef-a968-3043386f6f95.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -21750,7 +21750,7 @@
 				"type": "upload",
 				"etag": "ea8ecd0ea2002d556e343136eaf938f0",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565723493/clients/grandrapids/042_3_9325_jpeg_455ac3a3-cbfe-4eef-a968-3043386f6f95.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565723493/clients/grandrapids/042_3_9325_jpeg_455ac3a3-cbfe-4eef-a968-3043386f6f95.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565723493/clients/grandrapids/042_3_9325_jpeg_455ac3a3-cbfe-4eef-a968-3043386f6f95.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -21872,7 +21872,7 @@
 				"type": "upload",
 				"etag": "fe31f4283deb8da11b7f0894166d9f97",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1519423187/clients/grandrapids/Kate_Herron_1a06bc67-5324-4e00-8ff1-d2cce84560b2.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1519423187/clients/grandrapids/Kate_Herron_1a06bc67-5324-4e00-8ff1-d2cce84560b2.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1519423187/clients/grandrapids/Kate_Herron_1a06bc67-5324-4e00-8ff1-d2cce84560b2.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -21984,7 +21984,7 @@
 				"type": "upload",
 				"etag": "ef723c8881db21868259e657ec631932",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565899333/clients/grandrapids/042_3_9259_jpeg_a6bad3d2-b734-4ed4-8744-81b28a8be6ef.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565899333/clients/grandrapids/042_3_9259_jpeg_a6bad3d2-b734-4ed4-8744-81b28a8be6ef.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565899333/clients/grandrapids/042_3_9259_jpeg_a6bad3d2-b734-4ed4-8744-81b28a8be6ef.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -22102,7 +22102,7 @@
 				"bytes": 1459790,
 				"type": "upload",
 				"etag": "127c8878f1096af226768ee9ca1d5f13",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1466626295/clients/grandrapids/mural_in_Grand_Rapids_0d3706d5-0158-4e17-96a6-68a364218fbb.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1466626295/clients/grandrapids/mural_in_Grand_Rapids_0d3706d5-0158-4e17-96a6-68a364218fbb.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1466626295/clients/grandrapids/mural_in_Grand_Rapids_0d3706d5-0158-4e17-96a6-68a364218fbb.jpg",
 				"exif": {
 					"ApertureValue": "6/1",
@@ -22213,7 +22213,7 @@
 				"bytes": 1207454,
 				"type": "upload",
 				"etag": "1613e71f1be78ce9eaec88df83d12bbb",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1437013891/clients/grandrapids/Grand%20Rapids%20Symphony%205_4ad0f5ae-7a60-465b-be47-3c5a8bbbb4a3.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1437013891/clients/grandrapids/Grand%20Rapids%20Symphony%205_4ad0f5ae-7a60-465b-be47-3c5a8bbbb4a3.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1437013891/clients/grandrapids/Grand%20Rapids%20Symphony%205_4ad0f5ae-7a60-465b-be47-3c5a8bbbb4a3.jpg",
 				"exif": {
 					"ApertureValue": "500/100",
@@ -22328,7 +22328,7 @@
 				"bytes": 1237164,
 				"type": "upload",
 				"etag": "25e2b0bb07b7903aefe00889850d291d",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1456345270/clients/grandrapids/kim_kajdan_7f50d56d-c4b5-4d07-b649-18cac41042ec.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1456345270/clients/grandrapids/kim_kajdan_7f50d56d-c4b5-4d07-b649-18cac41042ec.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1456345270/clients/grandrapids/kim_kajdan_7f50d56d-c4b5-4d07-b649-18cac41042ec.jpg",
 				"exif": {
 					"ApertureValue": "3356144/1000000",
@@ -22433,7 +22433,7 @@
 				"bytes": 636434,
 				"type": "upload",
 				"etag": "9b3a6776467f438664630de4ed4a18f5",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1478533875/clients/grandrapids/042_3_8470_jpeg_574ebc36-d239-4ef0-9cc5-e76b3596531c.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1478533875/clients/grandrapids/042_3_8470_jpeg_574ebc36-d239-4ef0-9cc5-e76b3596531c.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1478533875/clients/grandrapids/042_3_8470_jpeg_574ebc36-d239-4ef0-9cc5-e76b3596531c.jpg",
 				"exif": {
 					"ApertureValue": "4/1",
@@ -22541,7 +22541,7 @@
 				"bytes": 7317831,
 				"type": "upload",
 				"etag": "2a8f49fe03c5fd0b88027e13bea3dab8",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1476309174/clients/grandrapids/bertuzzi1666_4bc551db-2dfc-4144-bd04-c4844dd4a6a2.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1476309174/clients/grandrapids/bertuzzi1666_4bc551db-2dfc-4144-bd04-c4844dd4a6a2.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1476309174/clients/grandrapids/bertuzzi1666_4bc551db-2dfc-4144-bd04-c4844dd4a6a2.jpg",
 				"exif": {
 					"ApertureValue": "196608/65536",
@@ -22656,7 +22656,7 @@
 				"type": "upload",
 				"etag": "fd44126aedbecd5cf93c076e45453815",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1511272757/clients/grandrapids/ford_airport_expansive_shot_a015bcf9-d7aa-42c8-9848-cc785c33b575.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1511272757/clients/grandrapids/ford_airport_expansive_shot_a015bcf9-d7aa-42c8-9848-cc785c33b575.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1511272757/clients/grandrapids/ford_airport_expansive_shot_a015bcf9-d7aa-42c8-9848-cc785c33b575.jpg",
 				"exif": {
 					"Copyright": "Mark Andrus Photography"
@@ -22726,7 +22726,7 @@
 				"bytes": 402530,
 				"type": "upload",
 				"etag": "a0dfd590d82f791d7079f3adfe909bed",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1496937407/clients/grandrapids/Amway_Family_Fireworks_558bc019-7edb-4eb5-80da-6de02abc999c.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1496937407/clients/grandrapids/Amway_Family_Fireworks_558bc019-7edb-4eb5-80da-6de02abc999c.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1496937407/clients/grandrapids/Amway_Family_Fireworks_558bc019-7edb-4eb5-80da-6de02abc999c.jpg",
 				"exif": {
 					"ApertureValue": "6918863/1000000",
@@ -22840,7 +22840,7 @@
 				"type": "upload",
 				"etag": "d81bc6f54872c289ecdec2241da36ded",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1553792236/clients/grandrapids/Blog_header_2_d2ee0bb7-1fa4-45f0-8541-eadd0d6cd5e0.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1553792236/clients/grandrapids/Blog_header_2_d2ee0bb7-1fa4-45f0-8541-eadd0d6cd5e0.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1553792236/clients/grandrapids/Blog_header_2_d2ee0bb7-1fa4-45f0-8541-eadd0d6cd5e0.png",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -22908,7 +22908,7 @@
 				"type": "upload",
 				"etag": "2337ab7d911c45980fc26d3b6bd2b6ed",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565901673/clients/grandrapids/042_3_9304_jpeg_433f70d9-fab5-47c9-9079-dad8e7398c2d.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565901673/clients/grandrapids/042_3_9304_jpeg_433f70d9-fab5-47c9-9079-dad8e7398c2d.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565901673/clients/grandrapids/042_3_9304_jpeg_433f70d9-fab5-47c9-9079-dad8e7398c2d.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -23031,7 +23031,7 @@
 				"bytes": 855494,
 				"type": "upload",
 				"etag": "17a57e5ed03cda2220ab410d38cc5b19",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1456849149/clients/grandrapids/kim_rangel_1fdaa895-7eb8-426e-a975-5a4f3152e740.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1456849149/clients/grandrapids/kim_rangel_1fdaa895-7eb8-426e-a975-5a4f3152e740.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1456849149/clients/grandrapids/kim_rangel_1fdaa895-7eb8-426e-a975-5a4f3152e740.jpg",
 				"exif": {
 					"ApertureValue": "5310704/1000000",
@@ -23139,7 +23139,7 @@
 				"bytes": 11711140,
 				"type": "upload",
 				"etag": "22a714f6a04c176340cf4bfeb866a348",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1438969797/clients/grandrapids/6C6A6048_e445bf6b-368e-4714-863d-1fe307cfc1da.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1438969797/clients/grandrapids/6C6A6048_e445bf6b-368e-4714-863d-1fe307cfc1da.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1438969797/clients/grandrapids/6C6A6048_e445bf6b-368e-4714-863d-1fe307cfc1da.jpg",
 				"exif": {
 					"ApertureValue": "3356144/1000000",
@@ -23240,7 +23240,7 @@
 				"bytes": 1057838,
 				"type": "upload",
 				"etag": "14beef56cf9e00639f15c4b7756fcccc",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1439402812/clients/grandrapids/Upcoming%20Classes_51576e15-c416-4700-8e54-23c6d3a3e30a.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1439402812/clients/grandrapids/Upcoming%20Classes_51576e15-c416-4700-8e54-23c6d3a3e30a.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1439402812/clients/grandrapids/Upcoming%20Classes_51576e15-c416-4700-8e54-23c6d3a3e30a.jpg",
 				"exif": {
 					"ApertureValue": "128/32",
@@ -23354,7 +23354,7 @@
 				"bytes": 289588,
 				"type": "upload",
 				"etag": "8ee5a1740d9f19d568bba47d75b4be60",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1450368930/clients/grandrapids/Culture%20Pass_b7cf78fd-3244-4658-95a9-f393d5d60146.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1450368930/clients/grandrapids/Culture%20Pass_b7cf78fd-3244-4658-95a9-f393d5d60146.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1450368930/clients/grandrapids/Culture%20Pass_b7cf78fd-3244-4658-95a9-f393d5d60146.png",
 				"original_filename": "file"
 			},
@@ -23415,7 +23415,7 @@
 				"type": "upload",
 				"etag": "8e1213f48b34717a619c807824dc628b",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565901544/clients/grandrapids/042_3_9285_jpeg_a6556685-810d-48ea-996b-bba415de7cad.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565901544/clients/grandrapids/042_3_9285_jpeg_a6556685-810d-48ea-996b-bba415de7cad.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565901544/clients/grandrapids/042_3_9285_jpeg_a6556685-810d-48ea-996b-bba415de7cad.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -23532,7 +23532,7 @@
 				"bytes": 60304,
 				"type": "upload",
 				"etag": "c4419722ba3636614905c89c102f5ef1",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1469626647/clients/grandrapids/Website_header_a7083e8f-655c-4ddc-ace4-71365f2ee268.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1469626647/clients/grandrapids/Website_header_a7083e8f-655c-4ddc-ace4-71365f2ee268.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1469626647/clients/grandrapids/Website_header_a7083e8f-655c-4ddc-ace4-71365f2ee268.png",
 				"original_filename": "file"
 			},
@@ -23597,7 +23597,7 @@
 				"bytes": 6447218,
 				"type": "upload",
 				"etag": "7afd9c742389df0161305680e8ca1bfc",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1499356171/clients/grandrapids/042_3_8765_jpeg_ed920e3a-0ac7-4975-864e-cc14a5db32e4.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1499356171/clients/grandrapids/042_3_8765_jpeg_ed920e3a-0ac7-4975-864e-cc14a5db32e4.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1499356171/clients/grandrapids/042_3_8765_jpeg_ed920e3a-0ac7-4975-864e-cc14a5db32e4.jpg",
 				"exif": {
 					"Artist": "Craig Vander Lende",
@@ -23733,7 +23733,7 @@
 				"type": "upload",
 				"etag": "8f5447194c7e346af820783f0bef97d3",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1542822057/clients/grandrapids/98b704ae_67a2_4be3_9b6b_3f392faedf21_dfd157dc-7bab-47d0-a094-fde8bab89023.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1542822057/clients/grandrapids/98b704ae_67a2_4be3_9b6b_3f392faedf21_dfd157dc-7bab-47d0-a094-fde8bab89023.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1542822057/clients/grandrapids/98b704ae_67a2_4be3_9b6b_3f392faedf21_dfd157dc-7bab-47d0-a094-fde8bab89023.jpg",
 				"access_mode": "public",
 				"original_filename": "98b704ae-67a2-4be3-9b6b-3f392faedf21"
@@ -23808,7 +23808,7 @@
 				"bytes": 14112893,
 				"type": "upload",
 				"etag": "8e518182445e5403f87a349f2ffb8e1f",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1433365284/clients/grandrapids/Rockford-Downtown-SWalker-cropped_1dc50b64-981c-48b0-aac8-dd74dabf8cf4.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1433365284/clients/grandrapids/Rockford-Downtown-SWalker-cropped_1dc50b64-981c-48b0-aac8-dd74dabf8cf4.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1433365284/clients/grandrapids/Rockford-Downtown-SWalker-cropped_1dc50b64-981c-48b0-aac8-dd74dabf8cf4.jpg",
 				"original_filename": "file"
 			},
@@ -23864,7 +23864,7 @@
 				"bytes": 16347052,
 				"type": "upload",
 				"etag": "890ad85f662bdb0566c764ca6ee141cc",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1466706068/clients/grandrapids/05162016_ExGR2323_06e45e7a-36c4-4da1-bab2-b6077d61b8d8.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1466706068/clients/grandrapids/05162016_ExGR2323_06e45e7a-36c4-4da1-bab2-b6077d61b8d8.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1466706068/clients/grandrapids/05162016_ExGR2323_06e45e7a-36c4-4da1-bab2-b6077d61b8d8.jpg",
 				"exif": {
 					"Compression": "6",
@@ -23943,7 +23943,7 @@
 				"bytes": 3023265,
 				"type": "upload",
 				"etag": "896c634ebc0240a7094431d534ead100",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1495738235/clients/grandrapids/DeVos_Place_GG_Wolverine_20ddf7e9-47da-45bd-ad41-3d43e765c44f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1495738235/clients/grandrapids/DeVos_Place_GG_Wolverine_20ddf7e9-47da-45bd-ad41-3d43e765c44f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1495738235/clients/grandrapids/DeVos_Place_GG_Wolverine_20ddf7e9-47da-45bd-ad41-3d43e765c44f.jpg",
 				"exif": {
 					"ApertureValue": "153/100",
@@ -24086,7 +24086,7 @@
 				"bytes": 3023265,
 				"type": "upload",
 				"etag": "896c634ebc0240a7094431d534ead100",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1495738235/clients/grandrapids/DeVos_Place_GG_Wolverine_20ddf7e9-47da-45bd-ad41-3d43e765c44f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1495738235/clients/grandrapids/DeVos_Place_GG_Wolverine_20ddf7e9-47da-45bd-ad41-3d43e765c44f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1495738235/clients/grandrapids/DeVos_Place_GG_Wolverine_20ddf7e9-47da-45bd-ad41-3d43e765c44f.jpg",
 				"exif": {
 					"ApertureValue": "153/100",
@@ -24230,7 +24230,7 @@
 				"type": "upload",
 				"etag": "12412f8002d08453894e0e230409254b",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1520000961/clients/grandrapids/042_3_8790_jpeg_8afdfc6a-2cb5-4457-8847-c90794e17023.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1520000961/clients/grandrapids/042_3_8790_jpeg_8afdfc6a-2cb5-4457-8847-c90794e17023.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1520000961/clients/grandrapids/042_3_8790_jpeg_8afdfc6a-2cb5-4457-8847-c90794e17023.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -24319,7 +24319,7 @@
 				"type": "upload",
 				"etag": "12412f8002d08453894e0e230409254b",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1520000961/clients/grandrapids/042_3_8790_jpeg_8afdfc6a-2cb5-4457-8847-c90794e17023.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1520000961/clients/grandrapids/042_3_8790_jpeg_8afdfc6a-2cb5-4457-8847-c90794e17023.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1520000961/clients/grandrapids/042_3_8790_jpeg_8afdfc6a-2cb5-4457-8847-c90794e17023.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -24429,7 +24429,7 @@
 				"type": "upload",
 				"etag": "6bef7600499862759cab160d654b38dc",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1566419081/clients/grandrapids/042_3_9295_jpeg_8c07aa0d-f176-480c-adbc-cada2e85a985.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1566419081/clients/grandrapids/042_3_9295_jpeg_8c07aa0d-f176-480c-adbc-cada2e85a985.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1566419081/clients/grandrapids/042_3_9295_jpeg_8c07aa0d-f176-480c-adbc-cada2e85a985.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -24547,7 +24547,7 @@
 				"bytes": 6194949,
 				"type": "upload",
 				"etag": "ee44c24914e86fba5da58fa601493708",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1500648870/clients/grandrapids/BlueBridge_V2_1_cd6136c3-a15e-4ec5-a5b8-8f4a9c2b546c.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1500648870/clients/grandrapids/BlueBridge_V2_1_cd6136c3-a15e-4ec5-a5b8-8f4a9c2b546c.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1500648870/clients/grandrapids/BlueBridge_V2_1_cd6136c3-a15e-4ec5-a5b8-8f4a9c2b546c.jpg",
 				"exif": {
 					"ApertureValue": "5655638/1000000",
@@ -24671,7 +24671,7 @@
 				"type": "upload",
 				"etag": "cd2a8924354d1e2671fc0286d57f404e",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1511194356/clients/grandrapids/042_3_8796_jpeg_9403a636-91b7-4932-b492-d809e0412944.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1511194356/clients/grandrapids/042_3_8796_jpeg_9403a636-91b7-4932-b492-d809e0412944.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1511194356/clients/grandrapids/042_3_8796_jpeg_9403a636-91b7-4932-b492-d809e0412944.jpg",
 				"exif": {
 					"ApertureValue": "2970854/1000000",
@@ -24788,7 +24788,7 @@
 				"type": "upload",
 				"etag": "666083a84c1c0630bac8422afafda45a",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1511362089/clients/grandrapids/042_3_8795_jpeg_76a9abf3-ee41-4aae-a671-1d28c18c8c14.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1511362089/clients/grandrapids/042_3_8795_jpeg_76a9abf3-ee41-4aae-a671-1d28c18c8c14.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1511362089/clients/grandrapids/042_3_8795_jpeg_76a9abf3-ee41-4aae-a671-1d28c18c8c14.jpg",
 				"exif": {
 					"ApertureValue": "4970854/1000000",
@@ -24902,7 +24902,7 @@
 				"bytes": 8263317,
 				"type": "upload",
 				"etag": "be7825140a3ed1269b74e3df25f912b4",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1481214146/clients/grandrapids/Ice_Skating_Rosa_Park_Circle_28b31049-f3e8-4d9a-876c-65b1c130599f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1481214146/clients/grandrapids/Ice_Skating_Rosa_Park_Circle_28b31049-f3e8-4d9a-876c-65b1c130599f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1481214146/clients/grandrapids/Ice_Skating_Rosa_Park_Circle_28b31049-f3e8-4d9a-876c-65b1c130599f.jpg",
 				"exif": {
 					"ApertureValue": "4/1",
@@ -25007,7 +25007,7 @@
 				"bytes": 2722858,
 				"type": "upload",
 				"etag": "909239282033e2e68b19cb80d471899e",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1499873492/clients/grandrapids/ArtThrob_Stills_34_f1cbb334-311d-42c6-9fa0-f632153a5c81.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1499873492/clients/grandrapids/ArtThrob_Stills_34_f1cbb334-311d-42c6-9fa0-f632153a5c81.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1499873492/clients/grandrapids/ArtThrob_Stills_34_f1cbb334-311d-42c6-9fa0-f632153a5c81.jpg",
 				"exif": {
 					"Artist": "Brian Kelly",
@@ -25094,7 +25094,7 @@
 				"type": "upload",
 				"etag": "6851f0c6e5d1c68b6b88f5035ff446f7",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565623649/clients/grandrapids/042_3_9253_jpeg_2b187f76-5ed9-4f69-9fc6-74b3adae6a7b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565623649/clients/grandrapids/042_3_9253_jpeg_2b187f76-5ed9-4f69-9fc6-74b3adae6a7b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565623649/clients/grandrapids/042_3_9253_jpeg_2b187f76-5ed9-4f69-9fc6-74b3adae6a7b.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -25194,7 +25194,7 @@
 				"type": "upload",
 				"etag": "6851f0c6e5d1c68b6b88f5035ff446f7",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565623649/clients/grandrapids/042_3_9253_jpeg_2b187f76-5ed9-4f69-9fc6-74b3adae6a7b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565623649/clients/grandrapids/042_3_9253_jpeg_2b187f76-5ed9-4f69-9fc6-74b3adae6a7b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565623649/clients/grandrapids/042_3_9253_jpeg_2b187f76-5ed9-4f69-9fc6-74b3adae6a7b.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -25322,7 +25322,7 @@
 				"type": "upload",
 				"etag": "c4c8647114d9c4352ff915e9f28f41bf",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565901833/clients/grandrapids/042_3_9322_jpeg_5b6d6f72-579c-4e5d-b1d6-a9b0fac8de4e.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565901833/clients/grandrapids/042_3_9322_jpeg_5b6d6f72-579c-4e5d-b1d6-a9b0fac8de4e.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565901833/clients/grandrapids/042_3_9322_jpeg_5b6d6f72-579c-4e5d-b1d6-a9b0fac8de4e.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -25450,7 +25450,7 @@
 				"type": "upload",
 				"etag": "da701ce98938de096131508ff784ef9f",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565901795/clients/grandrapids/042_3_9289_jpeg_b3e744c0-85cf-447e-8380-f13009c906da.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565901795/clients/grandrapids/042_3_9289_jpeg_b3e744c0-85cf-447e-8380-f13009c906da.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565901795/clients/grandrapids/042_3_9289_jpeg_b3e744c0-85cf-447e-8380-f13009c906da.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -25569,7 +25569,7 @@
 				"bytes": 2848930,
 				"type": "upload",
 				"etag": "035c41c9b4853cbd667714f87a271eb8",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1435688099/clients/grandrapids/King%20Tut_7ccd9ce9-1d02-48ef-ba77-2a6f2640889f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1435688099/clients/grandrapids/King%20Tut_7ccd9ce9-1d02-48ef-ba77-2a6f2640889f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1435688099/clients/grandrapids/King%20Tut_7ccd9ce9-1d02-48ef-ba77-2a6f2640889f.jpg",
 				"original_filename": "file"
 			},
@@ -25638,7 +25638,7 @@
 				"bytes": 150125,
 				"type": "upload",
 				"etag": "a1966925019a1d1e08d7ea00c006ebd3",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434745551/clients/grandrapids/mast-skate-rpc-highres_3e2870f8-8307-454d-8460-a0b48d8c6fa9.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434745551/clients/grandrapids/mast-skate-rpc-highres_3e2870f8-8307-454d-8460-a0b48d8c6fa9.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434745551/clients/grandrapids/mast-skate-rpc-highres_3e2870f8-8307-454d-8460-a0b48d8c6fa9.jpg",
 				"original_filename": "file"
 			},
@@ -25705,7 +25705,7 @@
 				"bytes": 1130494,
 				"type": "upload",
 				"etag": "7862681e8c0a0c09aa5647a79ce66162",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1439817852/clients/grandrapids/Roses%20on%20Reeds%20Lake%204_da44dc7a-0829-4f78-92b3-dc4a6a8b54e0.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1439817852/clients/grandrapids/Roses%20on%20Reeds%20Lake%204_da44dc7a-0829-4f78-92b3-dc4a6a8b54e0.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1439817852/clients/grandrapids/Roses%20on%20Reeds%20Lake%204_da44dc7a-0829-4f78-92b3-dc4a6a8b54e0.jpg",
 				"exif": {
 					"ApertureValue": "51501/11867",
@@ -25811,7 +25811,7 @@
 				"bytes": 102890,
 				"type": "upload",
 				"etag": "457ce303f075b53e2c98b6f4b6a59575",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436898558/clients/grandrapids/KBS_b690c4f0-64f1-4f3c-b061-86fb13044517.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436898558/clients/grandrapids/KBS_b690c4f0-64f1-4f3c-b061-86fb13044517.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436898558/clients/grandrapids/KBS_b690c4f0-64f1-4f3c-b061-86fb13044517.jpg",
 				"exif": {
 					"ExifOffset": "26",
@@ -25874,7 +25874,7 @@
 				"bytes": 16611362,
 				"type": "upload",
 				"etag": "809d3afbb1e8d5c4ffdc5b5798f0423b",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1500669292/clients/grandrapids/Founders_Tour_3_2563f21e-0603-4a31-925e-ef92fe98818c.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1500669292/clients/grandrapids/Founders_Tour_3_2563f21e-0603-4a31-925e-ef92fe98818c.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1500669292/clients/grandrapids/Founders_Tour_3_2563f21e-0603-4a31-925e-ef92fe98818c.jpg",
 				"exif": {
 					"ApertureValue": "4643856/1000000",
@@ -26008,7 +26008,7 @@
 				"type": "upload",
 				"etag": "5ce77aacb0a1579c1f48a739d73a1fe8",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1508166049/clients/grandrapids/development_c9127e4a-a1a3-491a-89db-7319743c4cf4.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1508166049/clients/grandrapids/development_c9127e4a-a1a3-491a-89db-7319743c4cf4.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1508166049/clients/grandrapids/development_c9127e4a-a1a3-491a-89db-7319743c4cf4.jpg",
 				"exif": {
 					"ApertureValue": "433985/100000",
@@ -26122,7 +26122,7 @@
 				"type": "upload",
 				"etag": "9ea6da6f910e791d3a6a968be0d58c2a",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1542821844/clients/grandrapids/_OD_0354_c78fbb66-c75a-4804-9430-9af38ed8e9d5.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1542821844/clients/grandrapids/_OD_0354_c78fbb66-c75a-4804-9430-9af38ed8e9d5.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1542821844/clients/grandrapids/_OD_0354_c78fbb66-c75a-4804-9430-9af38ed8e9d5.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -26225,7 +26225,7 @@
 				"type": "upload",
 				"etag": "efd1cc85e5b189bac18315a071299afe",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1511291077/clients/grandrapids/042_3_8799_jpeg_272679da-04b4-42e2-a981-d7ca8fe9f175.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1511291077/clients/grandrapids/042_3_8799_jpeg_272679da-04b4-42e2-a981-d7ca8fe9f175.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1511291077/clients/grandrapids/042_3_8799_jpeg_272679da-04b4-42e2-a981-d7ca8fe9f175.jpg",
 				"exif": {
 					"ApertureValue": "5310704/1000000",
@@ -26321,7 +26321,7 @@
 				"type": "upload",
 				"etag": "6d0d34a360400bc4f0c413bbdb0c2fe1",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1514917205/clients/grandrapids/IMG_7157_c425a3fe-2a04-43d8-8da8-a86a787c8c4d.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1514917205/clients/grandrapids/IMG_7157_c425a3fe-2a04-43d8-8da8-a86a787c8c4d.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1514917205/clients/grandrapids/IMG_7157_c425a3fe-2a04-43d8-8da8-a86a787c8c4d.jpg",
 				"exif": {
 					"ApertureValue": "433985/100000",
@@ -26428,7 +26428,7 @@
 				"type": "upload",
 				"etag": "028efd2c8435a11df12875cf823cecb6",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1520369971/clients/grandrapids/042_3_8789_jpeg_e86c9b24-6019-4d50-ac67-9924c04232da.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1520369971/clients/grandrapids/042_3_8789_jpeg_e86c9b24-6019-4d50-ac67-9924c04232da.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1520369971/clients/grandrapids/042_3_8789_jpeg_e86c9b24-6019-4d50-ac67-9924c04232da.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -26553,7 +26553,7 @@
 				"type": "upload",
 				"etag": "ab69fd047e6717b29ac81471ab784ead",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1528814431/clients/grandrapids/Sovengard_7908c48e-747d-42df-af4c-6724990e9c21.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1528814431/clients/grandrapids/Sovengard_7908c48e-747d-42df-af4c-6724990e9c21.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1528814431/clients/grandrapids/Sovengard_7908c48e-747d-42df-af4c-6724990e9c21.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -26672,7 +26672,7 @@
 				"type": "upload",
 				"etag": "6209a69f1161b888ba1d99476b082a1d",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1523969533/clients/grandrapids/042_3_8870_jpeg_a2f73ba9-a8c4-4dc1-98fe-a333cca62e5b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1523969533/clients/grandrapids/042_3_8870_jpeg_a2f73ba9-a8c4-4dc1-98fe-a333cca62e5b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1523969533/clients/grandrapids/042_3_8870_jpeg_a2f73ba9-a8c4-4dc1-98fe-a333cca62e5b.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -26770,7 +26770,7 @@
 				"type": "upload",
 				"etag": "f0de459136179a12a1a3e0501623b78c",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1534788526/clients/grandrapids/042_3_8759_jpeg_f98453f1-dc8b-4522-9120-c41609a7b52f.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1534788526/clients/grandrapids/042_3_8759_jpeg_f98453f1-dc8b-4522-9120-c41609a7b52f.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1534788526/clients/grandrapids/042_3_8759_jpeg_f98453f1-dc8b-4522-9120-c41609a7b52f.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -26852,7 +26852,7 @@
 				"type": "upload",
 				"etag": "be0c3b23491040fe77cfffa500487d72",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1537455684/clients/grandrapids/Helen_Devos_Childrens_hospital_cbfaffcd-cf47-4e43-817e-3d397c70583a.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1537455684/clients/grandrapids/Helen_Devos_Childrens_hospital_cbfaffcd-cf47-4e43-817e-3d397c70583a.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1537455684/clients/grandrapids/Helen_Devos_Childrens_hospital_cbfaffcd-cf47-4e43-817e-3d397c70583a.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -26973,7 +26973,7 @@
 				"type": "upload",
 				"etag": "1d46610e84ece4da339476efa2fbc5bf",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1556912402/clients/grandrapids/temp_4d7b8a25-a156-4253-94c5-7fffda4acbb5.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1556912402/clients/grandrapids/temp_4d7b8a25-a156-4253-94c5-7fffda4acbb5.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1556912402/clients/grandrapids/temp_4d7b8a25-a156-4253-94c5-7fffda4acbb5.jpg",
 				"access_mode": "public",
 				"original_filename": "file",
@@ -27041,7 +27041,7 @@
 				"type": "upload",
 				"etag": "558c69acc27a79b21597ce1e3e39c3df",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1546025079/clients/grandrapids/042_3_9032_jpeg_04b3d073-0284-4319-b16e-5058b8542441.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1546025079/clients/grandrapids/042_3_9032_jpeg_04b3d073-0284-4319-b16e-5058b8542441.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1546025079/clients/grandrapids/042_3_9032_jpeg_04b3d073-0284-4319-b16e-5058b8542441.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -27155,7 +27155,7 @@
 				"bytes": 1947410,
 				"type": "upload",
 				"etag": "29b7193c0d17bc2ca110e900312fd37f",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436408265/clients/grandrapids/Van%20Andel%20Arena%204_7e569a9d-a4f6-42a9-9b61-17b899c4b1b4.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436408265/clients/grandrapids/Van%20Andel%20Arena%204_7e569a9d-a4f6-42a9-9b61-17b899c4b1b4.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436408265/clients/grandrapids/Van%20Andel%20Arena%204_7e569a9d-a4f6-42a9-9b61-17b899c4b1b4.jpg",
 				"original_filename": "file"
 			},
@@ -27214,7 +27214,7 @@
 				"bytes": 733102,
 				"type": "upload",
 				"etag": "fc288fb947e67b0f0c57a1acd3ca5446",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1436555764/clients/grandrapids/Fall%20Grand%20Rapids_33755667-f345-4a85-9d69-933633d332b2.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1436555764/clients/grandrapids/Fall%20Grand%20Rapids_33755667-f345-4a85-9d69-933633d332b2.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1436555764/clients/grandrapids/Fall%20Grand%20Rapids_33755667-f345-4a85-9d69-933633d332b2.jpg",
 				"exif": {
 					"ApertureValue": "70777/10653",
@@ -27338,7 +27338,7 @@
 				"type": "upload",
 				"etag": "7a6339f0907a29fa57fbd1365bf6245c",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1554141680/clients/grandrapids/RW_2019_Logo_e62db1c2-f41c-4a38-b3ed-5d5822cdef8b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1554141680/clients/grandrapids/RW_2019_Logo_e62db1c2-f41c-4a38-b3ed-5d5822cdef8b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1554141680/clients/grandrapids/RW_2019_Logo_e62db1c2-f41c-4a38-b3ed-5d5822cdef8b.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -27425,7 +27425,7 @@
 				"bytes": 1553854,
 				"type": "upload",
 				"etag": "012e487cba51c166012415dca2a62d14",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1438970033/clients/grandrapids/American%20Spirits%20Mugshot_c19995fb-8965-4824-8764-cf0a75ffde85.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1438970033/clients/grandrapids/American%20Spirits%20Mugshot_c19995fb-8965-4824-8764-cf0a75ffde85.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1438970033/clients/grandrapids/American%20Spirits%20Mugshot_c19995fb-8965-4824-8764-cf0a75ffde85.jpg",
 				"exif": {
 					"ApertureValue": "7400879/1000000",
@@ -27559,7 +27559,7 @@
 				"bytes": 1391641,
 				"type": "upload",
 				"etag": "07848940610cf52a34262ac101d67210",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1444310893/clients/grandrapids/Brewsadermustacheguy_2aa9fc84-6ac9-46ae-986c-5038ae8a3498.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1444310893/clients/grandrapids/Brewsadermustacheguy_2aa9fc84-6ac9-46ae-986c-5038ae8a3498.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1444310893/clients/grandrapids/Brewsadermustacheguy_2aa9fc84-6ac9-46ae-986c-5038ae8a3498.jpg",
 				"exif": {
 					"ApertureValue": "361471/100000",
@@ -27678,7 +27678,7 @@
 				"bytes": 760076,
 				"type": "upload",
 				"etag": "c3d93815f4065bc6fd532267efe2dd98",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1470248934/clients/grandrapids/042_3_0916_jpeg_ff098b68-f123-4354-b615-9b8301289103.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1470248934/clients/grandrapids/042_3_0916_jpeg_ff098b68-f123-4354-b615-9b8301289103.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1470248934/clients/grandrapids/042_3_0916_jpeg_ff098b68-f123-4354-b615-9b8301289103.jpg",
 				"exif": {
 					"ApertureValue": "303104/65536",
@@ -27802,7 +27802,7 @@
 				"bytes": 1383011,
 				"type": "upload",
 				"etag": "ef07769c697fd630190e2ed31ca02050",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1475857974/clients/grandrapids/_13_MFG_VanDis_11_4cb3e4d9-f636-4f53-982e-8e435667f0c0.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1475857974/clients/grandrapids/_13_MFG_VanDis_11_4cb3e4d9-f636-4f53-982e-8e435667f0c0.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1475857974/clients/grandrapids/_13_MFG_VanDis_11_4cb3e4d9-f636-4f53-982e-8e435667f0c0.jpg",
 				"exif": {
 					"ApertureValue": "286720/65536",
@@ -27924,7 +27924,7 @@
 				"bytes": 1403190,
 				"type": "upload",
 				"etag": "b23e491898f658b6587607fa29f833d4",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1491857724/clients/grandrapids/Taco_beer_comp_1f05b2e9-0939-4cda-b431-051bed4d4d16.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1491857724/clients/grandrapids/Taco_beer_comp_1f05b2e9-0939-4cda-b431-051bed4d4d16.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1491857724/clients/grandrapids/Taco_beer_comp_1f05b2e9-0939-4cda-b431-051bed4d4d16.jpg",
 				"exif": {
 					"Artist": "Craig Vander Lende",
@@ -28039,7 +28039,7 @@
 				"bytes": 9641804,
 				"type": "upload",
 				"etag": "8e3d56f30d5a56b52b6004f9602b5e1f",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1495636264/clients/grandrapids/042_3_7863_jpeg_8a0bb8d5-ed4a-4abd-9bf3-39232d5b0ca4.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1495636264/clients/grandrapids/042_3_7863_jpeg_8a0bb8d5-ed4a-4abd-9bf3-39232d5b0ca4.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1495636264/clients/grandrapids/042_3_7863_jpeg_8a0bb8d5-ed4a-4abd-9bf3-39232d5b0ca4.jpg",
 				"exif": {
 					"ApertureValue": "4/1",
@@ -28160,7 +28160,7 @@
 				"bytes": 141192,
 				"type": "upload",
 				"etag": "ca5b61fcbd71e6f95d34bf58529f1bec",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1495481473/clients/grandrapids/wmmba_a9dc5e6a-bc24-431a-bd9c-39929fa5dce9.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1495481473/clients/grandrapids/wmmba_a9dc5e6a-bc24-431a-bd9c-39929fa5dce9.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1495481473/clients/grandrapids/wmmba_a9dc5e6a-bc24-431a-bd9c-39929fa5dce9.jpg",
 				"original_filename": "file"
 			},
@@ -28227,7 +28227,7 @@
 				"type": "upload",
 				"etag": "f561d095dcb754624cdd0df2649554bc",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1519831316/clients/grandrapids/18807898_a40a_4bb0_ac41_88fa677fbe2e_e1552d38-4b84-40ba-9dfd-8e1e411a76cf.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1519831316/clients/grandrapids/18807898_a40a_4bb0_ac41_88fa677fbe2e_e1552d38-4b84-40ba-9dfd-8e1e411a76cf.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1519831316/clients/grandrapids/18807898_a40a_4bb0_ac41_88fa677fbe2e_e1552d38-4b84-40ba-9dfd-8e1e411a76cf.jpg",
 				"access_mode": "public",
 				"original_filename": "18807898-a40a-4bb0-ac41-88fa677fbe2e"
@@ -28302,7 +28302,7 @@
 				"bytes": 16347052,
 				"type": "upload",
 				"etag": "890ad85f662bdb0566c764ca6ee141cc",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1466706068/clients/grandrapids/05162016_ExGR2323_06e45e7a-36c4-4da1-bab2-b6077d61b8d8.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1466706068/clients/grandrapids/05162016_ExGR2323_06e45e7a-36c4-4da1-bab2-b6077d61b8d8.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1466706068/clients/grandrapids/05162016_ExGR2323_06e45e7a-36c4-4da1-bab2-b6077d61b8d8.jpg",
 				"exif": {
 					"Compression": "6",
@@ -28380,7 +28380,7 @@
 				"type": "upload",
 				"etag": "1f4581d423d0940b6881292cb5e136fa",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1528831092/clients/grandrapids/EXGR_JulyImagery_Canoe_27_of_39__8648f137-fe06-4015-9f88-77ef3a452cd2.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1528831092/clients/grandrapids/EXGR_JulyImagery_Canoe_27_of_39__8648f137-fe06-4015-9f88-77ef3a452cd2.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1528831092/clients/grandrapids/EXGR_JulyImagery_Canoe_27_of_39__8648f137-fe06-4015-9f88-77ef3a452cd2.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -28471,7 +28471,7 @@
 				"type": "upload",
 				"etag": "1e94f231bb8329929d2a52da7ad83cdb",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1565901315/clients/grandrapids/042_3_9294_jpeg_bb3ad4c1-f1a3-43a4-9995-78bd82cbffea.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1565901315/clients/grandrapids/042_3_9294_jpeg_bb3ad4c1-f1a3-43a4-9995-78bd82cbffea.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1565901315/clients/grandrapids/042_3_9294_jpeg_bb3ad4c1-f1a3-43a4-9995-78bd82cbffea.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -28603,7 +28603,7 @@
 				"type": "upload",
 				"etag": "03f64ddfef065cfe911eccbedc7366ca",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1567086503/clients/grandrapids/Kaleidoscopic_Amanda_Browder_Project_1_by_ArtPrize_7ea99a27-9467-4ec8-948a-a71c047a1662.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1567086503/clients/grandrapids/Kaleidoscopic_Amanda_Browder_Project_1_by_ArtPrize_7ea99a27-9467-4ec8-948a-a71c047a1662.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1567086503/clients/grandrapids/Kaleidoscopic_Amanda_Browder_Project_1_by_ArtPrize_7ea99a27-9467-4ec8-948a-a71c047a1662.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -28741,7 +28741,7 @@
 				"bytes": 1120394,
 				"type": "upload",
 				"etag": "21addd630a96cfd9a7534204d8582cf4",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1456860939/clients/grandrapids/kelly_mcgrail_c432a5e7-049c-4e0a-a331-96820b5e94f5.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1456860939/clients/grandrapids/kelly_mcgrail_c432a5e7-049c-4e0a-a331-96820b5e94f5.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1456860939/clients/grandrapids/kelly_mcgrail_c432a5e7-049c-4e0a-a331-96820b5e94f5.jpg",
 				"exif": {
 					"ApertureValue": "4/1",
@@ -28855,7 +28855,7 @@
 				"bytes": 2282548,
 				"type": "upload",
 				"etag": "2b8189b49b70dd5ecd742cad9550cdfa",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1442416899/clients/grandrapids/grstore_5ddfe3a6-97e8-4cfd-9996-dae442b0ea48.png",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1442416899/clients/grandrapids/grstore_5ddfe3a6-97e8-4cfd-9996-dae442b0ea48.png",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1442416899/clients/grandrapids/grstore_5ddfe3a6-97e8-4cfd-9996-dae442b0ea48.png",
 				"original_filename": "file"
 			},
@@ -28921,7 +28921,7 @@
 				"bytes": 1718019,
 				"type": "upload",
 				"etag": "3f34ca416c7e5a1bf5feaeecddb242bf",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1443536136/clients/grandrapids/bloodymary_4b71cded-db37-439e-86da-8ad0d1c587e9.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1443536136/clients/grandrapids/bloodymary_4b71cded-db37-439e-86da-8ad0d1c587e9.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1443536136/clients/grandrapids/bloodymary_4b71cded-db37-439e-86da-8ad0d1c587e9.jpg",
 				"exif": {
 					"ApertureValue": "1695994/1000000",
@@ -29024,7 +29024,7 @@
 				"bytes": 142528,
 				"type": "upload",
 				"etag": "470a1e85352b6dc03ff9246e6b19d141",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1434746901/clients/grandrapids/ford-museum_65c6d694-466b-451c-9d45-c7b84f9967ac.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1434746901/clients/grandrapids/ford-museum_65c6d694-466b-451c-9d45-c7b84f9967ac.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1434746901/clients/grandrapids/ford-museum_65c6d694-466b-451c-9d45-c7b84f9967ac.jpg",
 				"original_filename": "file"
 			},
@@ -29096,7 +29096,7 @@
 				"bytes": 1067429,
 				"type": "upload",
 				"etag": "c8d651106093c2193d8d97887fc865ea",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1477075110/clients/grandrapids/larissa_karimwabo_0692ae5e-0969-4a78-9993-060281c847ea.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1477075110/clients/grandrapids/larissa_karimwabo_0692ae5e-0969-4a78-9993-060281c847ea.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1477075110/clients/grandrapids/larissa_karimwabo_0692ae5e-0969-4a78-9993-060281c847ea.jpg",
 				"exif": {
 					"ApertureValue": "2970854/1000000",
@@ -29205,7 +29205,7 @@
 				"type": "upload",
 				"etag": "1737f86025f30f48f7eae0cab636cebe",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1524838547/clients/grandrapids/042_3_8784_jpeg_1c1230db-553a-447e-aa81-bb8687b68d05.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1524838547/clients/grandrapids/042_3_8784_jpeg_1c1230db-553a-447e-aa81-bb8687b68d05.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1524838547/clients/grandrapids/042_3_8784_jpeg_1c1230db-553a-447e-aa81-bb8687b68d05.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -29306,7 +29306,7 @@
 				"type": "upload",
 				"etag": "849330d75e1662fd2c904db2566bcced",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1520006000/clients/grandrapids/GrandRapids_IrishPubs_b8906cf8-189a-411e-9092-382ba27ebf4b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1520006000/clients/grandrapids/GrandRapids_IrishPubs_b8906cf8-189a-411e-9092-382ba27ebf4b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1520006000/clients/grandrapids/GrandRapids_IrishPubs_b8906cf8-189a-411e-9092-382ba27ebf4b.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -29392,7 +29392,7 @@
 				"type": "upload",
 				"etag": "38a968f4906bc9747aa79e980c6226de",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1552398022/clients/grandrapids/Cider_Week_2_sm_a531288f-5bca-4833-b817-3192151d3e3b.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1552398022/clients/grandrapids/Cider_Week_2_sm_a531288f-5bca-4833-b817-3192151d3e3b.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1552398022/clients/grandrapids/Cider_Week_2_sm_a531288f-5bca-4833-b817-3192151d3e3b.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -29505,7 +29505,7 @@
 				"bytes": 13163814,
 				"type": "upload",
 				"etag": "ee0eaff3719a0b14c7d93c10b424f1e6",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1493218944/clients/grandrapids/042_3_8749_jpeg_abbdd241-280c-4d2a-bb0d-38f501fb6722.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1493218944/clients/grandrapids/042_3_8749_jpeg_abbdd241-280c-4d2a-bb0d-38f501fb6722.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1493218944/clients/grandrapids/042_3_8749_jpeg_abbdd241-280c-4d2a-bb0d-38f501fb6722.jpg",
 				"exif": {
 					"ApertureValue": "2970854/1000000",
@@ -29625,7 +29625,7 @@
 				"bytes": 189841,
 				"type": "upload",
 				"etag": "967d9e6a189280949a75f866102c76d6",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1494447145/clients/grandrapids/Dining_at_Downtown_Market_dd51f931-6c5f-4f43-9865-f55045ddd664.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1494447145/clients/grandrapids/Dining_at_Downtown_Market_dd51f931-6c5f-4f43-9865-f55045ddd664.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1494447145/clients/grandrapids/Dining_at_Downtown_Market_dd51f931-6c5f-4f43-9865-f55045ddd664.jpg",
 				"exif": {
 					"BitsPerSample": "8, 8, 8",
@@ -29704,7 +29704,7 @@
 				"bytes": 2069320,
 				"type": "upload",
 				"etag": "07d279baef783def9e3ed94cc644de76",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1449695938/clients/grandrapids/UICA_980345b7-7699-41f2-aafe-f6fff960f6da.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1449695938/clients/grandrapids/UICA_980345b7-7699-41f2-aafe-f6fff960f6da.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1449695938/clients/grandrapids/UICA_980345b7-7699-41f2-aafe-f6fff960f6da.jpg",
 				"done": true
 			},
@@ -29777,7 +29777,7 @@
 				"type": "upload",
 				"etag": "849dc4dfcaea70a82ec8db4bda4b140d",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1525285284/clients/grandrapids/042_3_8812_jpeg_391335dd-a35a-4687-9d69-d039a4a463cc.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1525285284/clients/grandrapids/042_3_8812_jpeg_391335dd-a35a-4687-9d69-d039a4a463cc.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1525285284/clients/grandrapids/042_3_8812_jpeg_391335dd-a35a-4687-9d69-d039a4a463cc.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -29895,7 +29895,7 @@
 				"bytes": 402530,
 				"type": "upload",
 				"etag": "a0dfd590d82f791d7079f3adfe909bed",
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1496937407/clients/grandrapids/Amway_Family_Fireworks_558bc019-7edb-4eb5-80da-6de02abc999c.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1496937407/clients/grandrapids/Amway_Family_Fireworks_558bc019-7edb-4eb5-80da-6de02abc999c.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1496937407/clients/grandrapids/Amway_Family_Fireworks_558bc019-7edb-4eb5-80da-6de02abc999c.jpg",
 				"exif": {
 					"ApertureValue": "6918863/1000000",
@@ -30011,7 +30011,7 @@
 				"type": "upload",
 				"etag": "9ca5794427b1c02456279a13bc1710f6",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1527689179/clients/grandrapids/file_a681d201_f601_41b6_93e9_274ab7966309_aa69f293-6a61-4fd5-89dd-7d786e7add23.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1527689179/clients/grandrapids/file_a681d201_f601_41b6_93e9_274ab7966309_aa69f293-6a61-4fd5-89dd-7d786e7add23.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1527689179/clients/grandrapids/file_a681d201_f601_41b6_93e9_274ab7966309_aa69f293-6a61-4fd5-89dd-7d786e7add23.jpg",
 				"access_mode": "public",
 				"original_filename": "file"
@@ -30085,7 +30085,7 @@
 				"type": "upload",
 				"etag": "12d47879c54e114703c15009b3271d23",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1564677605/clients/grandrapids/042_3_9211_jpeg_68a8f977-6b6a-4551-9f25-4d6cf1116318.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1564677605/clients/grandrapids/042_3_9211_jpeg_68a8f977-6b6a-4551-9f25-4d6cf1116318.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1564677605/clients/grandrapids/042_3_9211_jpeg_68a8f977-6b6a-4551-9f25-4d6cf1116318.jpg",
 				"access_mode": "public",
 				"exif": {
@@ -30211,7 +30211,7 @@
 				"type": "upload",
 				"etag": "f8ef736c171defefa394acc4b4146ffe",
 				"placeholder": false,
-				"url": "http://res.cloudinary.com/simpleview/image/upload/v1568401901/clients/grandrapids/042_3_8967_jpeg_e0d91e37-8827-444c-b5ff-671c842104f3.jpg",
+				"url": "https://res.cloudinary.com/simpleview/image/upload/v1568401901/clients/grandrapids/042_3_8967_jpeg_e0d91e37-8827-444c-b5ff-671c842104f3.jpg",
 				"secure_url": "https://res.cloudinary.com/simpleview/image/upload/v1568401901/clients/grandrapids/042_3_8967_jpeg_e0d91e37-8827-444c-b5ff-671c842104f3.jpg",
 				"access_mode": "public",
 				"exif": {


### PR DESCRIPTION
# [MOS-1309](https://simpleviewtools.atlassian.net/browse/MOS-1309)

## Description
- (chore) Replace resource data images with SSL-enabled URLs

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1309]: https://simpleviewtools.atlassian.net/browse/MOS-1309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ