### PR TITLE
MOS-1476

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeForm.styled.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeForm.styled.tsx
@@ -2,6 +2,11 @@ import styled from "styled-components";
 
 import theme from "@root/theme";
 import Button from "@root/components/Button";
+import Popper from "@mui/material/Popper";
+
+export const StyledPopper = styled(Popper)`
+    z-index: 5;
+`;
 
 export const StyledNodeForm = styled.div`
     border: 1px solid ${theme.colors.gray300};

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeForm.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeForm.tsx
@@ -1,12 +1,11 @@
 import type { Editor } from "@tiptap/react";
 
 import React, { useCallback } from "react";
-import Popper from "@mui/material/Popper";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 
 import type { NodeFormState } from "../FormFieldTextEditorTypes";
 
-import { StyledNodeForm } from "./NodeForm.styled";
+import { StyledNodeForm, StyledPopper } from "./NodeForm.styled";
 import { NodeFormLink } from "./NodeFormLink";
 import { NodeFormImage } from "./NodeFormImage";
 
@@ -43,7 +42,7 @@ export function NodeForm({
 	}, [values]);
 
 	return (
-		<Popper
+		<StyledPopper
 			anchorEl={anchorEl}
 			open={open}
 			modifiers={popperModifiers}
@@ -67,6 +66,6 @@ export function NodeForm({
 					) : null}
 				</StyledNodeForm>
 			</ClickAwayListener>
-		</Popper>
+		</StyledPopper>
 	);
 }


### PR DESCRIPTION
# [MOS-1476](https://simpleviewtools.atlassian.net/browse/MOS-1476)

## Description
- (TextEditor) Increase the z-index of the built-in Tiptap node form to prevent it from appearing beneath the editor toolbar.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1476]: https://simpleviewtools.atlassian.net/browse/MOS-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ