### PR TITLE
MOS-1505

### DIFF
--- a/containers/mosaic/src/__tests__/components/DataView/DataViewTd/DataViewTd.test.tsx
+++ b/containers/mosaic/src/__tests__/components/DataView/DataViewTd/DataViewTd.test.tsx
@@ -45,7 +45,7 @@ describe(__dirname, () => {
 	});
 
 	it("should render the table cell with the bold class when bold is provided", async () => {
-		await setup({ bold: true });
+		await setup({ style: { bold: true } });
 
 		expect(screen.queryByRole("cell")).toHaveClass("bold");
 
@@ -53,7 +53,7 @@ describe(__dirname, () => {
 	});
 
 	it("should render the table cell with the italic class when italic is provided", async () => {
-		await setup({ italic: true });
+		await setup({ style: { italic: true } });
 
 		expect(screen.queryByRole("cell")).toHaveClass("italic");
 
@@ -61,7 +61,7 @@ describe(__dirname, () => {
 	});
 
 	it("should render the table cell with the strikeThrough class when strikeThrough is provided", async () => {
-		await setup({ strikeThrough: true });
+		await setup({ style: { strikeThrough: true } });
 
 		expect(screen.queryByRole("cell")).toHaveClass("strikeThrough");
 
@@ -69,7 +69,7 @@ describe(__dirname, () => {
 	});
 
 	it("should render the table cell inner div with the noWrap class when noWrap is provided", async () => {
-		await setup({ noWrap: true });
+		await setup({ style: { noWrap: true } });
 
 		expect(screen.queryByTestId(testIds.DATA_VIEW_TD_INNER)).toHaveClass("noWrap");
 
@@ -77,7 +77,7 @@ describe(__dirname, () => {
 	});
 
 	it("should render the table cell inner div with the ellipsis class when ellipsis is provided", async () => {
-		await setup({ ellipsis: true });
+		await setup({ style: { ellipsis: true } });
 
 		expect(screen.queryByTestId(testIds.DATA_VIEW_TD_INNER)).toHaveClass("ellipsis");
 
@@ -85,7 +85,7 @@ describe(__dirname, () => {
 	});
 
 	it("should render the table cell inner div with a title if ellipsis is provided and the content is a string", async () => {
-		await setup({ ellipsis: true, children: "My Text" });
+		await setup({ style: { ellipsis: true }, children: "My Text" });
 
 		expect(screen.queryByTestId(testIds.DATA_VIEW_TD_INNER)).toHaveAttribute("title", "My Text");
 	});

--- a/containers/mosaic/src/components/DataView/DataViewTd/DataViewTd.styled.tsx
+++ b/containers/mosaic/src/components/DataView/DataViewTd/DataViewTd.styled.tsx
@@ -1,0 +1,39 @@
+import styled from "styled-components";
+import theme from "@root/theme";
+
+export const StyledTd = styled.td`
+	height: 40px;
+	vertical-align: middle;
+
+	${/* This ensures that the td collapses to it's content size if it doesn't have the .expandCell class */""}
+	&:not(.expandCell) {
+		width: 1%;
+		white-space: nowrap;
+	}
+
+	& > div {
+		color: ${theme.newColors.almostBlack["100"]};
+		font-weight: 400;
+	}
+
+	&.bold > div {
+		font-weight: 600;
+	}
+
+	&.italic {
+		font-style: italic;
+	}
+
+	&.strikeThrough {
+		text-decoration-line: line-through;
+	}
+
+	& > div.noWrap {
+		white-space: nowrap;
+	}
+
+	& > div.ellipsis {
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+`;

--- a/containers/mosaic/src/components/DataView/DataViewTd/DataViewTd.tsx
+++ b/containers/mosaic/src/components/DataView/DataViewTd/DataViewTd.tsx
@@ -1,59 +1,24 @@
 import React, { memo } from "react";
-import styled from "styled-components";
-import theme from "@root/theme";
 
 import type { DataViewTdProps } from "./DataViewTdTypes";
 import testIds from "@root/utils/testIds";
-
-const StyledTd = styled.td`
-	height: 40px;
-	vertical-align: middle;
-
-	${/* This ensures that the td collapses to it's content size if it doesn't have the .expandCell class */""}
-	&:not(.expandCell) {
-		width: 1%;
-		white-space: nowrap;
-	}
-
-	& > div {
-		color: ${theme.newColors.almostBlack["100"]};
-		font-weight: 400;
-	}
-
-	&.bold > div {
-		font-weight: 600;
-	}
-
-	&.italic {
-		font-style: italic;
-	}
-
-	&.strikeThrough {
-		text-decoration-line: line-through;
-	}
-
-	& > div.noWrap {
-		white-space: nowrap;
-	}
-
-	& > div.ellipsis {
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
-`;
+import { StyledTd } from "./DataViewTd.styled";
 
 function DataViewTd({
 	ariaLabel,
 	expandCell = false,
-	bold = false,
-	italic = false,
-	strikeThrough = false,
-	noWrap = false,
-	ellipsis = false,
-	maxWidth,
-	textTransform,
+	style: providedStyle,
 	...props
 }: DataViewTdProps) {
+	const {
+		bold = false,
+		italic = false,
+		strikeThrough = false,
+		noWrap = false,
+		ellipsis = false,
+		...style
+	} = providedStyle || {};
+
 	return (
 		<StyledTd
 			className={`
@@ -63,6 +28,7 @@ function DataViewTd({
 				${strikeThrough ? "strikeThrough" : ""}
 			`}
 			aria-label={ariaLabel}
+			style={style}
 			{...props}
 		>
 			<div
@@ -70,7 +36,6 @@ function DataViewTd({
 					${noWrap ? "noWrap" : ""}
 					${ellipsis ? "ellipsis" : ""}
 				`}
-				style={{ maxWidth, textTransform }}
 				title={ellipsis && typeof props.children === "string" ? props.children : undefined}
 				data-testid={testIds.DATA_VIEW_TD_INNER}
 			>

--- a/containers/mosaic/src/components/DataView/DataViewTd/DataViewTdTypes.ts
+++ b/containers/mosaic/src/components/DataView/DataViewTd/DataViewTdTypes.ts
@@ -3,13 +3,7 @@ import type { DataViewColumn } from "../DataViewTypes";
 
 export interface DataViewTdProps extends ComponentProps<"td"> {
 	expandCell?: boolean;
-	bold?: DataViewColumn["style"]["bold"];
-	italic?: DataViewColumn["style"]["italic"];
-	strikeThrough?: DataViewColumn["style"]["strikeThrough"];
-	noWrap?: DataViewColumn["style"]["noWrap"];
-	ellipsis?: DataViewColumn["style"]["ellipsis"];
-	maxWidth?: DataViewColumn["style"]["maxWidth"];
-	textTransform?: DataViewColumn["style"]["textTransform"];
+	style?: DataViewColumn["style"];
 	children: React.ReactNode;
 	ariaLabel?: HTMLElement["ariaLabel"];
 	testId?: string;

--- a/containers/mosaic/src/components/DataView/DataViewTr/DataViewTr.tsx
+++ b/containers/mosaic/src/components/DataView/DataViewTr/DataViewTr.tsx
@@ -80,13 +80,7 @@ const DataViewTrStatic = forwardRef<HTMLTableRowElement, DataViewTrProps>(({
 						key={column.name}
 						ariaLabel={column.label}
 						expandCell={true}
-						bold={column.style?.bold}
-						italic={column.style?.italic}
-						strikeThrough={column.style?.strikeThrough}
-						noWrap={column.style?.noWrap}
-						ellipsis={column.style?.ellipsis}
-						maxWidth={column.style?.maxWidth}
-						textTransform={column.style?.textTransform}
+						style={column.style}
 					>
 						{row[column.name]}
 					</DataViewTd>

--- a/containers/mosaic/src/components/DataView/DataViewTypes.ts
+++ b/containers/mosaic/src/components/DataView/DataViewTypes.ts
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import type { CSSProperties, ReactElement } from "react";
 import type { Property } from "csstype";
 
 import type { MosaicObject, MosaicCallback, MosaicLabelValue, MosaicToggle } from "@root/types";
@@ -27,7 +27,7 @@ export interface DataViewColumn {
 	column?: string;
 	/** Whether this column can be sorted. */
 	sortable?: boolean;
-	style?: {
+	style?: CSSProperties & {
 		/** Bold the cell. */
 		bold?: boolean;
 		/** Italicize the cell. */


### PR DESCRIPTION
# [MOS-1505](https://simpleviewtools.atlassian.net/browse/MOS-1505)

## Description
- (DataView) Allows the passing of arbitrary styles to DataView columns alongside the existing styling flags.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1505]: https://simpleviewtools.atlassian.net/browse/MOS-1505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ