### PR TITLE
MOS-1466

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldToggle/FormFieldToggle.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldToggle/FormFieldToggle.tsx
@@ -1,12 +1,12 @@
+import type { ReactElement } from "react";
+
 import * as React from "react";
-import { ReactElement, memo } from "react";
+import { memo } from "react";
 
-// Components
+import type { MosaicFieldProps } from "@root/components/Field";
+import type { ToggleInputSettings, FieldDefToggleData } from "./FormFieldToggleTypes";
+
 import Toggle from "@root/components/Toggle";
-
-// Types and styles
-import { MosaicFieldProps } from "@root/components/Field";
-import { ToggleInputSettings, FieldDefToggleData } from "./FormFieldToggleTypes";
 import { FormFieldSwitchSkeleton } from "./FormFieldToggleSkeleton";
 
 const FormFieldToggle = (
@@ -32,7 +32,6 @@ const FormFieldToggle = (
 			label={fieldDef?.inputSettings?.toggleLabel}
 			onChange={onChange}
 			onBlur={onBlur}
-			required={fieldDef?.required}
 		/>
 	);
 };

--- a/containers/mosaic/src/components/Toggle/Toggle.tsx
+++ b/containers/mosaic/src/components/Toggle/Toggle.tsx
@@ -1,8 +1,9 @@
-import * as React from "react";
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 
-// Types and styles
-import { ToggleProps } from "./ToggleTypes";
+import * as React from "react";
+
+import type { ToggleProps } from "./ToggleTypes";
+
 import { StyledSwitch } from "./Toggle.styled";
 import StyledFormControlLabel from "@root/components/StyledFormControlLabel";
 import testIds from "@root/utils/testIds";


### PR DESCRIPTION
# [MOS-1466](https://simpleviewtools.atlassian.net/browse/MOS-1466)

## Description
-  (ToggleField) Stop passing down the required prop to Material's switch to prevent duplicate asterisks.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1466]: https://simpleviewtools.atlassian.net/browse/MOS-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ