### PR TITLE
MOS-1508

### DIFF
--- a/containers/mosaic/src/utils/hooks/useScrollSpy/useScrollSpy.ts
+++ b/containers/mosaic/src/utils/hooks/useScrollSpy/useScrollSpy.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ScrollSpyProps, ScrollSpyResult } from "./ScrollSpyTypes";
+
+import type { ScrollSpyProps, ScrollSpyResult } from "./ScrollSpyTypes";
+
 import debounce from "lodash/debounce";
 import useScrollTo from "../useScrollTo/useScrollTo";
 
@@ -33,6 +35,10 @@ export default function useScrollSpy<E extends HTMLElement>({
 
 		const containerBox = container.getBoundingClientRect();
 
+		if (Math.ceil(container.scrollTop + containerBox.height) >= container.scrollHeight) {
+			return refs.length - 1;
+		}
+
 		for (let i = 0; i < refs.length; i++) {
 			const section = refs[i];
 			const box = section.getBoundingClientRect();
@@ -44,6 +50,8 @@ export default function useScrollSpy<E extends HTMLElement>({
 			newActiveSection = i;
 
 		}
+
+		console.log(newActiveSection);
 
 		return newActiveSection;
 	}, [container, refs, threshold]);


### PR DESCRIPTION
# [MOS-1508](https://simpleviewtools.atlassian.net/browse/MOS-1508)

## Description
- (ScrollSpy) Force last section to be considered active if the viewport is scrolled all the way to the bottom, regardless of section height.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1508]: https://simpleviewtools.atlassian.net/browse/MOS-1508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ