### PR TITLE
MOS-1430

### DIFF
--- a/containers/mosaic/src/__tests__/components/Field/FormFieldChips/FormFieldChips.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldChips/FormFieldChips.test.tsx
@@ -98,9 +98,9 @@ describe("FormFieldChips component", () => {
 	it("should select a Chip when clicked once and deselect it when clicked again", async () => {
 		const [chip1, chip2, chip3] = getAllByRole("option");
 
-		expect(chip1).not.toHaveAttribute("aria-selected");
-		expect(chip2).not.toHaveAttribute("aria-selected");
-		expect(chip3).not.toHaveAttribute("aria-selected");
+		expect(chip1).toHaveAttribute("aria-selected", "false");
+		expect(chip2).toHaveAttribute("aria-selected", "false");
+		expect(chip3).toHaveAttribute("aria-selected", "false");
 
 		await act(async () => {
 			await fireEvent.click(chip1);

--- a/containers/mosaic/src/components/Chip/Chip.tsx
+++ b/containers/mosaic/src/components/Chip/Chip.tsx
@@ -8,7 +8,7 @@ import { ChipsProps } from "./ChipTypes";
 import { StyledChip, StyledDeletableChip } from "./Chip.styled";
 
 const Chip = (props: ChipsProps & HTMLAttributes<HTMLDivElement>): ReactElement => {
-	const { label, disabled, selected, onDelete, onClick } = props;
+	const { label, disabled, selected = false, onDelete, onClick } = props;
 	const ref = useRef<HTMLDivElement>();
 
 	return onDelete ? (


### PR DESCRIPTION
# [MOS-1430](https://simpleviewtools.atlassian.net/browse/MOS-1430)

## Description
- (ChipField) Fallback to a false selected state to ensure aria-selected is always provided

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1430]: https://simpleviewtools.atlassian.net/browse/MOS-1430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ