### PR TITLE
MOS-1536

### DIFF
--- a/containers/mosaic/src/components/Content/Content.styled.ts
+++ b/containers/mosaic/src/components/Content/Content.styled.ts
@@ -73,7 +73,7 @@ export const FieldsList = styled.div`
 
 export const ContentRowWrapper = styled.dl<{ $columns?: number }>`
 	display: grid;
-	row-gap: 12px;
+	gap: 0 12px;
 	width: 100%;
 	margin: 0;
 	grid-template-columns: repeat(${({ $columns }) => $columns} ,minmax(0,1fr));


### PR DESCRIPTION
# [MOS-1536](https://simpleviewtools.atlassian.net/browse/MOS-1536)

## Description
- (Content) Swaps out the row-gap style for gap due to unknown bug.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1536]: https://simpleviewtools.atlassian.net/browse/MOS-1536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ