### PR TITLE
MOS-1434

### DIFF
--- a/containers/mosaic/src/components/Button/Button.styled.ts
+++ b/containers/mosaic/src/components/Button/Button.styled.ts
@@ -129,6 +129,10 @@ function getPadding(variant: ButtonProps["variant"], size: ButtonProps["size"] =
 		return variant === "outlined" ? "1px 12px" : "3px 14px";
 	}
 
+	if (size === "large") {
+		return variant === "outlined" ? "7px 22px" : "9px 24px";
+	}
+
 	return variant === "outlined" ? "4px 16px" : "6px 18px";
 }
 

--- a/containers/mosaic/src/components/Button/ButtonTypes.tsx
+++ b/containers/mosaic/src/components/Button/ButtonTypes.tsx
@@ -11,7 +11,7 @@ export interface ButtonProps {
 	color: ColorTypes;
 	mIcon?: SvgIconComponent;
 	variant: "icon" | "outlined" | "contained" | "text" | "input";
-	size?: "small" | "medium";
+	size?: "small" | "medium" | "large";
 	iconPosition?: "left" | "right";
 	disabled?: MosaicToggle;
 	/** Button will occupy 100% of the width provided to it */

--- a/containers/mosaic/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocomplete.styled.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocomplete.styled.tsx
@@ -8,7 +8,6 @@ import ClearIcon from "@mui/icons-material/Clear";
 export const LocationSearchInputWrapper = styled.div`
 	&.mapCoordinates {
 		margin-bottom: 8px;
-		margin-top: 15px;
 	}
 `;
 

--- a/containers/mosaic/src/components/Field/FormFieldMapCoordinates/Map/MapWithMarker.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldMapCoordinates/Map/MapWithMarker.tsx
@@ -16,7 +16,7 @@ function MapWithMarker({
 }: MapWithMarkerProps) {
 
 	return (
-		<>
+		<div>
 			<Map
 				initialCenter={initialCenter}
 				value={value}
@@ -29,7 +29,7 @@ function MapWithMarker({
 			<StyledSpan>
 				Click on the map to update the latitude and longitude coordinates
 			</StyledSpan>
-		</>
+		</div>
 	);
 }
 

--- a/containers/mosaic/src/components/Field/FormFieldMapCoordinates/Map/ResetButton.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldMapCoordinates/Map/ResetButton.tsx
@@ -19,6 +19,7 @@ function ResetButton({
 				variant="text"
 				label="Reset"
 				onClick={onClick}
+				size="large"
 			/>
 		</ResetButtonContainer>
 	);

--- a/containers/mosaic/src/components/Field/FormFieldMapCoordinates/MapCoordinates.styled.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldMapCoordinates/MapCoordinates.styled.tsx
@@ -3,11 +3,11 @@ import theme from "@root/theme";
 
 // Styles for the MapCoordinates component
 
-export const StyledSpan = styled.span`
+export const StyledSpan = styled.div`
   color: ${theme.newColors.grey3["100"]};
   font-family: ${theme.fontFamily};
   font-size: 14px;
-  margin: 0px 20px 15px 20px;
+  margin-top: 4px;
 
   @media (max-width: ${theme.breakpoints.mobile}) {
     width: calc(100vw - 40px);
@@ -84,8 +84,6 @@ export const LatitudeValue = styled(CoordinatesValues)`
 // Styles for the Map component
 
 export const MapContainer = styled.div`
-  margin: 0px 20px 16px 20px;
-
   @media (max-width: ${theme.breakpoints.mobile}) {
     width: calc(100vw - 40px);
   };
@@ -95,15 +93,6 @@ export const MapContainer = styled.div`
 
 export const ResetButtonContainer = styled.div`
   display: flex;
-  justify-content: center;
   flex-grow: 1;
-  position: relative;
-
-
-  .reset-button {
-    align-self: center;
-    position: absolute;
-    top: 56px;
-    left: 0;
-}
+  align-items: end;
 `;


### PR DESCRIPTION
# [MOS-1434](https://simpleviewtools.atlassian.net/browse/MOS-1434)

## Description
- (CoordsField) Amend styling issues to reduce padding around the coordinate drawer map and bring the reset button in line with the coordinate fields.
- (Button) Adds support for a large button size

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1434]: https://simpleviewtools.atlassian.net/browse/MOS-1434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ