### PR TITLE
MOS-1483

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/predefinedControls.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/predefinedControls.tsx
@@ -283,14 +283,19 @@ export const controlLink: Control = {
 
 		onLink({
 			...values,
-			updateLink: ({ url, newTab, text }) => editor.chain().focus()
-				.extendMarkRange("link")
-				.setLink({
-					href: sanitizeUrl(url, allowedLinkProtocols),
-					target: newTab ? "_blank" : "",
-				})
-				.insertContent(text)
-				.run(),
+			updateLink: ({ url, newTab, text }) => {
+				const { state: { selection: { $from } } } = editor;
+				editor.chain()
+					.insertContent(text, { updateSelection: true })
+					.setTextSelection({ from: $from.pos, to: $from.pos + text.length })
+					.focus()
+					.extendMarkRange("link")
+					.setLink({
+						href: sanitizeUrl(url, allowedLinkProtocols),
+						target: newTab ? "_blank" : "",
+					})
+					.run();
+			},
 		});
 	},
 	Icon: LinkIcon,


### PR DESCRIPTION
# [MOS-1483](https://simpleviewtools.atlassian.net/browse/MOS-1483)

## Description
- (TextEditor) Ensure the text selection is retained after setting the link text therefore fixing the set link method.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1483]: https://simpleviewtools.atlassian.net/browse/MOS-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ