### PR TITLE
MOS-1428

### DIFF
--- a/containers/mosaic/.eslintrc.js
+++ b/containers/mosaic/.eslintrc.js
@@ -143,6 +143,7 @@ module.exports = {
 				"no-unused-vars": "off",
 				"@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true, argsIgnorePattern: "^_" }],
 				"@typescript-eslint/no-explicit-any": "warn",
+				"@typescript-eslint/consistent-type-imports": ["warn"],
 			},
 			extends: [
 				"eslint:recommended",

--- a/containers/mosaic/src/__tests__/components/Field/FormFieldTextEditor/FormFieldTextEditorTiptap.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldTextEditor/FormFieldTextEditorTiptap.test.tsx
@@ -311,15 +311,14 @@ describe("TextEditorTiptap component - Linking text", () => {
 		await user.click(screen.getAllByTestId(`${testIds.TEXT_EDITOR_CONTROL}:link`)[0]);
 
 		const url = screen.getByLabelText("URL*");
+		const text = screen.getByLabelText("Text*");
 		const submit = screen.getByRole("button", { name: "Submit" });
 
 		await user.type(url, "https://www.example.com");
+		await user.type(text, "My Link");
 		await user.click(submit);
 
-		const canvas = screen.getByTestId(testIds.TEXT_EDITOR_CANVAS);
-		await user.type(canvas, "A");
-
-		expect(onChangeMock).toBeCalledWith("<p><a target=\"\" rel=\"noopener noreferrer nofollow\" href=\"https://www.example.com\">A</a></p>");
+		expect(onChangeMock).toBeCalledWith("<p><a target=\"\" rel=\"noopener noreferrer nofollow\" href=\"https://www.example.com\">My Link</a></p>");
 	});
 
 	it("should remove the correct elements when text is unlinked", async () => {
@@ -359,6 +358,7 @@ describe("TextEditorTiptap component - Linking text", () => {
 		const onLinkMock = vi.fn<TextEditorNextInputSettings["onLink"]>(({ updateLink }) => updateLink({
 			url: "https://www.example.com",
 			newTab: true,
+			text: "My Link",
 		}));
 
 		const { user, onChangeMock } = await setup({ onLink: onLinkMock });
@@ -368,7 +368,7 @@ describe("TextEditorTiptap component - Linking text", () => {
 		await user.tripleClick(canvas);
 		await user.click(screen.getAllByTestId(`${testIds.TEXT_EDITOR_CONTROL}:link`)[0]);
 
-		expect(onChangeMock).toBeCalledWith("<p><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://www.example.com\">Test</a></p>");
+		expect(onChangeMock).toBeCalledWith("<p><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://www.example.com\">My Link</a></p>");
 	});
 });
 

--- a/containers/mosaic/src/__tests__/components/Field/FormFieldTextEditor/FormFieldTextEditorTiptap.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldTextEditor/FormFieldTextEditorTiptap.test.tsx
@@ -1,7 +1,9 @@
-import { FormFieldTextEditorTipTap, MosaicFieldProps, TextEditorNextInputSettings } from "@root/components/Field";
+import type { MosaicFieldProps, TextEditorNextInputSettings } from "@root/components/Field";
+import { FormFieldTextEditorTipTap } from "@root/components/Field";
 import testIds from "@root/utils/testIds";
 import { render, screen, waitFor } from "@testing-library/react";
-import userEvent, { UserEvent } from "@testing-library/user-event";
+import type { UserEvent } from "@testing-library/user-event";
+import userEvent from "@testing-library/user-event";
 import React, { act } from "react";
 
 type SetupParams = Pick<MosaicFieldProps, "value"> & {
@@ -385,25 +387,7 @@ describe("TextEditorTiptap component - Managing images", () => {
 		await user.type(source, "https://www.placehold.it/200");
 		await user.click(submit);
 
-		expect(onChangeMock).toBeCalledWith("<img src=\"https://www.placehold.it/200\">");
-	});
-
-	it("should provide the custom onImage handler with the source and alt text", async () => {
-		const onImageMock = vi.fn<TextEditorNextInputSettings["onImage"]>();
-
-		const value = "<img alt=\"Placeholder Image\" src=\"https://www.placehold.it/200\">";
-		const { user } = await setup({ value, onImage: onImageMock });
-
-		const canvas = screen.getByTestId(testIds.TEXT_EDITOR_CANVAS);
-
-		await user.tripleClick(canvas);
-		await user.click(screen.getByTestId(`${testIds.TEXT_EDITOR_CONTROL}:menu-4-1`));
-		await user.click(screen.getAllByTestId(`${testIds.TEXT_EDITOR_CONTROL}:image`)[0]);
-
-		expect(onImageMock).toBeCalledWith(expect.objectContaining({
-			src: "https://www.placehold.it/200",
-			alt: "Placeholder Image",
-		}));
+		expect(onChangeMock).toBeCalledWith("<p><img src=\"https://www.placehold.it/200\"></p>");
 	});
 
 	it("should render the correct elements when an image is added using custom link handler", async () => {
@@ -417,6 +401,6 @@ describe("TextEditorTiptap component - Managing images", () => {
 		await user.click(screen.getByTestId(`${testIds.TEXT_EDITOR_CONTROL}:menu-4-1`));
 		await user.click(screen.getAllByTestId(`${testIds.TEXT_EDITOR_CONTROL}:image`)[0]);
 
-		expect(onChangeMock).toBeCalledWith("<img src=\"https://www.placehold.it/200\" alt=\"Placeholder Image\">");
+		expect(onChangeMock).toBeCalledWith("<p><img src=\"https://www.placehold.it/200\" alt=\"Placeholder Image\"></p>");
 	});
 });

--- a/containers/mosaic/src/__tests__/utils/dom/escapeHtmlSpace.test.ts
+++ b/containers/mosaic/src/__tests__/utils/dom/escapeHtmlSpace.test.ts
@@ -1,10 +1,10 @@
-import { escapeHtmlSpaces } from "@root/utils/dom/escapeHtmlSpaces";
+import { escapeHtml } from "@root/utils/dom/escapeHtml";
 
 describe(__filename, function () {
 	it("should convert multiple spaces into a single space followed by &nbsp; entities", async () => {
 		const html = "<p>   </p>";
 
-		expect(escapeHtmlSpaces(html)).toBe("<p> &nbsp;&nbsp;</p>");
+		expect(escapeHtml(html)).toBe("<p> &nbsp;&nbsp;</p>");
 	});
 
 	it("should convert multple whitespace characters into a single space followed by &nbsp; entities", async () => {
@@ -12,18 +12,18 @@ describe(__filename, function () {
 
  </p>`;
 
-		expect(escapeHtmlSpaces(html)).toBe("<p> &nbsp;&nbsp;</p>");
+		expect(escapeHtml(html)).toBe("<p> &nbsp;&nbsp;</p>");
 	});
 
 	it("should not convert single spaces", async () => {
 		const html = "<p>Foo Bar</p>";
 
-		expect(escapeHtmlSpaces(html)).toBe("<p>Foo Bar</p>");
+		expect(escapeHtml(html)).toBe("<p>Foo Bar</p>");
 	});
 
 	it("should not convert space-only content between tags", async () => {
 		const html = "<p><span>Foo</span>    <span>Bar</span></p>";
 
-		expect(escapeHtmlSpaces(html)).toBe("<p><span>Foo</span>    <span>Bar</span></p>");
+		expect(escapeHtml(html)).toBe("<p><span>Foo</span>    <span>Bar</span></p>");
 	});
 });

--- a/containers/mosaic/src/__tests__/utils/dom/getHtmlCharacterCount.test.ts
+++ b/containers/mosaic/src/__tests__/utils/dom/getHtmlCharacterCount.test.ts
@@ -20,13 +20,6 @@ describe(__filename, function () {
 		expect(getHtmlCharacterCount(html)).toBe(21);
 	});
 
-	it("should not count inline elements as a single character", async () => {
-		const html = `<span>Test 12345</span>
-		<span>Test 12345</span>`;
-
-		expect(getHtmlCharacterCount(html)).toBe(20);
-	});
-
 	it("should ignore leading whitespace when counting text content", async () => {
 		const html = `<p>
 			Test 12345</p>`;
@@ -50,5 +43,11 @@ describe(__filename, function () {
 		const html = "<p>🙂</p>";
 
 		expect(getHtmlCharacterCount(html)).toBe(1);
+	});
+
+	it("should count spaces between inline elements", async () => {
+		const html = "<p><span>Test</span> <span>12345</span></p>";
+
+		expect(getHtmlCharacterCount(html)).toBe(10);
 	});
 });

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Extensions/ScriptNodeView.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Extensions/ScriptNodeView.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from "react";
+import type { ReactElement } from "react";
+
+import React from "react";
 import Code from "@mui/icons-material/Code";
 import { NodeViewWrapper } from "@tiptap/react";
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Extensions/defaultExtensions.ts
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Extensions/defaultExtensions.ts
@@ -39,7 +39,9 @@ export const defaultExtensions = [
 	CodeBlock.configure({
 		lowlight,
 	}),
-	Image,
+	Image.configure({
+		inline: true,
+	}),
 	Italic,
 	Underline,
 	Strike,

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FloatingToolbar.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FloatingToolbar.tsx
@@ -1,10 +1,13 @@
-import React, { MutableRefObject, ReactElement } from "react";
+import type { MutableRefObject, ReactElement } from "react";
+
+import React from "react";
 import Popper from "@mui/material/Popper";
 
 import type { FloatingToolbarState } from "./FormFieldTextEditorTypes";
+import type { ToolbarControlsProps } from "./Toolbar";
 
 import { StyledFloatingToolbar } from "./FormFieldTextEditorTipTap.styled";
-import { ToolbarControls, ToolbarControlsProps } from "./Toolbar";
+import { ToolbarControls } from "./Toolbar";
 
 type FloatingToolbarProps = ToolbarControlsProps & FloatingToolbarState & {
 	isBusy: MutableRefObject<boolean>;

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
@@ -1,10 +1,13 @@
-import * as React from "react";
-import { memo, ReactElement } from "react";
-import { MosaicFieldProps } from "@root/components/Field";
-import { StyledSkeletonWrapper } from "./FormFieldTextEditor.styled";
-import "jodit/build/jodit.min.css";
-import { TextEditorData, TextEditorInputSettings } from "./FormFieldTextEditorTypes";
+import type { ReactElement } from "react";
+
+import React, { memo } from "react";
 import Skeleton from "@mui/material/Skeleton";
+import "jodit/build/jodit.min.css";
+
+import type { MosaicFieldProps } from "@root/components/Field";
+import type { TextEditorData, TextEditorInputSettings } from "./FormFieldTextEditorTypes";
+
+import { StyledSkeletonWrapper } from "./FormFieldTextEditor.styled";
 import JoditEditor from "./JoditEditor";
 
 const FormFieldTextEditor = (

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTap.styled.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTap.styled.tsx
@@ -32,15 +32,22 @@ const selectedNode = css`
     outline-offset: 1px;
 `;
 
-export const StyledTextEditor = styled.div`
+export const StyledTextEditor = styled.div<{ $disabled?: boolean }>`
     font-family: ${theme.fontFamily};
-    color: ${theme.colors.black};
+
+    ${({ $disabled }) => $disabled ? `
+        --border-color: ${theme.colors.disableBorder};
+        color: ${theme.colors.disabledTextColor};
+    ` : `
+        --border-color: ${theme.newColors.simplyGrey["100"]};
+        color: ${theme.newColors.almostBlack["100"]};
+    `}
 `;
 
 export const Editor = styled(EditorContent)`
     .tiptap {
         background-color: ${theme.newColors.grey1["100"]};
-        border: 1px solid ${theme.colors.gray300};
+        border: 1px solid var(--border-color);
         border-top: 0;
         padding: 16px;
 
@@ -118,7 +125,7 @@ export const Editor = styled(EditorContent)`
         .tiptap-pill {
             background-color: ${theme.colors.gray200};
             border-radius: 3px;
-            border: 1px solid ${theme.colors.gray300};
+            border: 1px solid var(--border-color);
             color: ${theme.colors.gray600};
             padding: 0;
             font-size: 12px;
@@ -161,20 +168,20 @@ export const Editor = styled(EditorContent)`
         pre {
             background-color: ${theme.colors.gray200};
             border-radius: 3px;
-            border: 1px solid ${theme.colors.gray300};
+            border: 1px solid var(--border-color);
             font-size: 0.85rem;
             line-height: 1.4em;
             padding: 8px 12px;
         }
 
         blockquote {
-            border-left: 3px solid ${theme.colors.gray300};
+            border-left: 3px solid var(--border-color);
             padding: 4px 16px;
         }
 
         hr {
             border: none;
-            border-top: 1px solid ${theme.colors.gray300};
+            border-top: 1px solid var(--border-color);
             margin: 20px 0;
         }
 
@@ -191,16 +198,20 @@ export const Editor = styled(EditorContent)`
     }
 `;
 
-export const StyledFloatingToolbar = styled.div`
+export const StyledFloatingToolbar = styled.div<{ $disabled?: boolean }>`
+    ${({ $disabled }) => `
+        --border-color: ${$disabled ? theme.colors.disableBorder : theme.newColors.simplyGrey["100"]};
+    `}
+
     background: white;
     box-shadow: box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    border: 1px solid ${theme.colors.gray300};
+    border: 1px solid var(--border-color);
     padding: 4px 0;
 `;
 
 export const PrimaryToolbar = styled.div<{ $focus?: boolean }>`
     background: ${theme.newColors.grey1["100"]};
-    border: 1px solid ${theme.colors.gray300};
+    border: 1px solid var(--border-color);
     border-bottom: 0;
     position: sticky;
     padding: 4px 0;
@@ -208,7 +219,7 @@ export const PrimaryToolbar = styled.div<{ $focus?: boolean }>`
     z-index: 1;
 
     &::after {
-        border-bottom: 1px solid ${theme.colors.gray300};
+        border-bottom: 1px solid var(--border-color);
         bottom: -1px;
         content: " ";
         left: 16px;
@@ -239,7 +250,7 @@ export const ControlGroup = styled.div`
     &::after {
         content: " ";
         position: absolute;
-        border-right: 1px solid ${theme.colors.gray300};
+        border-right: 1px solid var(--border-color);
         top: 6px;
         bottom: 6px;
         right: -1px;
@@ -278,7 +289,7 @@ export const StyledTextStyleMenuButton = styled(StyledControlButton)`
 
 export const CodeView = styled(TextareaAutosize)`
     background: ${theme.newColors.grey1["100"]};
-    border: 1px solid ${theme.colors.gray300};
+    border: 1px solid var(--border-color);
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
@@ -362,7 +373,7 @@ export const MenuItemShortcut = styled.div`
 
 export const StyledModeSwitch = styled.div`
     background: white;
-    border: 1px solid ${theme.colors.gray300};
+    border: 1px solid var(--border-color);
     border-bottom: 0;
     justify-content: end;
     align-items: center;

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTap.styled.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTap.styled.tsx
@@ -186,9 +186,8 @@ export const Editor = styled(EditorContent)`
         }
 
         img {
-            display: block;
+            vertical-align: bottom;
             height: auto;
-            margin: 1.5rem 0;
             max-width: 100%;
 
             &.ProseMirror-selectednode {

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTap.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTap.tsx
@@ -16,7 +16,7 @@ import { isEmptyDOM } from "@root/utils/dom/isEmptyDOM";
 import { FloatingToolbar } from "./FloatingToolbar";
 import { arrayDifference } from "@root/utils/array";
 import { defaultExtensions } from "./Extensions/defaultExtensions";
-import { escapeHtmlSpaces } from "@root/utils/dom/escapeHtmlSpaces";
+import { escapeHtml } from "@root/utils/dom/escapeHtml";
 import testIds from "@root/utils/testIds";
 import { defaultControls, floatingControls, selectionVirtualElement } from "./textEditorUtils";
 
@@ -110,7 +110,7 @@ function FormFieldTextEditorTipTapUnmemoised({
 		onUpdate: ({ editor }) => {
 			updatesBlocked.current = true;
 
-			const content = isEmptyDOM(editor.view.dom) ? "" : escapeHtmlSpaces(transformScriptTags(editor.getHTML()));
+			const content = isEmptyDOM(editor.view.dom) ? "" : escapeHtml(transformScriptTags(editor.getHTML()));
 			lastValidContent.current = content;
 			onChange(content);
 		},

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTap.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTap.tsx
@@ -1,5 +1,9 @@
-import React, { ReactElement, useState, useMemo, useEffect, useRef, useCallback, memo } from "react";
-import { useEditor, EditorOptions, Extensions } from "@tiptap/react";
+import type { ReactElement } from "react";
+import type { EditorOptions, Extensions } from "@tiptap/react";
+
+import React, { useState, useMemo, useEffect, useRef, useCallback, memo } from "react";
+import { useEditor } from "@tiptap/react";
+import Skeleton from "@mui/material/Skeleton";
 
 import type { SelectionType, FloatingToolbarState, EditorMode, NodeFormState, TextEditorNextInputSettings, TextEditorData } from "./FormFieldTextEditorTypes";
 import type { MosaicFieldProps } from "../FieldTypes";
@@ -28,6 +32,7 @@ function FormFieldTextEditorTipTapUnmemoised({
 		} = {},
 	},
 	disabled,
+	skeleton,
 }: MosaicFieldProps<"textEditor", TextEditorNextInputSettings, TextEditorData>): ReactElement {
 	const [mode, setMode] = useState<EditorMode>("visual");
 	const [focus, setFocus] = useState(false);
@@ -117,8 +122,6 @@ function FormFieldTextEditorTipTapUnmemoised({
 		},
 		editable: !disabled,
 	}, []);
-	const { view } = editor;
-	const { state: { selection: { from, to } } } = view;
 
 	const inputSettings = useMemo<TextEditorNextInputSettings>(() => ({
 		...providedInputSettings,
@@ -142,7 +145,7 @@ function FormFieldTextEditorTipTapUnmemoised({
 				updateImage(...params);
 			},
 		})),
-	}), [from, providedInputSettings, to, view]);
+	}), [editor, providedInputSettings]);
 
 	useEffect(() => {
 		if (updatesBlocked.current) {
@@ -168,6 +171,16 @@ function FormFieldTextEditorTipTapUnmemoised({
 		setNodeForm((state) => ({ ...state, open: false }));
 		editor.chain().focus();
 	};
+
+	if (skeleton) {
+		return (
+			<Skeleton
+				variant="rectangular"
+				width="100%"
+				height={130}
+			/>
+		);
+	}
 
 	return (
 		<StyledTextEditor $disabled={disabled}>

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTapFieldType.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTapFieldType.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+
+import type { FieldDef } from "../FieldTypes";
+
 import FieldWrapper from "@root/components/FieldWrapper";
 import { FormFieldTextEditorTipTap } from "./FormFieldTextEditorTipTap";
-import { FieldDef } from "../FieldTypes";
 
 /**
  * TODO: Remove once tip tap field is stable

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
@@ -65,6 +65,7 @@ export type ControlName =
 	| "bulletList"
 	| "orderedList"
 	| "link"
+	| "linkPreview"
 	| "image"
 	| "codeBlock"
 	| "blockquote"

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
@@ -11,13 +11,15 @@ export type SelectionType =
 	| "image"
 	| "link";
 
-export interface FloatingToolbarState {
-	open: boolean;
-	anchor?: { getBoundingClientRect: () => DOMRect };
-	selectionTypes: SelectionType[];
+export interface VirtualElement {
+	getBoundingClientRect: () => DOMRect;
 }
 
-export type NodeFormType = "link" | "image";
+export interface FloatingToolbarState {
+	open: boolean;
+	anchor?: VirtualElement;
+	selectionTypes: SelectionType[];
+}
 
 export interface NodeFormTypeProps {
 	editor: Editor;
@@ -25,13 +27,18 @@ export interface NodeFormTypeProps {
 	getFormValues: FormProps["getFormValues"];
 }
 
-export interface NodeFormState {
+export type NodeFormState = {
 	open: boolean;
 	anchorEl?: PopperProps["anchorEl"];
-	values?: any;
-	type: NodeFormType;
-
-}
+} & ({
+	type: "link";
+	values: Partial<TextEditorUpdateLinkValues>;
+	update: TextEditorUpdateLink;
+} | {
+	type: "image";
+	values: Partial<TextEditorUpdateImageValues>;
+	update: TextEditorUpdateImage;
+});
 
 export type NodeFormSet = Dispatch<SetStateAction<NodeFormState>>;
 
@@ -74,7 +81,6 @@ export type ControlBase = {
 export type ControlWithProps = ControlBase & {
 	cmd: (params: {
 		editor: Editor;
-		setNodeForm: NodeFormSet;
 		inputSettings: TextEditorNextInputSettings;
 	}) => void;
 	Icon?: SvgIconComponent;
@@ -83,7 +89,6 @@ export type ControlWithProps = ControlBase & {
 export type ControlComponentProps = {
 	editor: Editor;
 	onClose?: () => void;
-	setNodeForm: NodeFormSet;
 	inputSettings: TextEditorNextInputSettings;
 } & Omit<ControlWithComponent, "component">;
 
@@ -153,6 +158,7 @@ export type TextEditorNextInputSettings = {
 	extensions?: Extensions;
 	onLink?: (params: TextEditorOnLinkParams) => void;
 	onImage?: (params: TextEditorOnImageParams) => void;
+	allowedLinkProtocols?: string[];
 };
 
 export type TextEditorData = string;

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
@@ -4,7 +4,7 @@ import type { Editor, Extensions } from "@tiptap/core";
 import type { FieldDefBase } from "@root/components/Field";
 import type { MosaicToggle, SvgIconComponent } from "@root/types";
 import type { PopperProps } from "@mui/material/Popper";
-import { FormProps } from "@root/components/Form";
+import type { FormProps } from "@root/components/Form";
 
 export type SelectionType =
 	| "formatting"

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
@@ -90,6 +90,7 @@ export type ControlComponentProps = {
 	editor: Editor;
 	onClose?: () => void;
 	inputSettings: TextEditorNextInputSettings;
+	disabled?: boolean;
 } & Omit<ControlWithComponent, "component">;
 
 export type ControlWithComponent = ControlBase & {
@@ -106,6 +107,7 @@ export type ControlMenu = ControlBase & {
 export interface MenuButtonProps {
 	onClick: (e: MouseEvent<HTMLButtonElement>) => void;
 	editor: Editor;
+	disabled?: boolean;
 }
 
 export type Controls = (

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
@@ -130,6 +130,7 @@ export type TextEditorInputSettings = {
 export interface TextEditorUpdateLinkValues {
 	url: string;
 	newTab?: boolean;
+	text?: string;
 }
 
 export type TextEditorUpdateLink = (params: TextEditorUpdateLinkValues) => void;

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/JoditEditor.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/JoditEditor.tsx
@@ -1,10 +1,13 @@
-import * as React from "react";
-import { memo, ReactElement, useEffect, useRef, useMemo } from "react";
-import { MosaicFieldProps } from "@root/components/Field";
-import { EditorWrapper } from "./FormFieldTextEditor.styled";
+import type { ReactElement } from "react";
+
 import { Jodit } from "jodit";
 import "jodit/build/jodit.min.css";
-import { TextEditorData, TextEditorInputSettings } from "./FormFieldTextEditorTypes";
+import React, { memo, useEffect, useRef, useMemo } from "react";
+
+import type { MosaicFieldProps } from "@root/components/Field";
+import type { TextEditorData, TextEditorInputSettings } from "./FormFieldTextEditorTypes";
+
+import { EditorWrapper } from "./FormFieldTextEditor.styled";
 
 const buttonList = [
 	"source",

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/LinkOpen.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/LinkOpen.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from "react";
+import type { ReactElement } from "react";
+
+import React from "react";
 import NewTabIcon from "@mui/icons-material/OpenInNew";
 
 import { StyledLinkOpen } from "./NodeForm.styled";

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeForm.styled.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeForm.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import theme from "@root/theme";
 import Button from "@root/components/Button";
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeForm.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeForm.tsx
@@ -1,5 +1,6 @@
+import type { Editor } from "@tiptap/react";
+
 import React, { useCallback } from "react";
-import { Editor } from "@tiptap/react";
 import Popper from "@mui/material/Popper";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeForm.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeForm.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, ReactElement } from "react";
+import React, { useCallback } from "react";
 import { Editor } from "@tiptap/react";
 import Popper from "@mui/material/Popper";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 
-import type { NodeFormState, NodeFormType, NodeFormTypeProps } from "../FormFieldTextEditorTypes";
+import type { NodeFormState } from "../FormFieldTextEditorTypes";
 
 import { StyledNodeForm } from "./NodeForm.styled";
 import { NodeFormLink } from "./NodeFormLink";
@@ -24,21 +24,15 @@ const popperModifiers = [
 	},
 ];
 
-const nodeTypeComponentMap: Record<NodeFormType, (editor: NodeFormTypeProps) => ReactElement> = {
-	link: NodeFormLink,
-	image: NodeFormImage,
-};
-
 export function NodeForm({
 	editor,
 	onClose,
 	type,
 	values,
+	update,
 	anchorEl,
 	open,
 }: NodeFormProps) {
-	const TypeComponent = nodeTypeComponentMap[type];
-
 	const getFormValues = useCallback(async () => {
 		if (!values) {
 			return {};
@@ -55,11 +49,21 @@ export function NodeForm({
 		>
 			<ClickAwayListener onClickAway={onClose}>
 				<StyledNodeForm>
-					<TypeComponent
-						editor={editor}
-						onClose={onClose}
-						getFormValues={getFormValues}
-					/>
+					{type === "link" ? (
+						<NodeFormLink
+							editor={editor}
+							getFormValues={getFormValues}
+							onClose={onClose}
+							update={update}
+						/>
+					) : type === "image" ? (
+						<NodeFormImage
+							editor={editor}
+							getFormValues={getFormValues}
+							onClose={onClose}
+							update={update}
+						/>
+					) : null}
 				</StyledNodeForm>
 			</ClickAwayListener>
 		</Popper>

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormFooter.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormFooter.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from "react";
+import type { ReactElement } from "react";
+import React from "react";
 
 import Button from "@root/components/Button";
 import { StyledFormFooter } from "@root/components/Form/Form.styled";

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormImage.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormImage.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useCallback, ReactElement } from "react";
+import type { ReactElement } from "react";
+import React, { useMemo, useCallback } from "react";
 
 import type { FieldDef } from "@root/components/Field";
 import type { NodeFormTypeProps, TextEditorUpdateImage } from "../FormFieldTextEditorTypes";

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormImage.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormImage.tsx
@@ -1,22 +1,22 @@
 import React, { useMemo, useCallback, ReactElement } from "react";
 
 import type { FieldDef } from "@root/components/Field";
-import type { NodeFormTypeProps } from "../FormFieldTextEditorTypes";
+import type { NodeFormTypeProps, TextEditorUpdateImage } from "../FormFieldTextEditorTypes";
 
 import Form, { useForm } from "@root/components/Form";
 import { NodeFormFooter } from "./NodeFormFooter";
 
-export function NodeFormImage({ editor, getFormValues, onClose }: NodeFormTypeProps): ReactElement {
+type NodeFormImageProps = NodeFormTypeProps & {
+	update: TextEditorUpdateImage;
+};
+
+export function NodeFormImage({ getFormValues, update }: NodeFormImageProps): ReactElement {
 	const controller = useForm();
 	const { handleSubmit } = controller;
 
 	const onSubmit = handleSubmit(useCallback(({ data: { alt, src } }) => {
-		editor.chain().focus()
-			.setImage({ alt, src })
-			.run();
-
-		onClose();
-	}, [editor, onClose]));
+		update({ alt, src });
+	}, [update]));
 
 	const fields = useMemo<FieldDef[]>(() => [
 		{

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormLink.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormLink.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useCallback, ReactElement } from "react";
+import type { ReactElement } from "react";
+import React, { useMemo, useCallback } from "react";
 
 import type { FieldDef } from "@root/components/Field";
 import type { NodeFormTypeProps, TextEditorUpdateLink } from "../FormFieldTextEditorTypes";

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormLink.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormLink.tsx
@@ -11,13 +11,14 @@ export function NodeFormLink({ editor, getFormValues, onClose }: NodeFormTypePro
 	const controller = useForm();
 	const { state: { data: { url } }, handleSubmit } = controller;
 
-	const onSubmit = handleSubmit(useCallback(({ data: { url, newTab } }) => {
+	const onSubmit = handleSubmit(useCallback(({ data: { url, newTab, text } }) => {
 		editor.chain().focus()
 			.extendMarkRange("link")
 			.setLink({
 				href: url,
 				target: newTab ? "_blank" : "",
 			})
+			.insertContent(text)
 			.run();
 
 		onClose();
@@ -36,6 +37,13 @@ export function NodeFormLink({ editor, getFormValues, onClose }: NodeFormTypePro
 		{
 			name: "url",
 			label: "URL",
+			type: "text",
+			required: true,
+			validateOn: "onSubmit",
+		},
+		{
+			name: "text",
+			label: "Text",
 			type: "text",
 			required: true,
 			validateOn: "onSubmit",

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormLink.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormLink.tsx
@@ -1,28 +1,23 @@
 import React, { useMemo, useCallback, ReactElement } from "react";
 
 import type { FieldDef } from "@root/components/Field";
-import type { NodeFormTypeProps } from "../FormFieldTextEditorTypes";
+import type { NodeFormTypeProps, TextEditorUpdateLink } from "../FormFieldTextEditorTypes";
 
 import Form, { useForm } from "@root/components/Form";
 import { LinkOpen } from "./LinkOpen";
 import { NodeFormFooter } from "./NodeFormFooter";
 
-export function NodeFormLink({ editor, getFormValues, onClose }: NodeFormTypeProps): ReactElement {
+type NodeFormLinkProps = NodeFormTypeProps & {
+	update: TextEditorUpdateLink;
+};
+
+export function NodeFormLink({ editor, getFormValues, onClose, update }: NodeFormLinkProps): ReactElement {
 	const controller = useForm();
 	const { state: { data: { url } }, handleSubmit } = controller;
 
 	const onSubmit = handleSubmit(useCallback(({ data: { url, newTab, text } }) => {
-		editor.chain().focus()
-			.extendMarkRange("link")
-			.setLink({
-				href: url,
-				target: newTab ? "_blank" : "",
-			})
-			.insertContent(text)
-			.run();
-
-		onClose();
-	}, [editor, onClose]));
+		update({ url, newTab, text });
+	}, [update]));
 
 	const onRemove = useCallback(() => {
 		editor.chain().focus()

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlButton.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlButton.tsx
@@ -11,9 +11,18 @@ interface ControlButtonProps extends ComponentProps<typeof StyledControlButton> 
 	active?: boolean;
 	square?: boolean;
 	shortcut?: ShortcutDef;
+	disabled?: boolean;
 }
 
-export const ControlButton = forwardRef<HTMLButtonElement, PropsWithChildren<ControlButtonProps>>(function ControlButton({ label, children, active, square, shortcut, ...props }, providedRef): ReactElement {
+export const ControlButton = forwardRef<HTMLButtonElement, PropsWithChildren<ControlButtonProps>>(function ControlButton({
+	label,
+	children,
+	active,
+	square,
+	shortcut,
+	disabled,
+	...props
+}, providedRef): ReactElement {
 	const { anchorProps, tooltipProps } = useTooltip();
 
 	const setRef = (ref: HTMLButtonElement) => {
@@ -36,6 +45,7 @@ export const ControlButton = forwardRef<HTMLButtonElement, PropsWithChildren<Con
 				ref={setRef}
 				$active={active}
 				$square={square}
+				disabled={disabled}
 			>
 				{children}
 			</StyledControlButton>

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlButton.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlButton.tsx
@@ -1,4 +1,6 @@
-import React, { ComponentProps, forwardRef, PropsWithChildren, ReactElement } from "react";
+import type { ComponentProps, PropsWithChildren, ReactElement } from "react";
+
+import React, { forwardRef } from "react";
 
 import type { ShortcutDef } from "../../FormFieldTextEditorTypes";
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlHeadings.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlHeadings.tsx
@@ -1,11 +1,14 @@
-import React, { ReactElement } from "react";
-import { Editor } from "@tiptap/core";
-import { Level } from "@tiptap/extension-heading";
+import type { ReactElement } from "react";
+import type { Editor } from "@tiptap/core";
+import type { Level } from "@tiptap/extension-heading";
 
-import { MenuItemLabel, MenuItemShortcut, StyledMenuItem } from "../../FormFieldTextEditorTipTap.styled";
-import { ControlWithComponent } from "../../FormFieldTextEditorTypes";
-import { Shortcut } from "..";
+import React from "react";
+
+import type { ControlWithComponent } from "../../FormFieldTextEditorTypes";
+
 import testIds from "@root/utils/testIds";
+import { MenuItemLabel, MenuItemShortcut, StyledMenuItem } from "../../FormFieldTextEditorTipTap.styled";
+import { Shortcut } from "..";
 
 type ControlHeadingProps = Omit<ControlWithComponent, "component"> & {
 	editor: Editor;

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenu.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenu.tsx
@@ -1,6 +1,8 @@
-import React, { useState, ReactElement, MouseEvent } from "react";
+import type { ReactElement, MouseEvent } from "react";
+import type { Editor } from "@tiptap/core";
+
+import React, { useState } from "react";
 import MoreIcon from "@mui/icons-material/MoreVert";
-import { Editor } from "@tiptap/core";
 
 import type { Control, MenuButtonProps, TextEditorNextInputSettings } from "../../FormFieldTextEditorTypes";
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenu.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenu.tsx
@@ -9,19 +9,23 @@ import { ControlMenuItem } from "./ControlMenuItem";
 import { ControlButton } from "./ControlButton";
 import testIds from "@root/utils/testIds";
 
+interface ControlMenuDropdownProps {
+	editor: Editor;
+	controls: Control[];
+	MenuButton?: (props: MenuButtonProps) => ReactElement;
+	inputSettings: TextEditorNextInputSettings;
+	testId?: string;
+	disabled?: boolean;
+}
+
 export function ControlMenuDropdown({
 	editor,
 	controls,
 	MenuButton,
 	inputSettings,
 	testId,
-}: {
-	editor: Editor;
-	controls: Control[];
-	MenuButton?: (props: MenuButtonProps) => ReactElement;
-	inputSettings: TextEditorNextInputSettings;
-	testId?: string;
-}): ReactElement {
+	disabled,
+}: ControlMenuDropdownProps): ReactElement {
 	const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
 	const onClick = (e: MouseEvent<HTMLButtonElement>) => {
@@ -41,6 +45,7 @@ export function ControlMenuDropdown({
 				<MenuButton
 					onClick={onClick}
 					editor={editor}
+					disabled={disabled}
 				/>
 			) : (
 				<ControlButton
@@ -48,6 +53,7 @@ export function ControlMenuDropdown({
 					square
 					active={isActive}
 					data-testid={testId}
+					disabled={disabled}
 				>
 					<MoreIcon />
 				</ControlButton>
@@ -65,6 +71,7 @@ export function ControlMenuDropdown({
 						key={index}
 						inputSettings={inputSettings}
 						data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${control.name}`}
+						disabled={disabled}
 					/>
 				) : (
 					<ControlMenuItem

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenu.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenu.tsx
@@ -2,7 +2,7 @@ import React, { useState, ReactElement, MouseEvent } from "react";
 import MoreIcon from "@mui/icons-material/MoreVert";
 import { Editor } from "@tiptap/core";
 
-import type { Control, MenuButtonProps, NodeFormSet, TextEditorNextInputSettings } from "../../FormFieldTextEditorTypes";
+import type { Control, MenuButtonProps, TextEditorNextInputSettings } from "../../FormFieldTextEditorTypes";
 
 import { StyledControlMenu } from "../../FormFieldTextEditorTipTap.styled";
 import { ControlMenuItem } from "./ControlMenuItem";
@@ -13,14 +13,12 @@ export function ControlMenuDropdown({
 	editor,
 	controls,
 	MenuButton,
-	setNodeForm,
 	inputSettings,
 	testId,
 }: {
 	editor: Editor;
 	controls: Control[];
 	MenuButton?: (props: MenuButtonProps) => ReactElement;
-	setNodeForm: NodeFormSet;
 	inputSettings: TextEditorNextInputSettings;
 	testId?: string;
 }): ReactElement {
@@ -65,7 +63,6 @@ export function ControlMenuDropdown({
 						onClose={onClose}
 						editor={editor}
 						key={index}
-						setNodeForm={setNodeForm}
 						inputSettings={inputSettings}
 						data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${control.name}`}
 					/>
@@ -74,7 +71,6 @@ export function ControlMenuDropdown({
 						{...control}
 						onClose={onClose}
 						editor={editor}
-						setNodeForm={setNodeForm}
 						inputSettings={inputSettings}
 						key={index}
 					/>

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenuItem.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenuItem.tsx
@@ -1,14 +1,13 @@
 import React, { ReactElement } from "react";
 import { Editor } from "@tiptap/core";
 
-import type { ControlWithProps, NodeFormSet, TextEditorNextInputSettings } from "../../FormFieldTextEditorTypes";
+import type { ControlWithProps, TextEditorNextInputSettings } from "../../FormFieldTextEditorTypes";
 
 import { MenuItemLabel, MenuItemShortcut, StyledMenuItem } from "../../FormFieldTextEditorTipTap.styled";
 import testIds from "@root/utils/testIds";
 
 type ControlMenuItemProps = ControlWithProps & {
 	editor: Editor;
-	setNodeForm: NodeFormSet;
 	inputSettings: TextEditorNextInputSettings;
 	onClose: () => void;
 };
@@ -21,11 +20,10 @@ export function ControlMenuItem({
 	cmd,
 	editor,
 	onClose,
-	setNodeForm,
 	inputSettings,
 }: ControlMenuItemProps): ReactElement {
 	const onClick = () => {
-		cmd({ editor, setNodeForm, inputSettings });
+		cmd({ editor, inputSettings });
 		onClose();
 	};
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenuItem.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenuItem.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from "react";
-import { Editor } from "@tiptap/core";
+import type { ReactElement } from "react";
+import type { Editor } from "@tiptap/core";
+
+import React from "react";
 
 import type { ControlWithProps, TextEditorNextInputSettings } from "../../FormFieldTextEditorTypes";
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/TextStyleMenuButton.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/TextStyleMenuButton.tsx
@@ -5,7 +5,7 @@ import type { MenuButtonProps } from "../../FormFieldTextEditorTypes";
 import { StyledTextStyleMenuButton } from "../../FormFieldTextEditorTipTap.styled";
 import testIds from "@root/utils/testIds";
 
-export function TextStyleMenuButton({ editor, onClick }: MenuButtonProps): ReactElement {
+export function TextStyleMenuButton({ disabled, editor, onClick }: MenuButtonProps): ReactElement {
 	const textStyles = {
 		"Normal Text": editor.isActive("paragraph"),
 		"Heading 1": editor.isActive("heading", { level: 1 }),
@@ -21,7 +21,7 @@ export function TextStyleMenuButton({ editor, onClick }: MenuButtonProps): React
 	return (
 		<StyledTextStyleMenuButton
 			onClick={onClick}
-			disabled={!currentStyle}
+			disabled={disabled || !currentStyle}
 			data-testid={testIds.TEXT_EDITOR_HEADING_MENU}
 		>
 			{currentStyle || "Normal Text"}

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/TextStyleMenuButton.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/TextStyleMenuButton.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from "react";
+import type { ReactElement } from "react";
+
+import React from "react";
 
 import type { MenuButtonProps } from "../../FormFieldTextEditorTypes";
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/predefinedControls.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/predefinedControls.tsx
@@ -11,6 +11,7 @@ import AlignJustifyIcon from "@mui/icons-material/FormatAlignJustify";
 import ImageIcon from "@mui/icons-material/Image";
 import ItalicIcon from "@mui/icons-material/FormatItalic";
 import LinkIcon from "@mui/icons-material/Link";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import UndoIcon from "@mui/icons-material/Undo";
 import RedoIcon from "@mui/icons-material/Redo";
 import UnderlineIcon from "@mui/icons-material/FormatUnderlined";
@@ -297,6 +298,22 @@ export const controlLink: Control = {
 	Icon: LinkIcon,
 };
 
+export const controlLinkPreview: Control = {
+	name: "linkPreview",
+	label: "Open URL in new tab",
+	cmd: ({ editor }) => {
+		const link = editor.state.selection.$to.marks()
+			.find(({ type }) => type.name === "link");
+
+		if (!link || !link.attrs.href) {
+			return;
+		}
+
+		window.open(link.attrs.href, "_blank");
+	},
+	Icon: OpenInNewIcon,
+};
+
 export const controlImage: Control = {
 	name: "image",
 	label: "Image",
@@ -381,6 +398,7 @@ export const predefinedControls: (Control | ControlMenu)[] = [
 	controlBulletList,
 	controlOrderedList,
 	controlLink,
+	controlLinkPreview,
 	controlImage,
 	controlCodeBlock,
 	controlBlockquote,

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/predefinedControls.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/predefinedControls.tsx
@@ -1,5 +1,6 @@
+import type { Node } from "@tiptap/pm/model";
+
 import "highlight.js/styles/stackoverflow-light.min.css";
-import { Node } from "@tiptap/pm/model";
 
 import BoldIcon from "@mui/icons-material/FormatBold";
 import ClearIcon from "@mui/icons-material/FormatClear";

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/predefinedControls.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/predefinedControls.tsx
@@ -254,8 +254,8 @@ export const controlAlignJustify: Control = {
 	cmd: ({ editor }) => editor.chain().focus().setTextAlign("justify").run(),
 	Icon: AlignJustifyIcon,
 	shortcut: {
-		mac: "Cmd+Shift+R",
-		pc: "Ctrl+Shift+R",
+		mac: "Cmd+Shift+J",
+		pc: "Ctrl+Shift+J",
 	},
 };
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/predefinedControls.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/predefinedControls.tsx
@@ -264,25 +264,29 @@ export const controlLink: Control = {
 	label: "Link",
 	cmd: ({ editor, inputSettings: { onLink }, setNodeForm }) => {
 		const { view } = editor;
-		const { state: { selection: { from, to } } } = view;
+		const { state, state: { selection: { from, to } } } = view;
 
 		const link = editor.state.selection.$to.marks()
 			.find(({ type }) => type.name === "link");
 
+		const text = link ? editor.state.doc.nodeAt(to - 1)?.textContent : state.doc.textBetween(from, to);
+
 		const values = {
 			url: link?.attrs.href || "",
 			newTab: link?.attrs.target === "_blank",
+			text,
 		};
 
 		if (onLink) {
 			onLink({
 				...values,
-				updateLink: ({ url, newTab }) => editor.chain().focus()
+				updateLink: ({ url, newTab, text }) => editor.chain().focus()
 					.extendMarkRange("link")
 					.setLink({
 						href: url,
 						target: newTab ? "_blank" : "",
 					})
+					.insertContent(text)
 					.run(),
 			});
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ModeSwitch.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ModeSwitch.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from "react";
+import type { ReactElement } from "react";
+
+import React from "react";
 
 import type { EditorMode } from "../FormFieldTextEditorTypes";
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Shortcut.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Shortcut.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement } from "react";
+import type { ReactElement } from "react";
+
+import React from "react";
 
 import type { ShortcutDef } from "../FormFieldTextEditorTypes";
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControls.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControls.tsx
@@ -12,6 +12,7 @@ export interface ToolbarControlsProps {
 	editor: Editor;
 	selectionTypes?: SelectionType[];
 	inputSettings: TextEditorNextInputSettings;
+	disabled?: boolean;
 }
 
 export function ToolbarControls({
@@ -19,6 +20,7 @@ export function ToolbarControls({
 	controls: controlsDef,
 	selectionTypes,
 	inputSettings = {},
+	disabled,
 }: ToolbarControlsProps): ReactElement {
 	const groups = useMemo(() => resolveControls(controlsDef, selectionTypes), [controlsDef, selectionTypes]);
 
@@ -33,6 +35,7 @@ export function ToolbarControls({
 							controls={control}
 							inputSettings={inputSettings}
 							testId={`${testIds.TEXT_EDITOR_CONTROL}:menu-${groupIndex}-${index}`}
+							disabled={disabled}
 						/>
 					) : "MenuButton" in control ? (
 						<ControlMenuDropdown
@@ -41,6 +44,7 @@ export function ToolbarControls({
 							controls={control.controls}
 							MenuButton={control.MenuButton}
 							inputSettings={inputSettings}
+							disabled={disabled}
 						/>
 					) : "Component" in control ? (
 						<control.Component
@@ -49,6 +53,7 @@ export function ToolbarControls({
 							editor={editor}
 							inputSettings={inputSettings}
 							data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${control.name}`}
+							disabled={disabled}
 						/>
 					) : (
 						<ControlButton
@@ -59,6 +64,7 @@ export function ToolbarControls({
 							active={editor.isActive(control.name)}
 							square
 							data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${control.name}`}
+							disabled={disabled}
 						>
 							<control.Icon />
 						</ControlButton>

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControls.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControls.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useMemo } from "react";
 import { Editor } from "@tiptap/core";
 
-import type { ControlsConfig, SelectionType, NodeFormSet, TextEditorNextInputSettings } from "../FormFieldTextEditorTypes";
+import type { ControlsConfig, SelectionType, TextEditorNextInputSettings } from "../FormFieldTextEditorTypes";
 
 import { ControlButton, ControlMenuDropdown, resolveControls } from "./Controls";
 import { ControlGroup, ControlGroups } from "../FormFieldTextEditorTipTap.styled";
@@ -11,7 +11,6 @@ export interface ToolbarControlsProps {
 	controls: ControlsConfig;
 	editor: Editor;
 	selectionTypes?: SelectionType[];
-	setNodeForm: NodeFormSet;
 	inputSettings: TextEditorNextInputSettings;
 }
 
@@ -19,7 +18,6 @@ export function ToolbarControls({
 	editor,
 	controls: controlsDef,
 	selectionTypes,
-	setNodeForm,
 	inputSettings = {},
 }: ToolbarControlsProps): ReactElement {
 	const groups = useMemo(() => resolveControls(controlsDef, selectionTypes), [controlsDef, selectionTypes]);
@@ -33,7 +31,6 @@ export function ToolbarControls({
 							key={index}
 							editor={editor}
 							controls={control}
-							setNodeForm={setNodeForm}
 							inputSettings={inputSettings}
 							testId={`${testIds.TEXT_EDITOR_CONTROL}:menu-${groupIndex}-${index}`}
 						/>
@@ -43,7 +40,6 @@ export function ToolbarControls({
 							editor={editor}
 							controls={control.controls}
 							MenuButton={control.MenuButton}
-							setNodeForm={setNodeForm}
 							inputSettings={inputSettings}
 						/>
 					) : "Component" in control ? (
@@ -51,14 +47,13 @@ export function ToolbarControls({
 							{...control}
 							key={index}
 							editor={editor}
-							setNodeForm={setNodeForm}
 							inputSettings={inputSettings}
 							data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${control.name}`}
 						/>
 					) : (
 						<ControlButton
 							key={control.name}
-							onClick={() => control.cmd({ editor, setNodeForm, inputSettings })}
+							onClick={() => control.cmd({ editor, inputSettings })}
 							label={control.label}
 							shortcut={control.shortcut}
 							active={editor.isActive(control.name)}

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControls.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControls.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement, useMemo } from "react";
-import { Editor } from "@tiptap/core";
+import type { ReactElement } from "react";
+import type { Editor } from "@tiptap/core";
+
+import React, { useMemo } from "react";
 
 import type { ControlsConfig, SelectionType, TextEditorNextInputSettings } from "../FormFieldTextEditorTypes";
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/textEditorUtils.ts
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/textEditorUtils.ts
@@ -1,0 +1,45 @@
+import { posToDOMRect, Editor as TipTapEditor } from "@tiptap/react";
+
+import type { ControlBase, ControlsConfig, VirtualElement } from "./FormFieldTextEditorTypes";
+
+import { controlBold, controlClear, controlImage, controlItalic, controlLink, controlStrikethrough, controlSuperscript, controlUnderline } from "./Toolbar/Controls/predefinedControls";
+
+export const defaultControls: ControlsConfig = [
+	["headings"],
+	["bold", "italic", ["underline", "strike", "superscript", "subscript", "clear"]],
+	["bulletList", "orderedList"],
+	["alignLeft", "alignCenter", ["alignRight", "alignJustify"]],
+	["link", ["image", "codeBlock", "blockquote"]],
+	["undo", "redo"],
+];
+
+const formattingShow: ControlBase["show"] = ({ selectionTypes = [] }) => selectionTypes.includes("formatting");
+
+export const floatingControls: ControlsConfig = [
+	[
+		{ ...controlBold, show: formattingShow },
+		{ ...controlItalic, show: formattingShow },
+		[
+			{ ...controlUnderline, show: formattingShow },
+			{ ...controlStrikethrough, show: formattingShow },
+			{ ...controlSuperscript, show: formattingShow },
+			{ ...controlClear, show: formattingShow },
+		],
+	],
+	[
+		{
+			...controlLink,
+			show: ({ selectionTypes = [] }) => !selectionTypes.includes("image"),
+		},
+		{
+			...controlImage,
+			show: ({ selectionTypes = [] }) => selectionTypes.includes("image"),
+		},
+	],
+];
+
+export function selectionVirtualElement({ view, state: { selection: { from, to } } }: TipTapEditor): VirtualElement {
+	return {
+		getBoundingClientRect: () => posToDOMRect(view, from, to),
+	};
+}

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/textEditorUtils.ts
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/textEditorUtils.ts
@@ -4,7 +4,7 @@ import { posToDOMRect } from "@tiptap/react";
 
 import type { ControlBase, ControlsConfig, VirtualElement } from "./FormFieldTextEditorTypes";
 
-import { controlBold, controlClear, controlImage, controlItalic, controlLink, controlStrikethrough, controlSuperscript, controlUnderline } from "./Toolbar/Controls/predefinedControls";
+import { controlBold, controlClear, controlImage, controlItalic, controlLink, controlLinkPreview, controlStrikethrough, controlSuperscript, controlUnderline } from "./Toolbar/Controls/predefinedControls";
 
 export const defaultControls: ControlsConfig = [
 	["headings"],
@@ -33,6 +33,12 @@ export const floatingControls: ControlsConfig = [
 			...controlLink,
 			show: ({ selectionTypes = [] }) => !selectionTypes.includes("image"),
 		},
+		{
+			...controlLinkPreview,
+			show: ({ selectionTypes = [] }) => !selectionTypes.includes("image") && selectionTypes.includes("link"),
+		},
+	],
+	[
 		{
 			...controlImage,
 			show: ({ selectionTypes = [] }) => selectionTypes.includes("image"),

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/textEditorUtils.ts
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/textEditorUtils.ts
@@ -1,4 +1,6 @@
-import { posToDOMRect, Editor as TipTapEditor } from "@tiptap/react";
+import type { Editor as TipTapEditor } from "@tiptap/react";
+
+import { posToDOMRect } from "@tiptap/react";
 
 import type { ControlBase, ControlsConfig, VirtualElement } from "./FormFieldTextEditorTypes";
 

--- a/containers/mosaic/src/components/FieldWrapper/FieldWrapper.tsx
+++ b/containers/mosaic/src/components/FieldWrapper/FieldWrapper.tsx
@@ -15,7 +15,7 @@ function getValueLimit(def: FieldDef): number | undefined {
 	if (!def || !def.inputSettings) {
 		return;
 	}
-	console.log(typeof def.type === "function" && def.type.name);
+
 	if (def.type === "text" || def.type === "textEditor" || isTipTapField(def.type)) {
 		return def.inputSettings.maxCharacters;
 	}

--- a/containers/mosaic/src/utils/dom/escapeHtml.ts
+++ b/containers/mosaic/src/utils/dom/escapeHtml.ts
@@ -1,7 +1,7 @@
 import { isElement } from "./guards";
 import { mutateHtml } from "./mutateHtml";
 
-export function escapeHtmlSpaces(html: string, entity = "&nbsp"): string {
+export function escapeHtml(html: string, entity = "&nbsp"): string {
 	return mutateHtml(html, ({ parent, siblings, text }) => {
 		const parentTagName = parent.tagName.toLowerCase();
 		if (parentTagName === "script" || parentTagName === "style") {
@@ -17,7 +17,10 @@ export function escapeHtmlSpaces(html: string, entity = "&nbsp"): string {
 			const newText = text.textContent.replace(
 				/\s(?:\s+)/g,
 				(a) => ` ${entity.repeat(a.length - 1)}`,
-			);
+			)
+				.replace(/</g, "&lt;")
+				.replace(/>/g, "&gt;");
+
 			const fragment = document.createRange().createContextualFragment(newText);
 			text.replaceWith(fragment);
 		}

--- a/containers/mosaic/src/utils/dom/getHtmlCharacterCount.ts
+++ b/containers/mosaic/src/utils/dom/getHtmlCharacterCount.ts
@@ -2,12 +2,39 @@ import { getTextLength } from "../string";
 import { isElement } from "./guards";
 import { reduceHtml } from "./reduceHtml";
 
+function elementIsBlock(elem: HTMLElement): boolean {
+	// Chromium browsers will not calculate computed
+	// styles when the element is not inside the DOM.
+	// So we append it to the body, get its display
+	// type, then remove it.
+	const clone = elem.cloneNode() as HTMLElement;
+	document.body.appendChild(clone);
+
+	const styles = window.getComputedStyle(clone, "");
+
+	const result = styles && styles.display === "block";
+
+	document.body.removeChild(clone);
+
+	return result;
+}
+
 export function getHtmlCharacterCount(html: string): number {
-	return reduceHtml(html, (acc, { parent, siblings, text, elem }) => {
+	return reduceHtml(html, (acc, { index, parent, siblings, text, elem }) => {
+		const previousElement = siblings[index - 1];
+		const nextElement = siblings[index + 1];
+
 		if (
 			text &&
 			text.textContent &&
-			(!siblings.filter(isElement).length || text.textContent.match(/[^\s]/))
+			(
+				!siblings.filter(isElement).length ||
+				text.textContent.match(/[^\s]/) ||
+				(
+					previousElement && isElement(previousElement) && !elementIsBlock(previousElement) &&
+					nextElement && isElement(nextElement) && !elementIsBlock(nextElement)
+				)
+			)
 		) {
 			const parentTagName = parent.tagName.toLowerCase();
 
@@ -40,17 +67,7 @@ export function getHtmlCharacterCount(html: string): number {
 				// born are to be considered one character
 				// regardless of their content.
 				if (elem !== siblings[0]) {
-					// Chromium browsers will not calculate computed
-					// styles when the element is not inside the DOM.
-					// So we append it to the body, get its display
-					// type, then remove it.
-					const clone = elem.cloneNode() as HTMLElement;
-					document.body.appendChild(clone);
-
-					const styles = window.getComputedStyle(clone, "");
-					const returnValue = acc + (styles && styles.display === "block" ? 1 : 0);
-
-					document.body.removeChild(clone);
+					const returnValue = acc + (elementIsBlock(elem) ? 1 : 0);
 
 					return returnValue;
 				}

--- a/containers/mosaic/src/utils/dom/traverseHtml.ts
+++ b/containers/mosaic/src/utils/dom/traverseHtml.ts
@@ -2,6 +2,7 @@ import { isElement, isTextNode } from "./guards";
 
 export type TraverseHtmlCallback = (params: {
 	node: Node;
+	index: number;
 	elem?: HTMLElement;
 	text?: Text;
 	parent: HTMLElement;
@@ -11,12 +12,13 @@ export type TraverseHtmlCallback = (params: {
 export function traverseHtml(parent: HTMLElement, callback: TraverseHtmlCallback) {
 	const children = Array.from(parent.childNodes);
 
-	children.forEach((node) => {
+	children.forEach((node, index) => {
 		const elem = isElement(node) ? node : undefined;
 		const text = isTextNode(node) ? node : undefined;
 
 		callback({
 			node,
+			index,
 			parent,
 			elem,
 			text,

--- a/containers/mosaic/src/utils/string/getTextLength.ts
+++ b/containers/mosaic/src/utils/string/getTextLength.ts
@@ -1,5 +1,9 @@
 function getTextLength(str: string): number {
-	return Array.from(str).length;
+	if (!("Segmenter" in Intl)) {
+		return Array.from(str).length;
+	}
+
+	return [...new Intl.Segmenter("en", { granularity: "grapheme" }).segment(str)].length;
 }
 
 export default getTextLength;

--- a/containers/mosaic/src/utils/string/index.ts
+++ b/containers/mosaic/src/utils/string/index.ts
@@ -1,2 +1,3 @@
 export { default as joinAnd } from "./joinAnd";
 export { default as getTextLength } from "./getTextLength";
+export * from "./sanitizeUrl";

--- a/containers/mosaic/src/utils/string/sanitizeUrl.ts
+++ b/containers/mosaic/src/utils/string/sanitizeUrl.ts
@@ -1,0 +1,17 @@
+export const defaultAllowedProtocols = ["https", "http"];
+
+export function sanitizeUrl(url?: string, allowedProtocols: string[] = defaultAllowedProtocols): string {
+	if (!url) {
+		return "";
+	}
+
+	const [defaultProtocol = ""] = allowedProtocols;
+
+	for (const protocol of allowedProtocols) {
+		if (url.substring(0, protocol.length + 3) === `${protocol}://`) {
+			return url;
+		}
+	}
+
+	return `${defaultProtocol}://${url}`;
+}

--- a/containers/mosaic/tsconfig.json
+++ b/containers/mosaic/tsconfig.json
@@ -3,8 +3,10 @@
 		"jsx": "react",
 		"lib": [
 			"ES2019",
-			"DOM"
+			"DOM",
+			"ES2022.Intl"
 		],
+		"target": "ES2019",
 		"moduleResolution": "node",
 		"resolveJsonModule": true,
 		"baseUrl": "./",

--- a/containers/sb-8/stories/components/Field/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
@@ -203,7 +203,6 @@ export const Tiptap = ({
 	skeleton,
 	instructionText,
 	helperText,
-	spellcheck,
 	maxCharacters,
 	customImageHandler,
 	customLinkHandler,
@@ -260,7 +259,6 @@ export const Tiptap = ({
 			helperText,
 			instructionText,
 			maxCharacters,
-			spellcheck,
 			customImageHandler,
 			customLinkHandler,
 		],
@@ -309,7 +307,6 @@ Tiptap.args = {
 	skeleton: false,
 	instructionText: "Instruction text",
 	helperText: "Helper text",
-	spellcheck: false,
 	maxCharacters: 100,
 	customImageHandler: false,
 	customLinkHandler: false,
@@ -333,11 +330,6 @@ Tiptap.argTypes = {
 	},
 	helperText: {
 		name: "Helper Text",
-	},
-	spellcheck: {
-		name: "Direction",
-		control: { type: "select" },
-		options: ["ltr", "rtl"],
 	},
 	maxCharacters: {
 		name: "Maximum Characters",

--- a/containers/sb-8/stories/components/Field/FormFieldTextEditor/LinkLibraryDrawer.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldTextEditor/LinkLibraryDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useMemo } from "react";
+import React, { ReactElement, useCallback, useEffect, useMemo } from "react";
 import BulletinIcon from "@mui/icons-material/PushPin";
 import CalendarIcon from "@mui/icons-material/CalendarMonth";
 import ContactIcon from "@mui/icons-material/PermContactCalendar";
@@ -12,7 +12,7 @@ import Form, { useForm } from "@root/components/Form";
 import FieldWrapper from "@root/components/FieldWrapper";
 import { ButtonProps } from "@root/components/Button";
 
-import { DrawerWrapper, MediaGalleryChecked, MediaGalleryImage, MediaGalleryItem } from "./MediaGalleryDrawer.styled";
+import { DrawerWrapper } from "./MediaGalleryDrawer.styled";
 import { LinkLibraryAvatar } from "./LinkLibraryDrawer.styled";
 
 type LinkLibraryDrawerProps = Partial<TextEditorOnLinkParams> & {
@@ -92,7 +92,7 @@ function LinkSelectionField(props: any) {
     )
 }
 
-export function LinkLibraryDrawer({ onClose, updateLink, url, newTab }: LinkLibraryDrawerProps): ReactElement {
+export function LinkLibraryDrawer({ onClose, updateLink, url, newTab, text }: LinkLibraryDrawerProps): ReactElement {
     const controller = useForm();
     const { handleSubmit } = controller;
 
@@ -103,9 +103,14 @@ export function LinkLibraryDrawer({ onClose, updateLink, url, newTab }: LinkLibr
             label: "Open in New Tab"
         },
         {
+            name: "text",
+            type: "text",
+            label: "Text"
+        },
+        {
             name: "url",
             type: LinkSelectionField,
-            label: "target",
+            label: "Target",
             required: true,
         },
     ], []);
@@ -133,13 +138,15 @@ export function LinkLibraryDrawer({ onClose, updateLink, url, newTab }: LinkLibr
         updateLink({
             url: data.url,
             newTab: data.newTab,
+            text: data.text,
         });
     });
 
     const getFormValues = useCallback(async () => {
         return {
             newTab,
-            url
+            url,
+            text
         }
     }, [newTab, url]);
 


### PR DESCRIPTION
# [MOS-1428](https://simpleviewtools.atlassian.net/browse/MOS-1428)

## Description
- (TextEditor) Adds a "text" field to the link addition form and `updateLink` method which can be used to update the text content that the link wraps.
- Ensure character counter includes space between inline elements
- Introduce URL sanitiser and refactor node form
- Corrects align justify shortcut indicator
- Add disabled field functionality (or lack thereof) and styling
- Introduce a control to allow quick opening of existing editor links

## Checklist
- [x] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1428]: https://simpleviewtools.atlassian.net/browse/MOS-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ