### PR TITLE
MOS-1412

### DIFF
--- a/containers/mosaic/src/__tests__/utils/string/escapeRegexp.test.ts
+++ b/containers/mosaic/src/__tests__/utils/string/escapeRegexp.test.ts
@@ -1,0 +1,32 @@
+import { escapeRegexp } from "@root/utils/string/escapeRegexp";
+import type { TestDef } from "@simpleview/mochalib";
+import { testArray } from "@simpleview/mochalib";
+
+describe(__filename, function () {
+	interface Test {
+		input: string;
+		escaped: string;
+	}
+
+	const tests: TestDef<Test>[] = [
+		{
+			name: "should escape characters that have special meaning in a regular expression",
+			args: {
+				input: "T^h$i\\s .i*s +m?y( )s [tr]i{n|g}",
+				escaped: "T\\^h\\$i\\\\s \\.i\\*s \\+m\\?y\\( \\)s \\[tr\\]i\\{n\\|g\\}",
+			},
+		},
+		{
+			name: "should not escape characters that are not special regex characters",
+			args: {
+				input: "My Test",
+				escaped: "My Test",
+			},
+		},
+	];
+
+	testArray(tests, ({ input, escaped }) => {
+		const result = escapeRegexp(input);
+		expect(result).toBe(escaped);
+	});
+});

--- a/containers/mosaic/src/components/Field/FormFieldAdvancedSelection/AdvancedSelectionDrawer.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAdvancedSelection/AdvancedSelectionDrawer.tsx
@@ -10,6 +10,7 @@ import type { MosaicLabelValue } from "@root/types";
 import { FormDrawerWrapper } from "@root/components/common";
 import { DataViewFilterMultiselectDropdownContent } from "@root/components/DataViewFilterMultiselect";
 import PageHeader from "@root/components/PageHeader";
+import { escapeRegexp } from "@root/utils/string/escapeRegexp";
 
 const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactElement => {
 	const {
@@ -54,7 +55,7 @@ const AdvancedSelectionDrawer = (props: AdvanceSelectionDrawerPropTypes): ReactE
 
 	const getSyncOptions: GetOptions = ({ keyword }) => {
 		let newOptions: MosaicLabelValue[] = localOptions?.options || [];
-		const regSearchKeyword = new RegExp(keyword, "i");
+		const regSearchKeyword = new RegExp(escapeRegexp(keyword), "i");
 		if (keyword !== undefined && localOptions.options !== undefined) {
 			newOptions = localOptions?.options.filter(option => {
 				return regSearchKeyword.exec(option.label);

--- a/containers/mosaic/src/mock/options.ts
+++ b/containers/mosaic/src/mock/options.ts
@@ -65,6 +65,10 @@ export const optionsLibrary: MosaicLabelValue[] = [
 		label: "Category 5",
 		value: "abc123",
 	},
+	{
+		label: "Category (With Escaped Characters)",
+		value: "category_with_escape",
+	},
 ];
 
 export const getOptions: () => Promise<MosaicLabelValue[]> = async () => {

--- a/containers/mosaic/src/utils/string/escapeRegexp.ts
+++ b/containers/mosaic/src/utils/string/escapeRegexp.ts
@@ -1,0 +1,10 @@
+const reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
+const reHasRegExpChar = RegExp(reRegExpChar.source);
+
+export function escapeRegexp(str: string) {
+	if (!str || !reHasRegExpChar.test(str)) {
+		return str;
+	}
+
+	return str.replace(reRegExpChar, "\\$&");
+}


### PR DESCRIPTION
# [MOS-1412](https://simpleviewtools.atlassian.net/browse/MOS-1412)

## Description
- (util) Introduces a regex escape utility.
- (AdvancedSelection) Ensures the keyword used for filtering options is escaped of any regex characters.

## Checklist
- [x] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1412]: https://simpleviewtools.atlassian.net/browse/MOS-1412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ