### PR TITLE
MOS-1546

### DIFF
--- a/containers/mosaic/src/components/Field/FieldTypes.tsx
+++ b/containers/mosaic/src/components/Field/FieldTypes.tsx
@@ -128,6 +128,12 @@ export interface FieldDefBase<Type, T = any> {
 	 */
 	instructionText?: string;
 	/**
+	 * If instruction text is provided, force it to be displayed
+	 * in the form of a tooltip rather than alongside the field,
+	 * even when the horizontal space is available.
+	 */
+	forceInstructionTooltip?: boolean;
+	/**
 	 * Indicates whether the field can be written on or readonly.
 	 */
 	disabled?: MosaicToggle<FormState>;

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.styled.ts
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.styled.ts
@@ -1,5 +1,6 @@
 import { EditorContent } from "@tiptap/react";
 import TextareaAutosize from "@mui/material/TextareaAutosize";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import styled, { css } from "styled-components";
 
 import theme from "@root/theme";
@@ -214,54 +215,67 @@ export const StyledFloatingToolbar = styled.div<{ $disabled?: boolean }>`
     background: white;
     box-shadow: box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
     border: 1px solid var(--border-color);
-    padding: 4px 0;
+    border-bottom: 0;
 `;
 
-export const PrimaryToolbar = styled.div<{ $focus?: boolean }>`
+export const StyledPrimaryToolbar = styled.div<{ $focus?: boolean }>`
     background: ${theme.newColors.grey1["100"]};
     border: 1px solid var(--border-color);
     border-bottom: 0;
     position: sticky;
-    padding: 4px 0;
     top: -25px;
     z-index: 1;
-
-    &::after {
-        border-bottom: 1px solid var(--border-color);
-        bottom: -1px;
-        content: " ";
-        left: 16px;
-        right: 16px;
-        position: absolute;
-    }
 
     ${({ $focus }) => $focus && `
         border-color: ${theme.newColors.almostBlack["100"]};
     `}
 `;
 
-export const ControlGroups = styled.div`
+export const ToolbarOverflow = styled.div`
+    overflow: hidden;
+`;
+
+export const ToolbarOffset = styled.div`
+    margin-left: -1px;
+`;
+
+export const ControlRow = styled.div`
     display: flex;
     flex-wrap: wrap;
+    position: relative;
+    padding: 4px 0;
+
+    &::after {
+        border-bottom: 1px solid var(--border-color);
+        bottom: 0;
+        content: " ";
+        left: 8px;
+        right: 8px;
+        position: absolute;
+    }
+
+    &:last-child::after {
+        left: 0;
+        right: 0;
+    }
 `;
 
 export const ControlGroup = styled.div`
     display: flex;
     align-items: center;
-    justify-content: center;
     padding-left: 8px;
     padding-right: 8px;
     position: relative;
     margin-left: 1px;
     gap: 2px;
 
-    &::after {
+    &::before {
         content: " ";
         position: absolute;
-        border-right: 1px solid var(--border-color);
+        border-left: 1px solid var(--border-color);
         top: 6px;
         bottom: 6px;
-        right: -1px;
+        left: -1px;
     }
 `;
 
@@ -292,8 +306,18 @@ export const StyledControlButton = styled.button.attrs<{ $active?: boolean; $squ
 `;
 
 export const StyledTextStyleMenuButton = styled(StyledControlButton)`
-    width: 100px;
+    width: 110px;
     text-align: center;
+    justify-content: start;
+    padding: 0;
+    padding-left: 4px;
+`;
+
+export const MenuButtonArrow = styled(KeyboardArrowDownIcon)`
+    margin-left: auto;
+    margin-right: -0.2em;
+    height: 20px !important;
+    width: 20px !important;
 `;
 
 export const MultipleStyles = styled.div`

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.tsx
@@ -8,7 +8,7 @@ import Skeleton from "@mui/material/Skeleton";
 import type { SelectionType, FloatingToolbarState, EditorMode, NodeFormState, TextEditorInputSettings, TextEditorData } from "./FormFieldTextEditorTypes";
 import type { MosaicFieldProps } from "../FieldTypes";
 
-import { Editor, CodeView, StyledTextEditor, PrimaryToolbar } from "./FormFieldTextEditor.styled";
+import { Editor, CodeView, StyledTextEditor } from "./FormFieldTextEditor.styled";
 import { NodeForm } from "./NodeForm/NodeForm";
 import { ToolbarControls, ModeSwitch } from "./Toolbar";
 import { transformScriptTags } from "./Extensions/Script";
@@ -19,6 +19,7 @@ import { getDefaultExtensions } from "./Extensions/defaultExtensions";
 import { escapeHtml } from "@root/utils/dom/escapeHtml";
 import testIds from "@root/utils/testIds";
 import { defaultControls, floatingControls, selectionVirtualElement } from "./textEditorUtils";
+import PrimaryToolbar from "./Toolbar/PrimaryToolbar";
 
 function FormFieldTextEditorUnmemo({
 	value = "",
@@ -193,7 +194,7 @@ function FormFieldTextEditorUnmemo({
 				focus={focus}
 			/>
 			{mode === "visual" && (
-				<PrimaryToolbar $focus={focus} data-testid={testIds.TEXT_EDITOR_PRIMARY_TOOLBAR}>
+				<PrimaryToolbar focus={focus}>
 					<ToolbarControls
 						editor={editor}
 						controls={controls}

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
@@ -123,7 +123,7 @@ export type TextEditorOnImageParams = Partial<TextEditorUpdateImageValues> & {
 };
 
 export interface TextEditorInputSettings {
-	controls?: ControlsConfig;
+	controls?: ControlsConfig[];
 	extensions?: Extensions;
 	onLink?: (params: TextEditorOnLinkParams) => void;
 	onImage?: (params: TextEditorOnImageParams) => void;

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenu.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenu.tsx
@@ -31,7 +31,7 @@ export function ControlMenuDropdown({
 	const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
 	const onClick = (e: MouseEvent<HTMLButtonElement>) => {
-		setAnchorEl(e.target as HTMLElement);
+		setAnchorEl(e.currentTarget);
 	};
 
 	const onClose = () => {

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/TextStyleMenuButton.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/TextStyleMenuButton.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 import type { MenuButtonProps } from "../../FormFieldTextEditorTypes";
 
-import { MultipleStyles, StyledTextStyleMenuButton } from "../../FormFieldTextEditor.styled";
+import { MenuButtonArrow, MultipleStyles, StyledTextStyleMenuButton } from "../../FormFieldTextEditor.styled";
 import testIds from "@root/utils/testIds";
 
 export function TextStyleMenuButton({ disabled, editor, onClick }: MenuButtonProps): ReactElement {
@@ -27,6 +27,7 @@ export function TextStyleMenuButton({ disabled, editor, onClick }: MenuButtonPro
 			data-testid={testIds.TEXT_EDITOR_HEADING_MENU}
 		>
 			{currentStyle || <MultipleStyles>Multiple Styles</MultipleStyles>}
+			<MenuButtonArrow />
 		</StyledTextStyleMenuButton>
 	);
 }

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/PrimaryToolbar.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/PrimaryToolbar.tsx
@@ -1,0 +1,16 @@
+import type { PropsWithChildren, ReactElement } from "react";
+
+import React from "react";
+
+import testIds from "@root/utils/testIds";
+import { StyledPrimaryToolbar } from "../FormFieldTextEditor.styled";
+
+function PrimaryToolbar({ children, focus }: PropsWithChildren<{focus?: boolean}>): ReactElement {
+	return (
+		<StyledPrimaryToolbar $focus={focus} data-testid={testIds.TEXT_EDITOR_PRIMARY_TOOLBAR}>
+			{children}
+		</StyledPrimaryToolbar>
+	);
+}
+
+export default PrimaryToolbar;

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControlRow.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControlRow.tsx
@@ -1,0 +1,74 @@
+import type { ReactElement } from "react";
+
+import React, { useMemo } from "react";
+
+import type { ControlsConfig } from "../FormFieldTextEditorTypes";
+import type { ToolbarControlsProps } from "./ToolbarControls";
+
+import { ControlButton, ControlMenuDropdown, resolveControls } from "./Controls";
+import { ControlGroup, ControlRow } from "../FormFieldTextEditor.styled";
+import testIds from "@root/utils/testIds";
+
+type ToolbarControlRowProps = Omit<ToolbarControlsProps, "controls"> & {
+	controls: ControlsConfig;
+}
+
+export function ToolbarControlRow({
+	editor,
+	controls: controlsDef,
+	selectionTypes,
+	inputSettings = {},
+	disabled,
+}: ToolbarControlRowProps): ReactElement {
+	const groups = useMemo(() => resolveControls(controlsDef, selectionTypes), [controlsDef, selectionTypes]);
+
+	return (
+		<ControlRow>
+			{groups.map((group, groupIndex) => (
+				<ControlGroup key={groupIndex}>
+					{group.map((control, index) => Array.isArray(control) ? (
+						<ControlMenuDropdown
+							key={index}
+							editor={editor}
+							controls={control}
+							inputSettings={inputSettings}
+							testId={`${testIds.TEXT_EDITOR_CONTROL}:menu-${groupIndex}-${index}`}
+							disabled={disabled}
+						/>
+					) : "MenuButton" in control ? (
+						<ControlMenuDropdown
+							key={index}
+							editor={editor}
+							controls={control.controls}
+							MenuButton={control.MenuButton}
+							inputSettings={inputSettings}
+							disabled={disabled}
+						/>
+					) : "Component" in control ? (
+						<control.Component
+							{...control}
+							key={index}
+							editor={editor}
+							inputSettings={inputSettings}
+							data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${control.name}`}
+							disabled={disabled}
+						/>
+					) : (
+						<ControlButton
+							key={control.name}
+							onClick={(event) => control.cmd({ editor, inputSettings, event })}
+							label={control.label}
+							shortcut={control.shortcut}
+							active={editor.isActive(control.name)}
+							square
+							data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${control.name}`}
+							disabled={disabled}
+						>
+							<control.Icon />
+						</ControlButton>
+					))}
+				</ControlGroup>
+			))}
+		</ControlRow>
+	);
+}

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControls.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControls.tsx
@@ -1,16 +1,15 @@
 import type { ReactElement } from "react";
 import type { Editor } from "@tiptap/core";
 
-import React, { useMemo } from "react";
+import React from "react";
 
 import type { ControlsConfig, SelectionType, TextEditorInputSettings } from "../FormFieldTextEditorTypes";
 
-import { ControlButton, ControlMenuDropdown, resolveControls } from "./Controls";
-import { ControlGroup, ControlGroups } from "../FormFieldTextEditor.styled";
-import testIds from "@root/utils/testIds";
+import { ToolbarControlRow } from "./ToolbarControlRow";
+import { ToolbarOffset, ToolbarOverflow } from "../FormFieldTextEditor.styled";
 
 export interface ToolbarControlsProps {
-	controls: ControlsConfig;
+	controls: ControlsConfig[];
 	editor: Editor;
 	selectionTypes?: SelectionType[];
 	inputSettings: TextEditorInputSettings;
@@ -18,61 +17,19 @@ export interface ToolbarControlsProps {
 }
 
 export function ToolbarControls({
-	editor,
-	controls: controlsDef,
-	selectionTypes,
-	inputSettings = {},
-	disabled,
+	controls: controlRows,
+	...props
 }: ToolbarControlsProps): ReactElement {
-	const groups = useMemo(() => resolveControls(controlsDef, selectionTypes), [controlsDef, selectionTypes]);
-
 	return (
-		<ControlGroups>
-			{groups.map((group, groupIndex) => (
-				<ControlGroup key={groupIndex}>
-					{group.map((control, index) => Array.isArray(control) ? (
-						<ControlMenuDropdown
-							key={index}
-							editor={editor}
-							controls={control}
-							inputSettings={inputSettings}
-							testId={`${testIds.TEXT_EDITOR_CONTROL}:menu-${groupIndex}-${index}`}
-							disabled={disabled}
-						/>
-					) : "MenuButton" in control ? (
-						<ControlMenuDropdown
-							key={index}
-							editor={editor}
-							controls={control.controls}
-							MenuButton={control.MenuButton}
-							inputSettings={inputSettings}
-							disabled={disabled}
-						/>
-					) : "Component" in control ? (
-						<control.Component
-							{...control}
-							key={index}
-							editor={editor}
-							inputSettings={inputSettings}
-							data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${control.name}`}
-							disabled={disabled}
-						/>
-					) : (
-						<ControlButton
-							key={control.name}
-							onClick={(event) => control.cmd({ editor, inputSettings, event })}
-							label={control.label}
-							shortcut={control.shortcut}
-							active={editor.isActive(control.name)}
-							square
-							data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${control.name}`}
-							disabled={disabled}
-						>
-							<control.Icon />
-						</ControlButton>
-					))}
-				</ControlGroup>
-			))}
-		</ControlGroups>
+		<ToolbarOverflow>
+			<ToolbarOffset>
+				{controlRows.map(controlRow => (
+					<ToolbarControlRow
+						controls={controlRow}
+						{...props}
+					/>
+				))}
+			</ToolbarOffset>
+		</ToolbarOverflow>
 	);
 }

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControls.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/ToolbarControls.tsx
@@ -23,9 +23,10 @@ export function ToolbarControls({
 	return (
 		<ToolbarOverflow>
 			<ToolbarOffset>
-				{controlRows.map(controlRow => (
+				{controlRows.map((controlRow, index) => (
 					<ToolbarControlRow
 						controls={controlRow}
+						key={index}
 						{...props}
 					/>
 				))}

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/textEditorUtils.ts
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/textEditorUtils.ts
@@ -6,44 +6,48 @@ import type { ControlBase, ControlsConfig, VirtualElement } from "./FormFieldTex
 
 import { controlBold, controlClear, controlImage, controlItalic, controlLink, controlLinkPreview, controlStrikethrough, controlSubscript, controlSuperscript, controlUnderline } from "./Toolbar/Controls/predefinedControls";
 
-export const defaultControls: ControlsConfig = [
-	["headings"],
-	["bold", "italic", ["underline", "strike", "superscript", "subscript", "clear"]],
-	["bulletList", "orderedList"],
-	["alignLeft", "alignCenter", ["alignRight", "alignJustify"]],
-	["link", ["image", "codeBlock", "blockquote"]],
-	["undo", "redo"],
+export const defaultControls: ControlsConfig[] = [
+	[
+		["headings"],
+		["bold", "italic", ["underline", "strike", "superscript", "subscript", "clear"]],
+		["bulletList", "orderedList"],
+		["alignLeft", "alignCenter", ["alignRight", "alignJustify"]],
+		["link", ["image", "codeBlock", "blockquote"]],
+		["undo", "redo"],
+	],
 ];
 
 const formattingShow: ControlBase["show"] = ({ selectionTypes = [] }) => selectionTypes.includes("formatting");
 
-export const floatingControls: ControlsConfig = [
+export const floatingControls: ControlsConfig[] = [
 	[
-		{ ...controlBold, show: formattingShow },
-		{ ...controlItalic, show: formattingShow },
 		[
-			{ ...controlUnderline, show: formattingShow },
-			{ ...controlStrikethrough, show: formattingShow },
-			{ ...controlSuperscript, show: formattingShow },
-			{ ...controlSubscript, show: formattingShow },
-			{ ...controlClear, show: formattingShow },
+			{ ...controlBold, show: formattingShow },
+			{ ...controlItalic, show: formattingShow },
+			[
+				{ ...controlUnderline, show: formattingShow },
+				{ ...controlStrikethrough, show: formattingShow },
+				{ ...controlSuperscript, show: formattingShow },
+				{ ...controlSubscript, show: formattingShow },
+				{ ...controlClear, show: formattingShow },
+			],
 		],
-	],
-	[
-		{
-			...controlLink,
-			show: ({ selectionTypes = [] }) => !selectionTypes.includes("image"),
-		},
-		{
-			...controlLinkPreview,
-			show: ({ selectionTypes = [] }) => !selectionTypes.includes("image") && selectionTypes.includes("link"),
-		},
-	],
-	[
-		{
-			...controlImage,
-			show: ({ selectionTypes = [] }) => selectionTypes.includes("image"),
-		},
+		[
+			{
+				...controlLink,
+				show: ({ selectionTypes = [] }) => !selectionTypes.includes("image"),
+			},
+			{
+				...controlLinkPreview,
+				show: ({ selectionTypes = [] }) => !selectionTypes.includes("image") && selectionTypes.includes("link"),
+			},
+		],
+		[
+			{
+				...controlImage,
+				show: ({ selectionTypes = [] }) => selectionTypes.includes("image"),
+			},
+		],
 	],
 ];
 

--- a/containers/mosaic/src/components/FieldWrapper/FieldWrapper.tsx
+++ b/containers/mosaic/src/components/FieldWrapper/FieldWrapper.tsx
@@ -128,6 +128,7 @@ const FieldWrapper = (props: MosaicFieldProps<any>): ReactElement => {
 								limit={limit}
 								value={value}
 								instructionText={fieldDef?.instructionText}
+								forceInstructionTooltip={fieldDef?.forceInstructionTooltip}
 								colsInRow={colsInRow}
 								name={fieldDef.name}
 								as={hasRealLabel ? "label" : "div"}
@@ -148,7 +149,7 @@ const FieldWrapper = (props: MosaicFieldProps<any>): ReactElement => {
 					<HelperText>{fieldDef?.helperText}</HelperText>
 				)}
 			</StyledFieldWrapper>
-			{fieldDef?.instructionText && (
+			{fieldDef?.instructionText && !fieldDef?.forceInstructionTooltip && (
 				<InstructionText colsInRow={colsInRow}>
 					{fieldDef.instructionText}
 				</InstructionText>

--- a/containers/mosaic/src/components/FieldWrapper/Label.tsx
+++ b/containers/mosaic/src/components/FieldWrapper/Label.tsx
@@ -51,8 +51,8 @@ const StyledRequiredIndicator = styled.span`
 	color: ${theme.newColors.darkRed["100"]};
 `;
 
-const StyledTooltipWrapper = styled.div<{ $colsInRow?: number }>`
-  	${({ $colsInRow = 1 }) => $colsInRow === 1 && `
+const StyledTooltipWrapper = styled.div<{ $colsInRow?: number; $alwaysShow?: boolean }>`
+  	${({ $alwaysShow, $colsInRow = 1 }) => !$alwaysShow && $colsInRow === 1 && `
 		${containerQuery("sm", "FORM_COL")} {
 			display: none;
 		}
@@ -71,6 +71,7 @@ interface LabelProps {
 	value?: string;
 	limit?: [number, number];
 	instructionText?: string;
+	forceInstructionTooltip?: boolean;
 	colsInRow?: number;
 	as?: "label" | "div";
 }
@@ -83,6 +84,7 @@ const Label = (props: LabelProps): ReactElement => {
 		name,
 		limit,
 		instructionText,
+		forceInstructionTooltip,
 		colsInRow,
 		as = "label",
 	} = props;
@@ -101,7 +103,10 @@ const Label = (props: LabelProps): ReactElement => {
 				{required && <StyledRequiredIndicator>*</StyledRequiredIndicator>}
 			</StyledInputLabel>
 			{instructionText && (
-				<StyledTooltipWrapper $colsInRow={colsInRow}>
+				<StyledTooltipWrapper
+					$colsInRow={colsInRow}
+					$alwaysShow={forceInstructionTooltip}
+				>
 					<TooltipIcon {...anchorProps} />
 					<Tooltip {...tooltipProps}>
 						{instructionText}

--- a/containers/sb-8/stories/components/Field/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
@@ -14,6 +14,7 @@ import { LinkLibraryDrawer } from "./LinkLibraryDrawer";
 import ChatBubbleIcon from "@mui/icons-material/ChatBubble";
 import { SimpleViewAlert } from "./SimpleviewAlertExtension";
 import { controls } from "./controls";
+import { Sizes } from "@root/theme";
 
 export default {
 	title: "FormFields/FormFieldTextEditor",
@@ -32,9 +33,11 @@ export const Playground = ({
 	required,
 	skeleton,
 	instructionText,
+	forceInstructionTooltip,
 	helperText,
 	maxCharacters,
 	autolink,
+	size,
 	customControlConfig,
 	customImageHandler,
 	customLinkHandler,
@@ -65,7 +68,7 @@ export const Playground = ({
 						autolink,
 						controls: [
 							...customControlConfig?.length ? customControlConfig : controls,
-							...customExtensionExample ? [[customExtensionControl]] : [],
+							...customExtensionExample ? [[[customExtensionControl]]] : [],
 						],
 						extensions: customExtensionExample ? [...getDefaultExtensions(), SimpleViewAlert] : undefined,
 						onImage: customImageHandler ? ({ updateImage, ...params }) => {
@@ -93,6 +96,8 @@ export const Playground = ({
 					disabled,
 					helperText,
 					instructionText,
+					forceInstructionTooltip,
+					size,
 				},
 			],
 		[
@@ -101,6 +106,8 @@ export const Playground = ({
 			label,
 			helperText,
 			instructionText,
+			forceInstructionTooltip,
+			size,
 			maxCharacters,
 			autolink,
 			customControlConfig,
@@ -154,9 +161,11 @@ Playground.args = {
 	required: false,
 	skeleton: false,
 	instructionText: "Instruction text",
+	forceInstructionTooltip: false,
 	helperText: "Helper text",
 	maxCharacters: 100,
 	autolink: true,
+	size: "lg",
 	customControlConfig: [],
 	customImageHandler: false,
 	customLinkHandler: false,
@@ -181,6 +190,9 @@ Playground.argTypes = {
 	instructionText: {
 		name: "Instruction Text",
 	},
+	forceInstructionTooltip: {
+		name: "Force Instruction Tooltip",
+	},
 	helperText: {
 		name: "Helper Text",
 	},
@@ -189,6 +201,11 @@ Playground.argTypes = {
 	},
 	autolink: {
 		name: "Auto Link",
+	},
+	size: {
+		name: "Size",
+		options: Object.keys(Sizes),
+		control: { type: "select" },
 	},
 	customControlConfig: {
 		name: "Custom Control Config",

--- a/containers/sb-8/stories/components/Field/FormFieldTextEditor/controls.ts
+++ b/containers/sb-8/stories/components/Field/FormFieldTextEditor/controls.ts
@@ -1,10 +1,14 @@
 import type { ControlsConfig } from "@root/components/Field";
 
-export const controls: ControlsConfig = [
-	["headings"],
-	["bold", "italic", ["underline", "strike", "superscript", "subscript", "clear"]],
-	["bulletList", "orderedList"],
-	["alignLeft", "alignCenter", ["alignRight", "alignJustify"]],
-	["link", ["image", "codeBlock", "blockquote"]],
-	["undo", "redo"],
+export const controls: ControlsConfig[] = [
+	[
+		["headings"],
+		["bold", "italic", ["underline", "strike", "superscript", "subscript", "clear"]],
+		["bulletList", "orderedList"],
+		["alignLeft", "alignCenter", ["alignRight", "alignJustify"]],
+		["link", ["image", "codeBlock", "blockquote"]],
+	],
+	[
+		["undo", "redo"],
+	],
 ];


### PR DESCRIPTION
# [MOS-1546](https://simpleviewtools.atlassian.net/browse/MOS-1546)

## Description
- **BREAKING CHANGE** (TextEditor) Adds support for rows of controls.
- (TextEditor) Adjust styling to control groups to ensure there can't be a trailing separator even when control groups wrap.
- (TextEditor) Adjust styling to text block menu button to look more like a dropdown.

## Todo
- Update documentation.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [x] This contains breaking changes

[MOS-1546]: https://simpleviewtools.atlassian.net/browse/MOS-1546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ