### PR TITLE
MOS-1361

### DIFF
--- a/containers/mosaic/src/components/FieldWrapper/Label.tsx
+++ b/containers/mosaic/src/components/FieldWrapper/Label.tsx
@@ -14,17 +14,18 @@ import testIds from "@root/utils/testIds";
 
 const LabelWrapper = styled.div<TransientProps<LabelProps, "required">>`
 	display: flex;
-	align-items: center;
+	align-items: end;
 	margin-bottom: 8px;
 	font-family: ${theme.fontFamily};
 	gap: 8px;
-	height: 28px;
 
 	.MuiInputLabel-root {
 		font-family: inherit;
 		font-size: 16px;
 		color:  ${theme.newColors.almostBlack["100"]};
 		word-wrap: break-word;
+		text-overflow: clip;
+		white-space: normal;
 	}
 `;
 
@@ -39,9 +40,6 @@ const CharCounterWrapper = styled.div<{ $invalid?: boolean }>`
 	color: ${({ $invalid }) => $invalid ? theme.newColors.darkRed["100"] : theme.newColors.grey3["100"]};
 	font-size: 12px;
 	margin-left: auto;
-	// Aligns the bottom of the character counter with the field label
-	align-self: end;
-	margin-bottom: 4px;
 `;
 
 const StyledInfoOutlinedIcon = styled(InfoOutlinedIcon)`


### PR DESCRIPTION
# [MOS-1361](https://simpleviewtools.atlassian.net/browse/MOS-1361)

## Description
- (Form) Have long form labels wrap into a new line rather than being truncated.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1361]: https://simpleviewtools.atlassian.net/browse/MOS-1361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ