### PR TITLE
MOS-1472

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocompleteField.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocompleteField.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from "react";
 
 import React, { memo, useCallback, useContext, useState } from "react";
 import { createPortal } from "react-dom";
+import Skeleton from "@mui/material/Skeleton";
 
 import type { MosaicLabelValue } from "@root/types";
 
@@ -14,7 +15,7 @@ import { FormContext } from "@root/components/Form/FormContext";
 import Snackbar from "@root/components/Snackbar";
 
 function AddressAutocompleteField(props): ReactElement {
-	const { fieldDef, path } = props;
+	const { fieldDef, path, skeleton } = props;
 	const { inputSettings } = fieldDef;
 	const {
 		getOptionsCountries,
@@ -169,16 +170,25 @@ function AddressAutocompleteField(props): ReactElement {
 				methods={props.methods}
 				disabled={props.disabled}
 				useRealLabel
+				skeleton={skeleton}
 			>
-				<AddressAutocomplete
-					onChange={(address) => props.onChange(address)}
-					onBlur={props.onBlur}
-					value={props.value ?? ""}
-					onSelect={onSelect}
-					googleMapsApiKey={googleMapsApiKey}
-					disabled={props.disabled}
-					id={`${fieldDef.name}-input`}
-				/>
+				{skeleton ? (
+					<Skeleton
+						variant="rectangular"
+						width="100%"
+						height={43}
+					/>
+				) : (
+					<AddressAutocomplete
+						onChange={(address) => props.onChange(address)}
+						onBlur={props.onBlur}
+						value={props.value ?? ""}
+						onSelect={onSelect}
+						googleMapsApiKey={googleMapsApiKey}
+						disabled={props.disabled}
+						id={`${fieldDef.name}-input`}
+					/>
+				)}
 			</FieldWrapper>
 			{createPortal(
 				<Snackbar

--- a/containers/mosaic/src/components/Field/FormFieldAddress/AddressStateField/AddressStateField.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAddress/AddressStateField/AddressStateField.tsx
@@ -79,6 +79,7 @@ function AddressStateField(props): ReactElement {
 			methods={props.methods}
 			disabled={props.disabled}
 			useRealLabel
+			skeleton={props.skeleton}
 		>
 			<FormFieldDropdown
 				{...props}

--- a/containers/mosaic/src/components/Field/FormFieldAddress/utils/getAddressFields.ts
+++ b/containers/mosaic/src/components/Field/FormFieldAddress/utils/getAddressFields.ts
@@ -12,6 +12,7 @@ type GetAddressFieldsParams = Pick<AddressFieldInputSettings,
 	| "googleMapsApiKey"
 > & {
 	required?: boolean;
+	disabled?: FieldDef["disabled"];
 	include?: AddressFieldInputSettings["subFields"];
 }
 
@@ -47,6 +48,7 @@ function getAddressFields({
 	getOptionsStates,
 	googleMapsApiKey,
 	required,
+	disabled,
 	include,
 }: GetAddressFieldsParams): FieldDef[] {
 	const invalidParts = include && getInvalidParts(include);
@@ -59,6 +61,7 @@ function getAddressFields({
 		address1: {
 			name: "address1",
 			required,
+			disabled,
 			label: "Address",
 			size: "lg",
 			// If a google maps API key has been provided,
@@ -80,12 +83,14 @@ function getAddressFields({
 			type: "text",
 			label: undefined,
 			size: "lg",
+			disabled,
 		},
 		address3: {
 			name: "address3",
 			type: "text",
 			label: undefined,
 			size: "lg",
+			disabled,
 		},
 		country: {
 			name: "country",
@@ -93,6 +98,7 @@ function getAddressFields({
 			label: "Country",
 			size: "sm",
 			required,
+			disabled,
 			inputSettings: {
 				getOptions: getOptionsCountries,
 			},
@@ -107,12 +113,14 @@ function getAddressFields({
 			label: "City",
 			size: "sm",
 			required,
+			disabled,
 		},
 		state: {
 			name: "state",
 			type: AddressStateField,
 			label: "State",
 			size: "sm",
+			disabled,
 			inputSettings: {
 				getOptionsStates,
 			},
@@ -123,6 +131,7 @@ function getAddressFields({
 			label: "Postal Code",
 			size: "sm",
 			required,
+			disabled,
 			inputSettings: {
 				type: "string",
 			},

--- a/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
@@ -12,6 +12,7 @@ function sanitizeFieldDefs(fields: FieldDef[]): FieldDefSanitized[] {
 					subFields,
 				},
 				required,
+				disabled,
 			} = field;
 
 			return {
@@ -23,6 +24,7 @@ function sanitizeFieldDefs(fields: FieldDef[]): FieldDefSanitized[] {
 						getOptionsStates,
 						googleMapsApiKey,
 						required,
+						disabled,
 						include: subFields,
 					}),
 				},

--- a/containers/sb-8/stories/components/Field/FormFieldAddress/Address.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldAddress/Address.stories.tsx
@@ -241,7 +241,6 @@ Single.args = {
 	skeleton: false,
 	prepopulate: false,
 	subFields: ["address1", "address2", "address3", "country", "city", "state", "postalCode"],
-	foo: { foo: "bar" },
 	googleKey: defaultGoogleKey,
 };
 


### PR DESCRIPTION
# [MOS-1472](https://simpleviewtools.atlassian.net/browse/MOS-1472)

## Description
- (SingleAddress) Trickle disabled property down so that sub fields are disabled when the form is.
- (SingleAddress) Allow skeleton prop to trickle down to sub fields.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1472]: https://simpleviewtools.atlassian.net/browse/MOS-1472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ