### PR TITLE
MOS-1457

### DIFF
--- a/containers/mosaic/package.json
+++ b/containers/mosaic/package.json
@@ -17,6 +17,7 @@
 		"@testing-library/react": "16.0.1",
 		"@testing-library/user-event": "14.5.2",
 		"@types/lodash": "4.14.179",
+		"@types/node": "^22.5.5",
 		"@types/react": "18.3.5",
 		"@types/react-dom": "18.3.0",
 		"@typescript-eslint/eslint-plugin": "8.4.0",

--- a/containers/mosaic/src/__tests__/components/Field/FormFieldDate/DateField/DateField.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldDate/DateField/DateField.test.tsx
@@ -1,58 +1,122 @@
 import { render } from "@testing-library/react";
-import * as React from "react";
+import userEvent from "@testing-library/user-event";
+import React, { act } from "react";
+
+import type { DateData, DateFieldInputSettings, MosaicFieldProps } from "@root/components";
+
 import DateField from "@root/components/Field/FormFieldDate/DateField";
 import { screen } from "@testing-library/dom";
 
+async function setup({ onChange: providedOnChange, ...props }: MosaicFieldProps<"date", DateFieldInputSettings, DateData>) {
+	const onChangeMock = vi.fn();
+	const renderResult = await act(() => render(
+		<DateField
+			onChange={providedOnChange || onChangeMock}
+			{...props}
+		/>,
+	));
+
+	return {
+		...renderResult,
+		onChangeMock,
+		user: userEvent.setup(),
+	};
+}
+
 describe("DateField component", () => {
 	it("Should display the date value", () => {
-		render(
-			<DateField
-				fieldDef={{
-					name: "date",
-					type: "date",
-					label: "Date Input",
-					required: false,
-					disabled: false,
-					inputSettings: {
-						showTime: false,
-					},
-				}}
-				value={{
-					date: new Date("2022-01-01T00:00:00.000Z"),
-					validDate: true,
-					time: new Date("2022-01-01T00:00:00.000Z"),
-					validTime: true,
-				}}
+		setup({
+			fieldDef: {
+				name: "date",
+				type: "date",
+				label: "Date Input",
+				required: false,
+				disabled: false,
+				inputSettings: {
+					showTime: false,
+				},
+			},
+			value: {
+				date: new Date("2022-01-01T00:00:00.000Z"),
+				validDate: true,
+				time: new Date("2022-01-01T00:00:00.000Z"),
+				validTime: true,
+			},
+		});
 
-			/>,
-		);
 		expect(screen.getByDisplayValue("01/01/2022")).toBeInTheDocument();
 
 	});
 
 	it("Should display the date time values", () => {
-		render(
-			<DateField
-				fieldDef={{
-					name: "dateTime",
-					type: "date",
-					label: "Date Time Input",
-					required: false,
-					disabled: false,
-					inputSettings: {
-						showTime: true,
-					},
-				}}
-				value={{
-					date: new Date("2022-01-01T13:30:00.000Z"),
-					validDate: true,
-					time: new Date("2022-01-01T13:30:00.000Z"),
-					validTime: true,
-				}}
-			/>,
-		);
+		setup({
+			fieldDef: {
+				name: "dateTime",
+				type: "date",
+				label: "Date Time Input",
+				required: false,
+				disabled: false,
+				inputSettings: {
+					showTime: true,
+				},
+			},
+			value: {
+				date: new Date("2022-01-01T13:30:00.000Z"),
+				validDate: true,
+				time: new Date("2022-01-01T13:30:00.000Z"),
+				validTime: true,
+			},
+		});
 
 		expect(screen.getByDisplayValue("01/01/2022")).toBeInTheDocument();
 		expect(screen.getByDisplayValue("01:30 pm")).toBeInTheDocument();
+	});
+
+	it("should trigger a time change if a default time is provided but there is no value", async () => {
+		const onChangeMock = vi.fn(async (value) => {
+			if (typeof value === "function") {
+				return;
+			}
+
+			expect(value).toBeDefined();
+			expect(value.time).toBeInstanceOf(Date);
+			expect(value.time?.getHours()).toBe(23);
+			expect(value.time?.getMinutes()).toBe(59);
+		});
+
+		await setup({
+			fieldDef: {
+				name: "dateTime",
+				type: "date",
+				label: "Date Time Input",
+				inputSettings: {
+					showTime: true,
+					defaultTime: "23:59",
+				},
+			},
+			onChange: onChangeMock,
+		});
+	});
+
+	it("should not trigger a change if a default time is provided but there is a value", async () => {
+		const { onChangeMock } = await setup({
+			fieldDef: {
+				name: "dateTime",
+				type: "date",
+				label: "Date Time Input",
+				inputSettings: {
+					showTime: true,
+					defaultTime: "23:59",
+				},
+			},
+			value: {
+				date: new Date(25, 12, 24, 11, 30),
+				validDate: true,
+				time: new Date(25, 12, 24, 11, 30),
+				validTime: true,
+			},
+		});
+
+		expect(onChangeMock).not.toBeCalled();
 	});
 });

--- a/containers/mosaic/src/__tests__/components/Field/FormFieldTime/TimeField/TimeField.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldTime/TimeField/TimeField.test.tsx
@@ -1,7 +1,8 @@
 import { act, render, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
-import TimeField, { TimeData } from "@root/components/Field/FormFieldTime/TimeField";
+import type { TimeData } from "@root/components/Field/FormFieldTime/TimeField";
+import TimeField from "@root/components/Field/FormFieldTime/TimeField";
 import { screen } from "@testing-library/dom";
 
 function setup({ value }: { value?: TimeData } = {}) {
@@ -41,8 +42,6 @@ describe("TimeField component", () => {
 	it.skip("Should emit the correct date object with a valid input", async () => {
 		const { input, onChange, user } = setup();
 		await user.type(input, "06:30 am");
-
-		console.log(input);
 
 		expect(onChange).toBeCalledWith(
 			expect.objectContaining({

--- a/containers/mosaic/src/__tests__/utils/date/parseTime.test.ts
+++ b/containers/mosaic/src/__tests__/utils/date/parseTime.test.ts
@@ -1,0 +1,34 @@
+import type { TimeTuple } from "@root/components";
+
+import { parseTime } from "@root/utils/date";
+
+describe(__filename, function () {
+	it("should validate a correct 24hr time string", () => {
+		const value = "14:30";
+		const result = parseTime(value);
+
+		expect(result).toStrictEqual([14, 30, 0, 0]);
+	});
+	it("should validate a correct 24hr tuple", () => {
+		const value: TimeTuple = [18, 25, 30, 500];
+		const result = parseTime(value);
+
+		expect(result).toStrictEqual([18, 25, 30, 500]);
+	});
+	it("should throw when the string is not two time components, minutes and hours", () => {
+		const value = "6";
+
+		// @ts-expect-error We are testing for something that could be an invalid type
+		expect(() => parseTime(value)).toThrow("6 is not a valid 24hr time. It must contain hour and minute components separated by a colon.");
+	});
+	it("should throw when the string contains an invalid hour", () => {
+		const value = "24:59";
+
+		expect(() => parseTime(value)).toThrow("24:59 is not a valid 24hr time");
+	});
+	it("should throw when the string contains an invalid minute", () => {
+		const value = "00:60";
+
+		expect(() => parseTime(value)).toThrow("00:60 is not a valid 24hr time");
+	});
+});

--- a/containers/mosaic/src/components/Field/FormFieldDate/DateField/DateFieldTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDate/DateField/DateFieldTypes.tsx
@@ -1,4 +1,4 @@
-import { FieldDefBase } from "@root/components/Field";
+import type { FieldDefBase } from "@root/components/Field";
 
 export type DateFieldInputSettings = {
 	/**
@@ -24,6 +24,14 @@ export type DateFieldInputSettings = {
 	 * midnight
 	 */
 	fixedTime?: TimeTuple;
+	/**
+	 * The time to default to if the value for
+	 * this field is undefined. Can be a tuple like
+	 * `[hr, min, sec?, ms?]` or a 24hr string like `"HH:MM"`
+	 *
+	 * Only applicable if `showTime` is true.
+	 */
+	defaultTime?: TimeString | TimeTuple;
 };
 
 export type DateData = {
@@ -35,6 +43,8 @@ export type DateData = {
 
 export type FieldDefDate = FieldDefBase<"date", DateFieldInputSettings>;
 
-export type TimeTuple = [number, number, number, number];
+export type TimeTuple = [number, number, number?, number?];
+
+export type TimeString = `${number}${number}:${number}${number}`;
 
 export type FormFieldDateSkeletonProps = Pick<DateFieldInputSettings, "showTime">;

--- a/containers/mosaic/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
@@ -48,7 +48,6 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 	});
 
 	useEffect(() => {
-		console.log("setter effect..");
 		if (providedValue || !defaultTime) {
 			return;
 		}

--- a/containers/mosaic/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDate/DateField/FormFieldDate.tsx
@@ -1,28 +1,24 @@
-import * as React from "react";
-import { ReactElement, memo, useRef } from "react";
+import type { ReactElement } from "react";
 
-// Components
-import DatePicker from "../DatePicker";
-import TimePicker from "../../FormFieldTime/TimePicker";
+import React, { memo, useEffect, useMemo, useRef } from "react";
 
-// Styles
-import { DateTimePickerWrapper, DateTimeInputRow } from "./DateField.styled";
-import { MosaicFieldProps } from "@root/components/Field";
-import { DateFieldInputSettings, DateData } from "./DateFieldTypes";
-import { textIsValidDate } from "@root/utils/date";
+import type { MosaicFieldProps } from "@root/components/Field";
+import type { DateFieldInputSettings, DateData } from "./DateFieldTypes";
+
+import { matchTime, parseTime, textIsValidDate } from "@root/utils/date";
 import { DATE_FORMAT_FULL, DATE_FORMAT_FULL_PLACEHOLDER, TIME_FORMAT_FULL, TIME_FORMAT_FULL_PLACEHOLDER } from "@root/constants";
 import { INVALID_DATE, INVALID_TIME, TIME_REQUIRED } from "@root/components/Form/fieldErrors";
 import { useFieldErrors } from "@root/utils/hooks";
+import DatePicker from "../DatePicker";
+import TimePicker from "../../FormFieldTime/TimePicker";
+import { DateTimePickerWrapper, DateTimeInputRow } from "./DateField.styled";
 import { FormFieldDateSkeleton } from "./FormFieldDateSkeleton";
 
 const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, DateData>): ReactElement => {
 	const {
 		fieldDef,
 		onChange,
-		value = {
-			validDate: false,
-			validTime: false,
-		},
+		value: providedValue,
 		onBlur,
 		disabled,
 		error,
@@ -31,19 +27,49 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		skeleton,
 		id,
 	} = props;
+	const {
+		inputSettings: {
+			showTime,
+			minDate,
+			maxDate,
+			defaultTime,
+		} = {},
+	} = fieldDef;
 
-	const showTime = fieldDef?.inputSettings?.showTime;
 	const blurred = useRef<{ date: boolean; time: boolean }>({ date: false, time: false });
+	const value = useMemo(() => providedValue || {
+		validDate: false,
+		validTime: false,
+	}, [providedValue]);
 
 	const { addError, removeError } = useFieldErrors({
 		methods,
 		name: fieldDef.name,
 	});
 
+	useEffect(() => {
+		console.log("setter effect..");
+		if (providedValue || !defaultTime) {
+			return;
+		}
+
+		try {
+			const time = matchTime(new Date(), parseTime(defaultTime));
+			onChange({
+				date: undefined,
+				validDate: false,
+				time,
+				validTime: true,
+			});
+		} catch (err) {
+			console.error(err);
+		}
+	}, [defaultTime, providedValue, onChange]);
+
 	const handleDateChange = async (date: Date, keyboardInputValue?: string) => {
 		const validKeyboardInput = textIsValidDate(keyboardInputValue, DATE_FORMAT_FULL);
 
-		if (fieldDef?.inputSettings?.showTime && date && !value.validTime) {
+		if (showTime && date && !value.validTime) {
 			addError(TIME_REQUIRED);
 		} else {
 			removeError(TIME_REQUIRED);
@@ -120,7 +146,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 
 		if (
 			blurred.current.date &&
-			(!fieldDef?.inputSettings?.showTime || blurred.current.time)
+			(!showTime || blurred.current.time)
 		) {
 			onBlur();
 		}
@@ -143,8 +169,8 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 						type: "",
 						inputSettings: {
 							placeholder: DATE_FORMAT_FULL_PLACEHOLDER,
-							minDate: fieldDef?.inputSettings?.minDate,
-							maxDate: fieldDef?.inputSettings?.maxDate,
+							minDate,
+							maxDate,
 						},
 						required: fieldDef?.required,
 					}}

--- a/containers/mosaic/src/components/Form/Form.tsx
+++ b/containers/mosaic/src/components/Form/Form.tsx
@@ -1,7 +1,10 @@
-import React, { useState } from "react";
+import React, { useLayoutEffect, useState } from "react";
 import { memo, useEffect, useMemo, useRef, useCallback } from "react";
-import { FormProps } from "./FormTypes";
-import { MosaicCSSContainer } from "@root/types";
+
+import type { MosaicCSSContainer } from "@root/types";
+import type { FormProps } from "./FormTypes";
+import type { ButtonProps } from "../Button";
+import type { Item, SideNavArgs } from "../SideNav";
 
 import {
 	StyledFormContent,
@@ -13,8 +16,6 @@ import {
 import Layout from "./Layout";
 import Top from "./Top";
 import Dialog from "@root/components/Dialog";
-import { ButtonProps } from "../Button";
-import { Item, SideNavArgs } from "../SideNav";
 import useScrollSpy from "@root/utils/hooks/useScrollSpy";
 import Snackbar from "../Snackbar/Snackbar";
 import { useWrappedToggle } from "@root/utils/toggle";
@@ -250,7 +251,7 @@ const Form = (props: FormProps) => {
 	const isBusy = state.disabled || state.waits.length > 0;
 	const skeleton = providedSkeleton || loadingInitial;
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		init({ fields, sections });
 	}, [init, fields, sections]);
 

--- a/containers/mosaic/src/components/Form/useForm/useForm.ts
+++ b/containers/mosaic/src/components/Form/useForm/useForm.ts
@@ -1,5 +1,7 @@
 import { useRef, useCallback, useMemo, useReducer } from "react";
-import {
+
+import type { MosaicObject } from "@root/types";
+import type {
 	FieldCanBeValidated,
 	FormStable,
 	FormMethods,
@@ -22,9 +24,10 @@ import {
 	FormReset,
 	SetSubmitWarning,
 } from "./types";
+import type { FieldDefSanitized } from "../../Field";
+
 import { getToggle, wrapToggle } from "@root/utils/toggle";
-import { MosaicObject } from "@root/types";
-import { FieldDefSanitized, isTipTapField } from "../../Field";
+import { isTipTapField } from "../../Field";
 import { getFieldConfig } from "..";
 import { getInitialState, getInitialStable } from "./initial";
 import { reducer } from "./reducers";

--- a/containers/mosaic/src/utils/date/index.ts
+++ b/containers/mosaic/src/utils/date/index.ts
@@ -1,3 +1,4 @@
 export { default as matchTime } from "./matchTime";
 export { default as isValidDate } from "./isValidDate";
 export { default as textIsValidDate } from "./textIsValidDate";
+export { parseTime } from "./parseTime";

--- a/containers/mosaic/src/utils/date/matchTime.ts
+++ b/containers/mosaic/src/utils/date/matchTime.ts
@@ -1,4 +1,4 @@
-import { TimeTuple } from "@root/components/Field";
+import type { TimeTuple } from "@root/components/Field";
 
 function matchTime(date: Date, time: Date | TimeTuple) {
 	const clone = new Date(date.getTime());

--- a/containers/mosaic/src/utils/date/parseTime.ts
+++ b/containers/mosaic/src/utils/date/parseTime.ts
@@ -1,0 +1,25 @@
+import type { TimeString, TimeTuple } from "@root/components";
+
+export function parseTime(time: TimeString | TimeTuple): TimeTuple {
+	if (Array.isArray(time)) {
+		return time;
+	}
+
+	const [first, last] = time.split(":");
+
+	if (!first || first.length !== 2 || !last || last.length !== 2) {
+		throw new Error(`${time} is not a valid 24hr time. It must contain hour and minute components separated by a colon.`);
+	}
+
+	const hr = Number(first);
+	const min = Number(last);
+
+	if (
+		hr !== hr || hr < 0 || hr > 23 ||
+		min !== min || min < 0 || min > 59
+	) {
+		throw new Error(`${time} is not a valid 24hr time`);
+	}
+
+	return [hr, min, 0, 0];
+}

--- a/containers/mosaic/yarn.lock
+++ b/containers/mosaic/yarn.lock
@@ -2656,6 +2656,7 @@ __metadata:
     "@tiptap/pm": ^2.5.6
     "@tiptap/react": ^2.5.6
     "@types/lodash": 4.14.179
+    "@types/node": ^22.5.5
     "@types/react": 18.3.5
     "@types/react-dom": 18.3.0
     "@typescript-eslint/eslint-plugin": 8.4.0
@@ -3222,6 +3223,15 @@ __metadata:
   version: 4.14.179
   resolution: "@types/lodash@npm:4.14.179"
   checksum: 71faa0c8071732c2b7f0bd092850d3cea96fc7912055d57d819cf2ab399a64150e4190d8a4ea35a0905662ddc118be9d2abd55891d8047c085acf98608156149
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^22.5.5":
+  version: 22.5.5
+  resolution: "@types/node@npm:22.5.5"
+  dependencies:
+    undici-types: ~6.19.2
+  checksum: 1f788966ff7df07add0af3481fb68c7fe5091cc72a265c671432abb443788ddacca4ca6378af64fe100c20f857c4d80170d358e66c070171fcea0d4adb1b45b1
   languageName: node
   linkType: hard
 
@@ -8566,6 +8576,13 @@ __metadata:
     has-symbols: ^1.0.3
     which-boxed-primitive: ^1.0.2
   checksum: b7a1cf5862b5e4b5deb091672ffa579aa274f648410009c81cca63fed3b62b610c4f3b773f912ce545bb4e31edc3138975b5bc777fc6e4817dca51affb6380e9
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.19.2":
+  version: 6.19.8
+  resolution: "undici-types@npm:6.19.8"
+  checksum: de51f1b447d22571cf155dfe14ff6d12c5bdaec237c765085b439c38ca8518fc360e88c70f99469162bf2e14188a7b0bcb06e1ed2dc031042b984b0bb9544017
   languageName: node
   linkType: hard
 

--- a/containers/sb-8/stories/components/Field/FormFieldDate/DateField.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldDate/DateField.stories.tsx
@@ -43,7 +43,7 @@ export const Playground = ({
 				inputSettings: {
 					showTime,
 					minDate,
-					defaultTime: "12:05",
+					defaultTime,
 				},
 			},
 		],

--- a/containers/sb-8/stories/components/Field/FormFieldDate/DateField.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldDate/DateField.stories.tsx
@@ -19,6 +19,7 @@ export const Playground = ({
 	helperText,
 	showTime,
 	minDateStr,
+	defaultTime,
 }: typeof Playground.args): ReactElement => {
 	const controller = useForm();
 	const { state, handleSubmit } = controller;
@@ -42,10 +43,11 @@ export const Playground = ({
 				inputSettings: {
 					showTime,
 					minDate,
+					defaultTime: "12:05",
 				},
 			},
 		],
-		[label, required, disabled, helperText, instructionText, showTime, minDate],
+		[label, required, disabled, helperText, instructionText, showTime, minDate, defaultTime],
 	);
 
 	return (
@@ -71,6 +73,7 @@ Playground.args = {
 	helperText: "Helper text",
 	showTime: false,
 	minDateStr: "",
+	defaultTime: "",
 };
 
 Playground.argTypes = {
@@ -98,6 +101,9 @@ Playground.argTypes = {
 	minDateStr: {
 		name: "Minimum Date",
 	},
+	defaultTime: {
+		name: "Default Time",
+	}
 };
 
 const getFormValues = async () => {

--- a/containers/sb-8/stories/components/Field/FormFieldDate/DateField.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldDate/DateField.stories.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { ReactElement, useMemo } from "react";
+import React, { ReactElement, useMemo } from "react";
 import { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
 import { renderButtons } from "@root/utils/storyUtils";
@@ -10,12 +9,17 @@ export default {
 	title: "FormFields/FormFieldDateField",
 };
 
+const prepopulateData = {
+	date: new Date(2024, 12, 25, 11, 30),
+};
+
 export const Playground = ({
 	label,
 	required,
 	skeleton,
 	disabled,
 	instructionText,
+	prepopulate,
 	helperText,
 	showTime,
 	minDateStr,
@@ -23,6 +27,11 @@ export const Playground = ({
 }: typeof Playground.args): ReactElement => {
 	const controller = useForm();
 	const { state, handleSubmit } = controller;
+
+	const getFormValues = useMemo(() => prepopulate ?
+		async () => prepopulateData :
+		undefined,
+	[prepopulate]);
 
 	const minDate = minDateStr && textIsValidDate(minDateStr, DATE_FORMAT_FULL) ? new Date(
 		Number(minDateStr.split("/")[2]),
@@ -59,6 +68,7 @@ export const Playground = ({
 				title="Date Field"
 				fields={fields}
 				skeleton={skeleton}
+				getFormValues={getFormValues}
 			/>
 		</>
 	);
@@ -70,6 +80,7 @@ Playground.args = {
 	required: false,
 	skeleton: false,
 	instructionText: "Instruction text",
+	prepopulate: false,
 	helperText: "Helper text",
 	showTime: false,
 	minDateStr: "",
@@ -91,6 +102,9 @@ Playground.argTypes = {
 	},
 	instructionText: {
 		name: "Instruction Text",
+	},
+	prepopulate: {
+		name: "Prepopulate",
 	},
 	helperText: {
 		name: "Helper Text",


### PR DESCRIPTION
# [MOS-1457](https://simpleviewtools.atlassian.net/browse/MOS-1457)

## Description
- (DateField) Adds default time input setting
- (Form) Ensure field registration happens as early as possible. Organise Form and useForm imports.

## Checklist
- [x] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1457]: https://simpleviewtools.atlassian.net/browse/MOS-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ