### PR TITLE
MOS-1518

### DIFF
--- a/containers/e2e-tests/package-lock.json
+++ b/containers/e2e-tests/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "automation_testing",
-	"version": "39.0.0",
+	"version": "39.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "automation_testing",
-			"version": "39.0.0",
+			"version": "39.1.0",
 			"license": "ISC",
 			"devDependencies": {
 				"@playwright/test": "^1.44.0",
-				"@simpleview/sv-mosaic-eslint": "^0.0.1",
+				"@simpleview/sv-mosaic-eslint": "^0.0.2",
 				"@types/node": "^20.12.12",
 				"eslint": "^9.15.0"
 			}
@@ -242,9 +242,9 @@
 			}
 		},
 		"node_modules/@simpleview/sv-mosaic-eslint": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/@simpleview/sv-mosaic-eslint/-/sv-mosaic-eslint-0.0.1.tgz",
-			"integrity": "sha512-vynxo8nvhJqmNriTm6nSBb27+1K7efXDdRzYuYtYVGvr9xZD4CXJrxWsW9rK+6YohrYkG1x0f2Indw3BrSx+Gw==",
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/@simpleview/sv-mosaic-eslint/-/sv-mosaic-eslint-0.0.2.tgz",
+			"integrity": "sha512-XPFDg63ZpczQlwJCxxg3NK0s6wK3ih0Qx9aXgFdGaYi4Bn+fOJS37Yi2lzQkr2jbpgNaLjhx/RvgopPDraClKQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint/js": "^9.15.0",
@@ -3314,9 +3314,9 @@
 			}
 		},
 		"@simpleview/sv-mosaic-eslint": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/@simpleview/sv-mosaic-eslint/-/sv-mosaic-eslint-0.0.1.tgz",
-			"integrity": "sha512-vynxo8nvhJqmNriTm6nSBb27+1K7efXDdRzYuYtYVGvr9xZD4CXJrxWsW9rK+6YohrYkG1x0f2Indw3BrSx+Gw==",
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/@simpleview/sv-mosaic-eslint/-/sv-mosaic-eslint-0.0.2.tgz",
+			"integrity": "sha512-XPFDg63ZpczQlwJCxxg3NK0s6wK3ih0Qx9aXgFdGaYi4Bn+fOJS37Yi2lzQkr2jbpgNaLjhx/RvgopPDraClKQ==",
 			"dev": true,
 			"requires": {
 				"@eslint/js": "^9.15.0",

--- a/containers/e2e-tests/package.json
+++ b/containers/e2e-tests/package.json
@@ -14,7 +14,7 @@
 	"license": "ISC",
 	"devDependencies": {
 		"@playwright/test": "^1.44.0",
-		"@simpleview/sv-mosaic-eslint": "^0.0.1",
+		"@simpleview/sv-mosaic-eslint": "^0.0.2",
 		"@types/node": "^20.12.12",
 		"eslint": "^9.15.0"
 	}

--- a/containers/mosaic/package.json
+++ b/containers/mosaic/package.json
@@ -11,7 +11,7 @@
 		"@mui/styles": "5.16.7",
 		"@mui/x-date-pickers": "5.0.0-beta.0",
 		"@simpleview/mochalib": "2.0.2",
-		"@simpleview/sv-mosaic-eslint": "0.0.1",
+		"@simpleview/sv-mosaic-eslint": "0.0.2",
 		"@testing-library/dom": "10.4.0",
 		"@testing-library/jest-dom": "6.5.0",
 		"@testing-library/react": "16.0.1",

--- a/containers/mosaic/scripts/publish-to-npm.ts
+++ b/containers/mosaic/scripts/publish-to-npm.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { execSync } from "child_process";
 import { writeFileSync } from "fs";
 

--- a/containers/mosaic/src/utils/hooks/useWhatChanged.ts
+++ b/containers/mosaic/src/utils/hooks/useWhatChanged.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { useRef } from "react";
 
 export function useWhatChanged(props: Record<string, any>) {

--- a/containers/mosaic/yarn.lock
+++ b/containers/mosaic/yarn.lock
@@ -2653,9 +2653,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@simpleview/sv-mosaic-eslint@npm:0.0.1":
-  version: 0.0.1
-  resolution: "@simpleview/sv-mosaic-eslint@npm:0.0.1"
+"@simpleview/sv-mosaic-eslint@npm:0.0.2":
+  version: 0.0.2
+  resolution: "@simpleview/sv-mosaic-eslint@npm:0.0.2"
   dependencies:
     "@eslint/js": ^9.15.0
     "@stylistic/eslint-plugin": ^2.11.0
@@ -2665,7 +2665,7 @@ __metadata:
     typescript-eslint: ^8.15.0
   peerDependencies:
     eslint: ">9"
-  checksum: 59d17cdd817dc80b708ea44bdee6313e7d4832182893d201b7b346a9dd21775e16ea90e908c478674a6e884fd6289fd2d715a6a87fa4fa459240782b5c1c42a9
+  checksum: 722c50ab1114668cd731a908c9c0c0ca2a834becee0a8e8d611907768cfccfac88351857d477838a62104e1ce6e1a075270f65a80cc231651af088950df53ff1
   languageName: node
   linkType: hard
 
@@ -2686,7 +2686,7 @@ __metadata:
     "@react-google-maps/api": ^2.7.0
     "@simpleview/mochalib": 2.0.2
     "@simpleview/react-phone-input-2": 2.16.5
-    "@simpleview/sv-mosaic-eslint": 0.0.1
+    "@simpleview/sv-mosaic-eslint": 0.0.2
     "@testing-library/dom": 10.4.0
     "@testing-library/jest-dom": 6.5.0
     "@testing-library/react": 16.0.1

--- a/containers/sb-8/package.json
+++ b/containers/sb-8/package.json
@@ -25,7 +25,7 @@
 		"styled-components": "6.0.7"
 	},
 	"devDependencies": {
-		"@simpleview/sv-mosaic-eslint": "^0.0.1",
+		"@simpleview/sv-mosaic-eslint": "0.0.2",
 		"@storybook/addon-essentials": "^8.1.11",
 		"@storybook/addon-interactions": "^8.1.11",
 		"@storybook/addon-links": "^8.1.11",

--- a/containers/sb-8/yarn.lock
+++ b/containers/sb-8/yarn.lock
@@ -3118,9 +3118,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@simpleview/sv-mosaic-eslint@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "@simpleview/sv-mosaic-eslint@npm:0.0.1"
+"@simpleview/sv-mosaic-eslint@npm:0.0.2":
+  version: 0.0.2
+  resolution: "@simpleview/sv-mosaic-eslint@npm:0.0.2"
   dependencies:
     "@eslint/js": ^9.15.0
     "@stylistic/eslint-plugin": ^2.11.0
@@ -3130,7 +3130,7 @@ __metadata:
     typescript-eslint: ^8.15.0
   peerDependencies:
     eslint: ">9"
-  checksum: 59d17cdd817dc80b708ea44bdee6313e7d4832182893d201b7b346a9dd21775e16ea90e908c478674a6e884fd6289fd2d715a6a87fa4fa459240782b5c1c42a9
+  checksum: 722c50ab1114668cd731a908c9c0c0ca2a834becee0a8e8d611907768cfccfac88351857d477838a62104e1ce6e1a075270f65a80cc231651af088950df53ff1
   languageName: node
   linkType: hard
 
@@ -11172,7 +11172,7 @@ __metadata:
     "@mui/material": 5.16.7
     "@mui/styles": 5.16.7
     "@mui/x-date-pickers": 5.0.0-beta.0
-    "@simpleview/sv-mosaic-eslint": ^0.0.1
+    "@simpleview/sv-mosaic-eslint": 0.0.2
     "@storybook/addon-essentials": ^8.1.11
     "@storybook/addon-interactions": ^8.1.11
     "@storybook/addon-links": ^8.1.11


### PR DESCRIPTION
# [MOS-1518](https://simpleviewtools.atlassian.net/browse/MOS-1518)

## Description
- (chore) Upgrades to @simpleview/sv-mosaic-eslint@0.0.2 to utilises the `no-console` rule.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1518]: https://simpleviewtools.atlassian.net/browse/MOS-1518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ