### PR TITLE
MOS-1534

### DIFF
--- a/containers/mosaic/src/__tests__/components/Card/Card.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Card/Card.test.tsx
@@ -53,4 +53,36 @@ describe(__dirname, () => {
 		expect(screen.queryByTestId(testIds.BUTTON_ROW)).toBeInTheDocument();
 		expect(screen.queryAllByRole("button")).toHaveLength(2);
 	});
+
+	it("should display the count alongside the title if more than 0", async () => {
+		await setup({ count: 1 });
+
+		const heading = screen.queryByTestId(testIds.CARD_HEADING);
+		expect(heading).toBeInTheDocument();
+		expect(heading).toHaveTextContent("My Card(1)");
+	});
+
+	it("should display the count alongside the title if it's zero and zero counts should be displayed", async () => {
+		await setup({ count: 0, displayZeroCount: true });
+
+		const heading = screen.queryByTestId(testIds.CARD_HEADING);
+		expect(heading).toBeInTheDocument();
+		expect(heading).toHaveTextContent("My Card(0)");
+	});
+
+	it("should not display the count alongside the title if it's zero and zero counts should not be displayed", async () => {
+		await setup({ count: 0, displayZeroCount: false });
+
+		const heading = screen.queryByTestId(testIds.CARD_HEADING);
+		expect(heading).toBeInTheDocument();
+		expect(heading).toHaveTextContent("My Card");
+	});
+
+	it("should not display the count if it's not provided", async () => {
+		await setup();
+
+		const heading = screen.queryByTestId(testIds.CARD_HEADING);
+		expect(heading).toBeInTheDocument();
+		expect(heading).toHaveTextContent("My Card");
+	});
 });

--- a/containers/mosaic/src/components/Card/Card.styled.tsx
+++ b/containers/mosaic/src/components/Card/Card.styled.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import theme from "@root/theme";
+import ButtonRow from "../ButtonRow";
 
 export const CardWrapper = styled.div`
 	border: 2px solid ${theme.newColors.grey2["100"]};
@@ -7,15 +8,15 @@ export const CardWrapper = styled.div`
 	width: 100%;
 `;
 
-export const TitleBar = styled.div`
+export const Heading = styled.div`
 	align-items: center;
   	background: ${theme.newColors.grey2["100"]};
 	display: flex;
-	justify-content: space-between;
 	padding: 8px 16px;
+	gap: 8px;
 `;
 
-export const TitleWrapper = styled.div`
+export const Title = styled.div`
 	display: flex;
 	align-items: center;
 	gap: 8px;
@@ -24,6 +25,14 @@ export const TitleWrapper = styled.div`
 		color: ${theme.newColors.almostBlack["100"]};
 		width: 16px;
 	}
+`;
+
+export const Count = styled.div`
+	font-size: 14px;
+`;
+
+export const CardButtonRow = styled(ButtonRow)`
+	margin-left: auto;
 `;
 
 export const BottomActionWrapper = styled.div`

--- a/containers/mosaic/src/components/Card/Card.tsx
+++ b/containers/mosaic/src/components/Card/Card.tsx
@@ -8,26 +8,43 @@ import {
 	ContentWrapper,
 	CardWrapper,
 	StyledHr,
-	TitleWrapper,
-	TitleBar,
+	Title,
+	Heading,
+	Count,
+	CardButtonRow,
 } from "./Card.styled";
 import ButtonRow from "../ButtonRow/ButtonRow";
 import { SubtitleText } from "../Typography";
 
 const Card = (props: CardProps): ReactElement => {
-	const { bottomActions, content, title, titleIcon: TitleIcon, topActions } = props;
+	const {
+		bottomActions,
+		content,
+		count,
+		displayZeroCount,
+		title,
+		titleIcon: TitleIcon,
+		topActions,
+	} = props;
 
 	return (
 		<CardWrapper data-testid={testIds.CARD}>
-			<TitleBar data-testid={testIds.CARD_HEADING}>
-				<TitleWrapper>
+			<Heading data-testid={testIds.CARD_HEADING}>
+				<Title>
 					{TitleIcon && <TitleIcon data-testid={testIds.CARD_TITLE_ICON} />}
 					<SubtitleText maxLines={1}>{title}</SubtitleText>
-				</TitleWrapper>
-				{topActions?.length > 0 && (
-					<ButtonRow buttons={topActions} />
+				</Title>
+				{count !== undefined && (count !== 0 || displayZeroCount) && (
+					<Count>
+						(
+						{count}
+						)
+					</Count>
 				)}
-			</TitleBar>
+				{topActions?.length > 0 && (
+					<CardButtonRow className="Foo" buttons={topActions} />
+				)}
+			</Heading>
 			<ContentWrapper>
 				{content.map((element, idx) => (
 					<div key={idx} data-testid={testIds.CARD_ITEM}>

--- a/containers/mosaic/src/components/Card/CardTypes.ts
+++ b/containers/mosaic/src/components/Card/CardTypes.ts
@@ -22,4 +22,14 @@ export interface CardProps {
 	 * List of buttons that will display at the top of the card.
 	 */
 	topActions?: ButtonProps[];
+	/**
+	 * If defined, a number that will be displayed to indicate the number of items
+	 * (whatever they may be) that are listed in the card's content
+	 */
+	count?: number;
+	/**
+	 * Whether or not to display the count if it is zero. Has no effect if `count`
+	 * is `undefined`.
+	 */
+	displayZeroCount?: boolean;
 }

--- a/containers/sb-8/stories/components/Card/Card.stories.tsx
+++ b/containers/sb-8/stories/components/Card/Card.stories.tsx
@@ -47,6 +47,8 @@ export const Playground = ({
 	showBottomAction,
 	quantityOfTopActions,
 	quantityOfBottomActions,
+	count,
+	displayZeroCount,
 }: typeof Playground.args): ReactElement => {
 	const topActions: ButtonProps[] = [
 		{
@@ -106,6 +108,8 @@ export const Playground = ({
 			titleIcon={showTitleIcon && ContactsIcon}
 			topActions={showTopAction && topActions}
 			bottomActions={showBottomAction && bottomActions}
+			count={count}
+			displayZeroCount={displayZeroCount}
 		/>
 	);
 };
@@ -116,6 +120,8 @@ Playground.args = {
 	showBottomAction: true,
 	quantityOfTopActions: 1,
 	quantityOfBottomActions: 1,
+	count: 0,
+	displayZeroCount: false,
 };
 
 Playground.argTypes = {
@@ -137,6 +143,12 @@ Playground.argTypes = {
 		options: [0, 1, 2, 3],
 		control: { type: "select" },
 		name: "Bottom Actions",
+	},
+	count: {
+		name: "Count",
+	},
+	displayZeroCount: {
+		name: "Display Zero Count",
 	},
 };
 


### PR DESCRIPTION
# [MOS-1534](https://simpleviewtools.atlassian.net/browse/MOS-1534)

## Description
- (Card) Introduces a way to display a numeric item count alongside the card title.

## Checklist
- [x] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes