### PR TITLE
MOS-1548

### DIFF
--- a/containers/mosaic/src/__tests__/components/Form/useForm/getFieldPaths.test.ts
+++ b/containers/mosaic/src/__tests__/components/Form/useForm/getFieldPaths.test.ts
@@ -80,6 +80,7 @@ describe(__dirname, () => {
 					field3: fieldObjects[2],
 				},
 				result: [
+					["group1"],
 					["group1", "field1"],
 					["group1", "field2"],
 					["field3"],
@@ -105,8 +106,10 @@ describe(__dirname, () => {
 					},
 				},
 				result: [
+					["group1"],
 					["group1", "field1"],
 					["group1", "field2"],
+					["group1", "group2"],
 					["group1", "group2", "field3"],
 				],
 			},

--- a/containers/mosaic/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocompleteField.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocompleteField.tsx
@@ -167,6 +167,7 @@ function AddressAutocompleteField(props): ReactElement {
 					required: fieldDef.required,
 					size: Sizes.lg,
 				}}
+				path={path}
 				methods={props.methods}
 				disabled={props.disabled}
 				useRealLabel

--- a/containers/mosaic/src/components/Field/FormFieldAddress/AddressStateField/AddressStateField.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAddress/AddressStateField/AddressStateField.tsx
@@ -76,6 +76,7 @@ function AddressStateField(props): ReactElement {
 				required: fieldDef.required,
 				size: fieldDef.size,
 			}}
+			path={path}
 			methods={props.methods}
 			disabled={props.disabled}
 			useRealLabel

--- a/containers/mosaic/src/components/Form/Field/Field.tsx
+++ b/containers/mosaic/src/components/Form/Field/Field.tsx
@@ -109,6 +109,7 @@ const Field = ({
 
 	const fieldWrapperProps = {
 		fieldDef: sanitizedFieldDef,
+		path: path,
 		value: value,
 		error: error,
 		colsInRow: colsInRow,

--- a/containers/mosaic/src/components/Form/Form.tsx
+++ b/containers/mosaic/src/components/Form/Form.tsx
@@ -23,6 +23,7 @@ import { generateLayout } from "./Layout/layoutUtils";
 import useScrollTo from "@root/utils/hooks/useScrollTo/useScrollTo";
 import { FormContext } from "./FormContext";
 import sanitizeFieldDefs from "./useForm/utils/sanitizeFieldDefs";
+import getFieldPaths from "./useForm/utils/getFieldPaths";
 
 const topCollapseContainer: MosaicCSSContainer = {
 	name: "FORM",
@@ -106,16 +107,15 @@ const Form = (props: FormProps) => {
 			return;
 		}
 
-		const [firstErroneousField] = Object.entries(stable.fields)
-			.filter(([, field]) => stable.mounted[field.name] && errors[field.name])
-			.map(([, field]) => field)
-			.sort(({ order: a }, { order: b }) => a - b);
+		const firstErrorPath = getFieldPaths(stable.fields)
+			.map(path => path.join("."))
+			.find(path => stable.mounted[path] && errors[path]);
 
-		if (!firstErroneousField) {
+		if (!firstErrorPath) {
 			return;
 		}
 
-		const mount = stable.mounted[firstErroneousField.name];
+		const mount = stable.mounted[firstErrorPath];
 
 		if (!mount) {
 			return;

--- a/containers/mosaic/src/components/Form/useForm/types.ts
+++ b/containers/mosaic/src/components/Form/useForm/types.ts
@@ -144,6 +144,7 @@ export type DisableForm = (params: DisableFormParams) => void;
 
 export interface MountFieldParams {
 	name: string;
+	path?: FieldPath;
 	fieldRef?: HTMLDivElement;
 	inputRef?: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
 }

--- a/containers/mosaic/src/components/Form/useForm/useForm.ts
+++ b/containers/mosaic/src/components/Form/useForm/useForm.ts
@@ -362,19 +362,21 @@ export function useForm(): UseFormReturn {
 		};
 	}, [removeWait]);
 
-	const mountField = useCallback<MountField>(({ name, fieldRef, inputRef }) => {
-		stable.current.mounted[name] = {
+	const mountField = useCallback<MountField>(({ name, path = [], fieldRef, inputRef }) => {
+		const key = [...path, name].join(".");
+
+		stable.current.mounted[key] = {
 			fieldRef,
 			inputRef,
 		};
 
 		return {
 			unmount: () => {
-				stable.current.mounted[name] = false;
+				stable.current.mounted[key] = false;
 
 				dispatch({
 					type: "SET_FIELD_ERRORS",
-					errors: { [name]: undefined },
+					errors: { [key]: undefined },
 					merge: true,
 				});
 			},

--- a/containers/mosaic/src/components/Form/useForm/utils/fieldIsActive.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/fieldIsActive.ts
@@ -12,12 +12,12 @@ interface FieldIsActiveParams {
 
 function fieldIsActive({
 	name,
-	path,
+	path = [],
 	stable,
 }: FieldIsActiveParams): boolean {
 	const { mounted } = stable;
 
-	if (!mounted[name]) {
+	if (!mounted[[...path, name].join(".")]) {
 		return false;
 	}
 

--- a/containers/mosaic/src/components/Form/useForm/utils/getFieldPaths.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/getFieldPaths.ts
@@ -2,8 +2,10 @@ import type { FieldObj } from "@root/components/Field";
 import type { FieldPath } from "../types";
 
 function getFieldPaths(fields: Record<string, FieldObj>, leading: FieldPath = []): FieldPath[] {
-	const entries = Object.entries(fields).toSorted(([, { order: a }], [, { order: b }]) => a - b);
+	const entries = Object.entries(fields);
 	const paths: FieldPath[] = [];
+
+	entries.sort(([, { order: a }], [, { order: b }]) => a - b);
 
 	for (const [, field] of entries) {
 		const fullPath = [...leading, field.name];

--- a/containers/mosaic/src/components/Form/useForm/utils/getFieldPaths.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/getFieldPaths.ts
@@ -6,12 +6,17 @@ function getFieldPaths(fields: Record<string, FieldObj>, leading: FieldPath = []
 	const paths: FieldPath[] = [];
 
 	for (const [, field] of entries) {
+		const fullPath = [...leading, field.name];
+
 		if (field.type === "group") {
-			paths.push(...getFieldPaths(field.fields, [...leading, field.name]));
+			paths.push(
+				fullPath,
+				...getFieldPaths(field.fields, fullPath),
+			);
 			continue;
 		}
 
-		paths.push([...leading, field.name]);
+		paths.push(fullPath);
 	}
 
 	return paths;

--- a/containers/mosaic/src/components/Form/useForm/utils/getFieldPaths.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/getFieldPaths.ts
@@ -2,7 +2,7 @@ import type { FieldObj } from "@root/components/Field";
 import type { FieldPath } from "../types";
 
 function getFieldPaths(fields: Record<string, FieldObj>, leading: FieldPath = []): FieldPath[] {
-	const entries = Object.entries(fields);
+	const entries = Object.entries(fields).toSorted(([, { order: a }], [, { order: b }]) => a - b);
 	const paths: FieldPath[] = [];
 
 	for (const [, field] of entries) {

--- a/containers/mosaic/src/utils/hooks/useRegisterField/useRegisterField.ts
+++ b/containers/mosaic/src/utils/hooks/useRegisterField/useRegisterField.ts
@@ -6,6 +6,7 @@ function useRegisterField(props: MosaicFieldProps & { fieldRef?: React.MutableRe
 		fieldDef: {
 			name,
 		} = {},
+		path,
 		skeleton,
 		methods: {
 			mountField,
@@ -21,12 +22,13 @@ function useRegisterField(props: MosaicFieldProps & { fieldRef?: React.MutableRe
 
 		const { unmount } = mountField({
 			name: name,
+			path,
 			fieldRef: fieldRef?.current,
 			inputRef: inputRef?.current,
 		});
 
 		return unmount;
-	}, [mountField, name, inputRef, skeleton, fieldRef]);
+	}, [mountField, name, path, inputRef, skeleton, fieldRef]);
 }
 
 export default useRegisterField;

--- a/containers/mosaic/tsconfig.json
+++ b/containers/mosaic/tsconfig.json
@@ -4,7 +4,8 @@
 		"lib": [
 			"ES2019",
 			"DOM",
-			"ES2022.Intl"
+			"ES2022.Intl",
+			"ES2023.Array"
 		],
 		"target": "ES2019",
 		"moduleResolution": "node",

--- a/containers/mosaic/tsconfig.json
+++ b/containers/mosaic/tsconfig.json
@@ -4,8 +4,7 @@
 		"lib": [
 			"ES2019",
 			"DOM",
-			"ES2022.Intl",
-			"ES2023.Array"
+			"ES2022.Intl"
 		],
 		"target": "ES2019",
 		"moduleResolution": "node",


### PR DESCRIPTION
# [MOS-1548](https://simpleviewtools.atlassian.net/browse/MOS-1548)

## Description
- (Form) Add the group itself to the list when collating a list of paths from field store.
- (Form) Ensure group sub fields are properly mounted so that their corresponding DOM elements can be referenced for auto scrolling.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1548]: https://simpleviewtools.atlassian.net/browse/MOS-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ