### PR TITLE
MOS-1405

### DIFF
--- a/containers/sb-8/stories/components/DataView/DataView.stories.tsx
+++ b/containers/sb-8/stories/components/DataView/DataView.stories.tsx
@@ -46,6 +46,7 @@ import DataViewFilterNumber from "@root/components/DataViewFilterNumber";
 
 export default {
 	title : "Components/DataView",
+	layout: "fullscreen",
 };
 
 // set an artificial delay of 500ms to simulate DB queries
@@ -460,7 +461,7 @@ const gridColumnsMap = {
 
 const StyledDiv = styled.div`
 	padding: 0px 16px;
-	height: 100%;
+	height: 100vh;
 `;
 
 const newSavedFormFields: FieldDef[] = [


### PR DESCRIPTION
# [MOS-1405](https://simpleviewtools.atlassian.net/browse/MOS-1405)

## Description
- (DataView) Ensures the sticky parameter works by forcing the story to take up the full height of the viewport.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1405]: https://simpleviewtools.atlassian.net/browse/MOS-1405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ