### PR TITLE
MOS-1501

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
@@ -55,6 +55,7 @@ export type ControlWithProps = ControlBase & {
 	cmd: (params: {
 		editor: Editor;
 		inputSettings: TextEditorInputSettings;
+		event: MouseEvent<HTMLButtonElement>;
 	}) => void;
 	Icon?: SvgIconComponent;
 };

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenuItem.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenuItem.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import type { MouseEvent, ReactElement } from "react";
 import type { Editor } from "@tiptap/core";
 
 import React from "react";
@@ -25,8 +25,8 @@ export function ControlMenuItem({
 	onClose,
 	inputSettings,
 }: ControlMenuItemProps): ReactElement {
-	const onClick = () => {
-		cmd({ editor, inputSettings });
+	const onClick = (event: MouseEvent<HTMLButtonElement>) => {
+		cmd({ editor, inputSettings, event });
 		onClose();
 	};
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControls.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControls.tsx
@@ -60,7 +60,7 @@ export function ToolbarControls({
 					) : (
 						<ControlButton
 							key={control.name}
-							onClick={() => control.cmd({ editor, inputSettings })}
+							onClick={(event) => control.cmd({ editor, inputSettings, event })}
 							label={control.label}
 							shortcut={control.shortcut}
 							active={editor.isActive(control.name)}


### PR DESCRIPTION
# [MOS-1501](https://simpleviewtools.atlassian.net/browse/MOS-1501)

## Description
- (TextEditor) Adds the click event to the list of properties available on the parameter passed to control cmd callbacks.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1501]: https://simpleviewtools.atlassian.net/browse/MOS-1501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ