### PR TITLE
MOS-1431

### DIFF
--- a/containers/mosaic/src/components/Title/TitleBackButton.tsx
+++ b/containers/mosaic/src/components/Title/TitleBackButton.tsx
@@ -5,23 +5,30 @@ import { memo, ReactElement } from "react";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import { BackButton } from "./TitleWrapper.styled";
 import { TitleBackButtonProps } from "./TitleWrapperTypes";
+import Tooltip, { useTooltip } from "../Tooltip";
 
 const TitleBackButton = ({
 	collapse,
 	label = "Go back",
 	...props
 }: TitleBackButtonProps): ReactElement => {
+	const { anchorProps, tooltipProps } = useTooltip();
 
 	return (
-		<BackButton
-			$collapse={collapse}
-			{...props}
-			className="back-button"
-			color="gray"
-			variant="icon"
-			mIcon={ChevronLeftIcon}
-			muiAttrs={{ "aria-label": label }}
-		/>
+		<>
+			<BackButton
+				$collapse={collapse}
+				{...props}
+				className="back-button"
+				color="gray"
+				variant="icon"
+				mIcon={ChevronLeftIcon}
+				muiAttrs={{ "aria-label": label, ...anchorProps }}
+			/>
+			<Tooltip {...tooltipProps} >
+				{label}
+			</Tooltip>
+		</>
 	);
 };
 


### PR DESCRIPTION
# [MOS-1431](https://simpleviewtools.atlassian.net/browse/MOS-1431)

## Description
- (TitleWrapper) Use back button label as a tooltip when hovered

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1431]: https://simpleviewtools.atlassian.net/browse/MOS-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ