### PR TITLE
MOS-1555

### DIFF
--- a/containers/mosaic/src/utils/hooks/useScrollSpy/useScrollSpy.ts
+++ b/containers/mosaic/src/utils/hooks/useScrollSpy/useScrollSpy.ts
@@ -10,17 +10,14 @@ export default function useScrollSpy<E extends HTMLElement>({
 	threshold = 0.2,
 }: ScrollSpyProps<E>): ScrollSpyResult {
 	const scrollHandlerActive = useRef<boolean>(true);
-	const scrollHandlerActiveTimeout = useRef<undefined | ReturnType<typeof setTimeout>>(undefined);
 
 	const { current: container } = containerRef;
 
 	const { animation, scrollTo } = useScrollTo({
 		container: containerRef,
-		onStop: () => {
-			scrollHandlerActiveTimeout.current = setTimeout(() => {
-				scrollHandlerActive.current = true;
-			}, 10);
-		},
+		onScrollFinished: useCallback(() => {
+			scrollHandlerActive.current = true;
+		}, []),
 	});
 
 	const [activeSection, setActiveSection] = useState<number>(0);
@@ -82,7 +79,6 @@ export default function useScrollSpy<E extends HTMLElement>({
 			return;
 		}
 
-		clearTimeout(scrollHandlerActiveTimeout.current);
 		scrollHandlerActive.current = false;
 
 		setActiveSection(index);

--- a/containers/mosaic/src/utils/hooks/useScrollTo/useScrollToTypes.ts
+++ b/containers/mosaic/src/utils/hooks/useScrollTo/useScrollToTypes.ts
@@ -18,4 +18,9 @@ export interface UseScrollToParams<E extends HTMLElement> {
 	 * complete
 	 */
 	onStop?: () => void;
+	/**
+	 * A callback to invoke when scrolling has
+	 * finished and events have all fired.
+	 */
+	onScrollFinished?: () => void;
 }

--- a/containers/mosaic/src/utils/math/animate.ts
+++ b/containers/mosaic/src/utils/math/animate.ts
@@ -53,12 +53,12 @@ export default function animate(params: AnimateParams = {}): Animation {
 		window.requestAnimationFrame(_tick);
 	};
 
-	const stop: AnimateStop = () => {
-		state.preventNext = true;
-	};
-
 	const inProgress = () => {
 		return !state.preventNext;
+	};
+
+	const stop: AnimateStop = () => {
+		state.preventNext = true;
 	};
 
 	return {


### PR DESCRIPTION
# [MOS-1555](https://simpleviewtools.atlassian.net/browse/MOS-1555)

## Description
- (ScrollSpy) Introduce mechanism to invoke an action more accurately when a container has finished scrolling, not just when the animation is complete.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1555]: https://simpleviewtools.atlassian.net/browse/MOS-1555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ