### PR TITLE
MOS-1454

### DIFF
--- a/containers/sb-8/.storybook/main.ts
+++ b/containers/sb-8/.storybook/main.ts
@@ -4,8 +4,8 @@ import remarkGfm from 'remark-gfm';
 const config: StorybookConfig = {
   stories: [
     "../stories/Introduction.mdx",
-    "../stories/**/*.mdx",
     "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../stories/**/*.mdx",
   ],
   addons: [
     "@storybook/addon-links",


### PR DESCRIPTION
# [MOS-1454](https://simpleviewtools.atlassian.net/browse/MOS-1454)

## Description
- (chore) Reorder story entry query to ensure documentation gets listed after component stories in the Storybook navigation.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1454]: https://simpleviewtools.atlassian.net/browse/MOS-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ