### PR TITLE
MOS-1480

### DIFF
--- a/containers/mosaic/src/components/Field/FieldTypes.tsx
+++ b/containers/mosaic/src/components/Field/FieldTypes.tsx
@@ -1,26 +1,26 @@
-import { FieldDefAddress } from "@root/components/Field/FormFieldAddress";
-import { FieldDefAdvancedSelection } from "@root/components/Field/FormFieldAdvancedSelection";
-import { FieldDefCheckbox } from "@root/components/Field/FormFieldCheckbox";
-import { FieldDefChip } from "@root/components/Field/FormFieldChips";
-import { FieldDefColor } from "@root/components/Field/FormFieldColor/FormFieldColorTypes";
-import { FieldDefDate } from "@root/components/Field/FormFieldDate/DateField";
-import { FieldDefTime } from "@root/components/Field/FormFieldTime/TimeField";
-import { FieldDefDropdown } from "@root/components/Field/FormFieldDropdown";
-import { FieldDefMapCoordinates } from "@root/components/Field/FormFieldMapCoordinates";
-import { FieldDefMatrix } from "@root/components/Field/FormFieldMatrix";
-import { FieldDefNumber } from "@root/components/Field/FormFieldNumber";
-import { FieldDefNumberTable } from "@root/components/Field/FormFieldNumberTable";
-import { FieldDefPhoneSelection } from "@root/components/Field/FormFieldPhone";
-import { FieldDefRadio } from "@root/components/Field/FormFieldRadio";
-import { FieldDefRaw } from "@root/components/Field/FormFieldRaw";
-import { FieldDefText } from "@root/components/Field/FormFieldText";
-import { FieldDefTextEditor } from "@root/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes";
-import { FieldDefToggle } from "@root/components/Field/FormFieldToggle";
-import { FieldDefUpload } from "@root/components/Field/FormFieldUpload";
-import { MosaicToggle } from "@root/types";
-import { ElementType, HTMLAttributes, MutableRefObject, ReactNode } from "react";
-import { FieldValueResolver, FormSpacing } from "../Form";
-import { FormMethods, FormState, Validator } from "../Form/useForm/types";
+import type { FieldDefAddress } from "@root/components/Field/FormFieldAddress";
+import type { FieldDefAdvancedSelection } from "@root/components/Field/FormFieldAdvancedSelection";
+import type { FieldDefCheckbox } from "@root/components/Field/FormFieldCheckbox";
+import type { FieldDefChip } from "@root/components/Field/FormFieldChips";
+import type { FieldDefColor } from "@root/components/Field/FormFieldColor/FormFieldColorTypes";
+import type { FieldDefDate } from "@root/components/Field/FormFieldDate/DateField";
+import type { FieldDefTime } from "@root/components/Field/FormFieldTime/TimeField";
+import type { FieldDefDropdown } from "@root/components/Field/FormFieldDropdown";
+import type { FieldDefMapCoordinates } from "@root/components/Field/FormFieldMapCoordinates";
+import type { FieldDefMatrix } from "@root/components/Field/FormFieldMatrix";
+import type { FieldDefNumber } from "@root/components/Field/FormFieldNumber";
+import type { FieldDefNumberTable } from "@root/components/Field/FormFieldNumberTable";
+import type { FieldDefPhoneSelection } from "@root/components/Field/FormFieldPhone";
+import type { FieldDefRadio } from "@root/components/Field/FormFieldRadio";
+import type { FieldDefRaw } from "@root/components/Field/FormFieldRaw";
+import type { FieldDefText } from "@root/components/Field/FormFieldText";
+import type { FieldDefTextEditor } from "@root/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes";
+import type { FieldDefToggle } from "@root/components/Field/FormFieldToggle";
+import type { FieldDefUpload } from "@root/components/Field/FormFieldUpload";
+import type { MosaicToggle } from "@root/types";
+import type { ElementType, HTMLAttributes, MutableRefObject, ReactNode } from "react";
+import type { FieldValueResolver, FormSpacing } from "../Form";
+import type { FormMethods, FormState, Validator } from "../Form/useForm/types";
 
 // MOSAIC GENERIC CONTRACT
 export interface MosaicFieldProps<T = any, U = any, V = any> {
@@ -36,7 +36,7 @@ export interface MosaicFieldProps<T = any, U = any, V = any> {
 	/**
 	 * Function that listens to changes on the field and updates its value.
 	 */
-	onChange?: (value: V | ((current: V) => V)) => Promise<void>;
+	onChange?: (value: V | ((current: V) => V), options?: any) => Promise<void>;
 	/**
 	 * Function that listens to a blur event on the field and executes an action.
 	 */

--- a/containers/mosaic/src/components/Form/Field/Field.tsx
+++ b/containers/mosaic/src/components/Form/Field/Field.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useCallback, useMemo, useRef } from "react";
 import type { FieldConfig, FieldDef } from "@root/components/Field";
 import { getFieldConfig } from "@root/components/Form";
-import { FieldProps } from "./FieldTypes";
+import type { FieldProps } from "./FieldTypes";
 import { sanitizeFieldSize } from "@root/components/Field";
 import FieldWrapper, { CustomFieldWrapper } from "@root/components/FieldWrapper";
 import { useWrappedToggle } from "@root/utils/toggle";
@@ -35,13 +35,14 @@ const Field = ({
 	const disabled = useWrappedToggle(field, state, "disabled", false);
 	const inputRef = useRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | undefined>();
 
-	const onChange = useCallback((value: any) => {
+	const onChange = useCallback((value: any, options: any = {}) => {
 		field.onChangeCb && field.onChangeCb();
 
 		setFieldValue({
 			name: field.name,
 			value,
 			touched: true,
+			validate: options.validate,
 		});
 	}, [field, setFieldValue]);
 


### PR DESCRIPTION
# [MOS-1480](https://simpleviewtools.atlassian.net/browse/MOS-1480)

## Description
- (DateField) Modify the way that the default time is utilised, by only populating the time field once a date is chosen.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1480]: https://simpleviewtools.atlassian.net/browse/MOS-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ