### PR TITLE
MOS-1555

### DIFF
--- a/containers/mosaic/package.json
+++ b/containers/mosaic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@simpleview/sv-mosaic",
-	"version": "39.3.2",
+	"version": "39.3.3-80435581e",
 	"description": "Mosaic UI Library",
 	"author": "Owen Allen <owenallenaz@gmail.com>",
 	"devDependencies": {

--- a/containers/mosaic/package.json
+++ b/containers/mosaic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@simpleview/sv-mosaic",
-	"version": "39.3.3-80435581e",
+	"version": "39.3.3-35a44fc3b",
 	"description": "Mosaic UI Library",
 	"author": "Owen Allen <owenallenaz@gmail.com>",
 	"devDependencies": {

--- a/containers/mosaic/src/utils/hooks/useScrollSpy/useScrollSpy.ts
+++ b/containers/mosaic/src/utils/hooks/useScrollSpy/useScrollSpy.ts
@@ -17,9 +17,8 @@ export default function useScrollSpy<E extends HTMLElement>({
 	const { animation, scrollTo } = useScrollTo({
 		container: containerRef,
 		onStop: () => {
-			scrollHandlerActiveTimeout.current = setTimeout(() => {
-				scrollHandlerActive.current = true;
-			}, 10);
+			console.log("Enable scroll listener");
+			scrollHandlerActive.current = true;
 		},
 	});
 
@@ -67,6 +66,7 @@ export default function useScrollSpy<E extends HTMLElement>({
 				return;
 			}
 
+			console.log("Set active based on scroll listener");
 			setActiveSection(getActiveSection());
 		}
 

--- a/containers/mosaic/src/utils/hooks/useScrollSpy/useScrollSpy.ts
+++ b/containers/mosaic/src/utils/hooks/useScrollSpy/useScrollSpy.ts
@@ -10,16 +10,14 @@ export default function useScrollSpy<E extends HTMLElement>({
 	threshold = 0.2,
 }: ScrollSpyProps<E>): ScrollSpyResult {
 	const scrollHandlerActive = useRef<boolean>(true);
-	const scrollHandlerActiveTimeout = useRef<undefined | ReturnType<typeof setTimeout>>(undefined);
 
 	const { current: container } = containerRef;
 
 	const { animation, scrollTo } = useScrollTo({
 		container: containerRef,
-		onStop: () => {
-			console.log("Enable scroll listener");
+		onScrollFinished: useCallback(() => {
 			scrollHandlerActive.current = true;
-		},
+		}, []),
 	});
 
 	const [activeSection, setActiveSection] = useState<number>(0);
@@ -66,7 +64,6 @@ export default function useScrollSpy<E extends HTMLElement>({
 				return;
 			}
 
-			console.log("Set active based on scroll listener");
 			setActiveSection(getActiveSection());
 		}
 
@@ -82,7 +79,6 @@ export default function useScrollSpy<E extends HTMLElement>({
 			return;
 		}
 
-		clearTimeout(scrollHandlerActiveTimeout.current);
 		scrollHandlerActive.current = false;
 
 		setActiveSection(index);

--- a/containers/mosaic/src/utils/hooks/useScrollTo/useScrollTo.ts
+++ b/containers/mosaic/src/utils/hooks/useScrollTo/useScrollTo.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import clamp from "@root/utils/math/clamp";
 import type { UseScrollToParams } from "./useScrollToTypes";
@@ -11,11 +11,29 @@ export default function useScrollTo<E extends HTMLElement>({
 	container: containerRef,
 	onComplete,
 	onStop,
+	onScrollFinished,
 }: UseScrollToParams<E>) {
+	/**
+	 * We keep a track of the scroll handlers that are attached with setting of scroll offsets.
+	 *
+	 * Just because the animation has finished, it doesn't mean that the final scroll event
+	 * has fired. On the flipside, the last scroll event can also fire before the animation
+	 * has finished if easing calculations mean that the scroll top is set to its current
+	 * value.
+	 *
+	 * Therefore, we fire the onScrollFinished callback either when the animation completes
+	 * and the scroll handler queue is empty, or when the final scroll handler fires, but
+	 * it should only happen once per animation.
+	 */
+	const scrollHandlers = useRef<(() => void)[]>([]);
 	const animation = useAnimate({
 		onComplete: () => {
 			onComplete && onComplete();
 			onStop && onStop();
+
+			if (onScrollFinished && !scrollHandlers.current.length) {
+				onScrollFinished();
+			}
 		},
 	});
 
@@ -39,6 +57,40 @@ export default function useScrollTo<E extends HTMLElement>({
 		return () => container.removeEventListener("wheel", onMouseWheel);
 	}, [animation, containerRef, onStop]);
 
+	const setScroll = useCallback(({ top, left }: { top?: number; left?: number }) => {
+		const { current: container } = containerRef;
+
+		if (!container) {
+			return;
+		}
+
+		let hasChanged = false;
+
+		if (top !== undefined && container.scrollTop !== top) {
+			container.scrollTop = top;
+			hasChanged = true;
+		}
+
+		if (left !== undefined && container.scrollLeft !== left) {
+			container.scrollLeft = left;
+			hasChanged = true;
+		}
+
+		if (hasChanged) {
+			const handler = () => {
+				container.removeEventListener("scroll", handler);
+				scrollHandlers.current = scrollHandlers.current.filter(item => item !== handler);
+
+				if (!scrollHandlers.current.length && !animation.inProgress()) {
+					onScrollFinished();
+				}
+			};
+
+			scrollHandlers.current.push(handler);
+			container.addEventListener("scroll", handler, { passive: true });
+		}
+	}, [onScrollFinished, animation, containerRef]);
+
 	const scrollTo = useCallback(({ target, offset = 0 }: { target: HTMLElement; offset?: number }) => {
 		if (!target) {
 			return;
@@ -57,13 +109,14 @@ export default function useScrollTo<E extends HTMLElement>({
 		const valueEnd = Math.min(newScrollTop, scrollMax);
 
 		animation.start({
-			fn: (n) => typeof container.scrollTo === "function" && container.scrollTo({ top: n }),
+			fn: (n) => setScroll({ top: n }),
 			valueStart,
 			valueEnd,
 			duration: clamp(Math.abs(valueEnd - valueStart) * 0.75, {
 				min: MIN_SCROLL_DURATION,
 				max: MAX_SCROLL_DURATION,
 			}),
+			// duration: 5_000,
 		});
 	}, [animation, containerRef]);
 

--- a/containers/mosaic/src/utils/hooks/useScrollTo/useScrollTo.ts
+++ b/containers/mosaic/src/utils/hooks/useScrollTo/useScrollTo.ts
@@ -27,6 +27,10 @@ export default function useScrollTo<E extends HTMLElement>({
 		}
 
 		const onMouseWheel = () => {
+			if (!animation.inProgress()) {
+				return;
+			}
+
 			animation.stop();
 			onStop && onStop();
 		};

--- a/containers/mosaic/src/utils/hooks/useScrollTo/useScrollToTypes.ts
+++ b/containers/mosaic/src/utils/hooks/useScrollTo/useScrollToTypes.ts
@@ -18,4 +18,9 @@ export interface UseScrollToParams<E extends HTMLElement> {
 	 * complete
 	 */
 	onStop?: () => void;
+	/**
+	 * A callback to invoke when scrolling has
+	 * finished and events have all fired.
+	 */
+	onScrollFinished?: () => void;
 }

--- a/containers/mosaic/src/utils/math/animate.ts
+++ b/containers/mosaic/src/utils/math/animate.ts
@@ -53,12 +53,12 @@ export default function animate(params: AnimateParams = {}): Animation {
 		window.requestAnimationFrame(_tick);
 	};
 
-	const stop: AnimateStop = () => {
-		state.preventNext = true;
-	};
-
 	const inProgress = () => {
 		return !state.preventNext;
+	};
+
+	const stop: AnimateStop = () => {
+		state.preventNext = true;
 	};
 
 	return {


### PR DESCRIPTION
# [MOS-1555](https://simpleviewtools.atlassian.net/browse/MOS-1555)

## Description
- (ScrollSpy) Introduce mechanism to invoke an action more accurately when a container has finished scrolling, not just when the animation is complete.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1555]: https://simpleviewtools.atlassian.net/browse/MOS-1555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ