### PR TITLE
MOS-1460

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.styled.ts
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.styled.ts
@@ -292,7 +292,13 @@ export const StyledControlButton = styled.button.attrs<{ $active?: boolean; $squ
 `;
 
 export const StyledTextStyleMenuButton = styled(StyledControlButton)`
-    width: 90px;
+    width: 100px;
+    text-align: center;
+`;
+
+export const MultipleStyles = styled.div`
+    font-style: italic;
+    color: ${theme.newColors.grey3["100"]};
 `;
 
 export const CodeView = styled(TextareaAutosize)`

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/TextStyleMenuButton.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/TextStyleMenuButton.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 import type { MenuButtonProps } from "../../FormFieldTextEditorTypes";
 
-import { StyledTextStyleMenuButton } from "../../FormFieldTextEditor.styled";
+import { MultipleStyles, StyledTextStyleMenuButton } from "../../FormFieldTextEditor.styled";
 import testIds from "@root/utils/testIds";
 
 export function TextStyleMenuButton({ disabled, editor, onClick }: MenuButtonProps): ReactElement {
@@ -23,10 +23,10 @@ export function TextStyleMenuButton({ disabled, editor, onClick }: MenuButtonPro
 	return (
 		<StyledTextStyleMenuButton
 			onClick={onClick}
-			disabled={disabled || !currentStyle}
+			disabled={disabled}
 			data-testid={testIds.TEXT_EDITOR_HEADING_MENU}
 		>
-			{currentStyle || "Normal Text"}
+			{currentStyle || <MultipleStyles>Multiple Styles</MultipleStyles>}
 		</StyledTextStyleMenuButton>
 	);
 }


### PR DESCRIPTION
# [MOS-1460](https://simpleviewtools.atlassian.net/browse/MOS-1460)

## Description
- (TextEditor) Allow text styling of multiple blocks by not disabling the text style dropdown. Indicates that there are multiple styles active in the selection.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1460]: https://simpleviewtools.atlassian.net/browse/MOS-1460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ