### PR TITLE
MOS-1504

### DIFF
--- a/containers/mosaic/src/components/SideNav/SideNav.tsx
+++ b/containers/mosaic/src/components/SideNav/SideNav.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { ReactElement, useCallback, memo, MouseEvent } from "react";
-import { SideNavProps } from ".";
+import type { ReactElement, MouseEvent } from "react";
+import { useCallback, memo } from "react";
+import type { SideNavProps } from ".";
 import {
 	LinkWrapper,
 	StyledSideNav,
@@ -10,7 +11,7 @@ import {
 	Badge,
 	BadgeWrapper,
 } from "./SideNav.styled";
-import { Item, SideNavGroupProps } from "./SideNavTypes";
+import type { Item, SideNavGroupProps } from "./SideNavTypes";
 import { useToggle } from "@root/utils/toggle";
 
 const SideNavGroup = ({ items, collapse, onLinkClicked, active }: SideNavGroupProps): ReactElement => {
@@ -35,15 +36,18 @@ const SideNavGroup = ({ items, collapse, onLinkClicked, active }: SideNavGroupPr
 						key={`${item.label}-${idx}`}
 						className={item.name === active && "highlight"}
 					>
-						{item.icon && <LinkIcon />}
-						<StyledLink>{item.label}</StyledLink>
+						{item.icon && <LinkIcon key="link-icon" />}
+						<StyledLink key="link-text">{item.label}</StyledLink>
 						{item?.badge && (
-							<BadgeWrapper>
+							<BadgeWrapper key="badge">
 								<Badge>{item.badge}</Badge>
 							</BadgeWrapper>
 						)}
 						{item?.action?.icon && (
-							<ActionIcon onClick={item.action.onClick} />
+							<ActionIcon
+								key="action-item"
+								onClick={item.action.onClick}
+							/>
 						)}
 					</LinkWrapper>
 				);

--- a/containers/mosaic/src/components/SideNav/SideNav.tsx
+++ b/containers/mosaic/src/components/SideNav/SideNav.tsx
@@ -1,17 +1,10 @@
-import * as React from "react";
 import type { ReactElement, MouseEvent } from "react";
-import { useCallback, memo } from "react";
-import type { SideNavProps } from ".";
-import {
-	LinkWrapper,
-	StyledSideNav,
-	SidebarWrap,
-	StyledLink,
-	LinksWrapper,
-	Badge,
-	BadgeWrapper,
-} from "./SideNav.styled";
-import type { Item, SideNavGroupProps } from "./SideNavTypes";
+
+import React, { useCallback, memo } from "react";
+
+import type { SideNavProps, Item, SideNavGroupProps } from "./SideNavTypes";
+
+import { LinkWrapper, StyledSideNav, SidebarWrap, StyledLink, LinksWrapper, Badge, BadgeWrapper } from "./SideNav.styled";
 import { useToggle } from "@root/utils/toggle";
 
 const SideNavGroup = ({ items, collapse, onLinkClicked, active }: SideNavGroupProps): ReactElement => {


### PR DESCRIPTION
# [MOS-1504](https://simpleviewtools.atlassian.net/browse/MOS-1504)

## Description
- (SideNav) Adds keys to the components rendered within each side nav item to prevent React errors being thrown in the console.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1504]: https://simpleviewtools.atlassian.net/browse/MOS-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ