### PR TITLE
MOS-1479

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTap.styled.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTipTap.styled.tsx
@@ -50,6 +50,7 @@ export const Editor = styled(EditorContent)`
         border: 1px solid var(--border-color);
         border-top: 0;
         padding: 16px;
+        overflow: auto;
 
         &:focus {
 			border-color: ${theme.newColors.almostBlack["100"]};


### PR DESCRIPTION
# [MOS-1479](https://simpleviewtools.atlassian.net/browse/MOS-1479)

## Description
- (TextEditor) Ensures text editor uses a scrollbar if the content is wider than the text area to prevent leakage outside of the boundaries.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1479]: https://simpleviewtools.atlassian.net/browse/MOS-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ