### PR TITLE
MOS-1483

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Extensions/defaultExtensions.ts
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Extensions/defaultExtensions.ts
@@ -23,37 +23,41 @@ import TextAlign from "@tiptap/extension-text-align";
 import Underline from "@tiptap/extension-underline";
 import { WildCardContent } from "./WildCardContent";
 
-export const defaultExtensions = [
-	Dropcursor,
-	Document,
-	Paragraph,
-	Text,
-	Bold,
-	Blockquote,
-	Code,
-	CodeBlock,
-	Image.configure({
-		inline: true,
-	}),
-	Italic,
-	Underline,
-	Strike,
-	Superscript,
-	Subscript,
-	Link.configure({
-		openOnClick: false,
-	}),
-	Heading.configure({
-		levels: [1, 2, 3, 4, 5, 6],
-	}),
-	OrderedList,
-	BulletList,
-	ListItem,
-	HardBreak,
-	History,
-	Script,
-	TextAlign.configure({
-		types: ["heading", "paragraph"],
-	}),
-	WildCardContent,
-];
+export const getDefaultExtensions = ({ autolink }: { autolink?: boolean } = {}) => {
+	console.log(autolink);
+	return [
+		Dropcursor,
+		Document,
+		Paragraph,
+		Text,
+		Bold,
+		Blockquote,
+		Code,
+		CodeBlock,
+		Image.configure({
+			inline: true,
+		}),
+		Italic,
+		Underline,
+		Strike,
+		Superscript,
+		Subscript,
+		Link.configure({
+			openOnClick: false,
+			autolink,
+		}),
+		Heading.configure({
+			levels: [1, 2, 3, 4, 5, 6],
+		}),
+		OrderedList,
+		BulletList,
+		ListItem,
+		HardBreak,
+		History,
+		Script,
+		TextAlign.configure({
+			types: ["heading", "paragraph"],
+		}),
+		WildCardContent,
+	];
+};

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTap.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTap.tsx
@@ -15,7 +15,7 @@ import { transformScriptTags } from "./Extensions/Script";
 import { isEmptyDOM } from "@root/utils/dom/isEmptyDOM";
 import { FloatingToolbar } from "./FloatingToolbar";
 import { arrayDifference } from "@root/utils/array";
-import { defaultExtensions } from "./Extensions/defaultExtensions";
+import { getDefaultExtensions } from "./Extensions/defaultExtensions";
 import { escapeHtml } from "@root/utils/dom/escapeHtml";
 import testIds from "@root/utils/testIds";
 import { defaultControls, floatingControls, selectionVirtualElement } from "./textEditorUtils";
@@ -33,6 +33,7 @@ function FormFieldTextEditorTipTapUnmemoised({
 	const {
 		extensions: providedExtensions,
 		controls = defaultControls,
+		autolink = true,
 	} = providedInputSettings;
 	const [mode, setMode] = useState<EditorMode>("visual");
 	const [focus, setFocus] = useState(false);
@@ -48,7 +49,7 @@ function FormFieldTextEditorTipTapUnmemoised({
 		_setNodeForm(value);
 	};
 
-	const extensions = useMemo<Extensions>(() => providedExtensions || defaultExtensions, [providedExtensions]);
+	const extensions = useMemo<Extensions>(() => providedExtensions || getDefaultExtensions({ autolink }), [autolink, providedExtensions]);
 
 	const updatesBlocked = useRef(false);
 	const lastValidContent = useRef<string>(value);

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
@@ -134,6 +134,7 @@ export type TextEditorNextInputSettings = {
 	onLink?: (params: TextEditorOnLinkParams) => void;
 	onImage?: (params: TextEditorOnImageParams) => void;
 	allowedLinkProtocols?: string[];
+	autolink?: boolean;
 };
 
 export type TextEditorData = string;

--- a/containers/sb-8/stories/components/Field/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { useMemo, useState, ReactElement } from "react";
 
 import Form, { useForm } from "@root/components/Form";
-import { ControlWithProps, defaultExtensions, FieldDef, FormFieldTextEditorTipTapFieldType, TextEditorOnImageParams, TextEditorOnLinkParams } from "@root/components/Field";
+import { ControlWithProps, getDefaultExtensions, FieldDef, FormFieldTextEditorTipTapFieldType, TextEditorOnImageParams, TextEditorOnLinkParams } from "@root/components/Field";
 import { renderButtons } from "../../../../utils";
 import Drawer from "@root/components/Drawer";
 
@@ -214,6 +214,7 @@ export const Tiptap = ({
 	instructionText,
 	helperText,
 	maxCharacters,
+	autolink,
 	customControlConfig,
 	customImageHandler,
 	customLinkHandler,
@@ -239,11 +240,12 @@ export const Tiptap = ({
 					type: FormFieldTextEditorTipTapFieldType,
 					required,
 					inputSettings: {
+						autolink,
 						controls: [
 							...customControlConfig?.length ? customControlConfig : controls,
 							...customExtensionExample ? [[customExtensionControl]] : [],
 						],
-						extensions: customExtensionExample ? [...defaultExtensions, SimpleViewAlert] : undefined,
+						extensions: customExtensionExample ? [...getDefaultExtensions(), SimpleViewAlert] : undefined,
 						onImage: customImageHandler ? ({ updateImage, ...params }) => {
 							setMediaDrawer({
 								...params,
@@ -276,6 +278,7 @@ export const Tiptap = ({
 			helperText,
 			instructionText,
 			maxCharacters,
+			autolink,
 			customControlConfig,
 			customImageHandler,
 			customLinkHandler,
@@ -327,6 +330,7 @@ Tiptap.args = {
 	instructionText: "Instruction text",
 	helperText: "Helper text",
 	maxCharacters: 100,
+	autolink: true,
 	customControlConfig: [],
 	customImageHandler: false,
 	customLinkHandler: false,
@@ -354,6 +358,9 @@ Tiptap.argTypes = {
 	},
 	maxCharacters: {
 		name: "Maximum Characters",
+	},
+	autolink: {
+		name: "Auto Link",
 	},
 	customControlConfig: {
 		name: "Custom Control Config",


### PR DESCRIPTION
# [MOS-1483](https://simpleviewtools.atlassian.net/browse/MOS-1483)

## Description
- (TextEditor) Introduces an input setting that disables automatically linking strings that look like URIs

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1483]: https://simpleviewtools.atlassian.net/browse/MOS-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ