### PR TITLE
MOS-1478

### DIFF
--- a/containers/e2e-tests/pages/Components/DataView/AdvancedFiltersComponent.ts
+++ b/containers/e2e-tests/pages/Components/DataView/AdvancedFiltersComponent.ts
@@ -64,7 +64,7 @@ export class AdvancedFiltersComponent extends FilterComponent {
 
 		this.comparisonDropdown = page.locator("div.comparisonDropdown button").nth(0);
 		this.helpComparisonCategoriesDialogButton = page.locator("div.comparisonDropdown button").nth(1);
-		this.helpComparisonCategoriesDialog = page.locator("[role='presentation'] p");
+		this.helpComparisonCategoriesDialog = page.getByTestId(testIds.COMPARISON_HELP);
 		this.keywordSearchComparisonCategories = page.locator("div.options input[type='text']");
 
 		this.titleFilterSearch = page.locator("div.inputRow input");
@@ -124,10 +124,6 @@ export class AdvancedFiltersComponent extends FilterComponent {
 		const selectedCategory = await this.labelCheckbox.first().textContent();
 		await this.filterCheckbox.first().click();
 		return selectedCategory;
-	}
-
-	async getHelpDialogFromCategoryWithComparisonOption(): Promise<string> {
-		return await this.helpComparisonCategoriesDialog.nth(1).textContent();
 	}
 
 	async keywordSearchForComparisonCategory(category: string): Promise<string> {

--- a/containers/e2e-tests/pages/Components/DataView/PaginationComponent.ts
+++ b/containers/e2e-tests/pages/Components/DataView/PaginationComponent.ts
@@ -73,11 +73,11 @@ export class PaginationComponent extends BasePage {
 	}
 
 	async getPageInput(): Promise<Locator> {
-		return this.pagesOption.locator("input[type='text']");
+		return this.page.getByLabel("Page*", { exact: true });
 	}
 
 	async getPageGoBtn(): Promise<Locator> {
-		return this.pagesOption.locator("button");
+		return this.page.getByRole("button", { name: "Go" });
 	}
 
 	async selectViewType(option: "List" | "Grid"): Promise<void> {

--- a/containers/e2e-tests/tests/Components/DataView/AdvancedFilters.spec.ts
+++ b/containers/e2e-tests/tests/Components/DataView/AdvancedFilters.spec.ts
@@ -147,8 +147,10 @@ test.describe("Components - Data View - Advanced Filters", () => {
 		await advancedFilters.selectFilter("categoriesWithComparisons");
 		await advancedFilters.categoryWithComparisonBtn.click();
 		await advancedFilters.helpComparisonCategoriesDialogButton.click();
-		const helpDialog = await advancedFilters.getHelpDialogFromCategoryWithComparisonOption();
-		expect(helpDialog.toString()).toBe(advanced_filter_data.categoryComparisonHelpDialog);
+		const size = await advancedFilters.helpComparisonCategoriesDialog.count();
+		expect(size).toBe(1);
+		const text = await advancedFilters.helpComparisonCategoriesDialog.textContent();
+		expect(text).toBe(advanced_filter_data.categoryComparisonHelpDialog);
 		await page.reload();
 	});
 

--- a/containers/e2e-tests/tests/Components/DataView/Pagination.spec.ts
+++ b/containers/e2e-tests/tests/Components/DataView/Pagination.spec.ts
@@ -58,41 +58,36 @@ test.describe("Components - Data View - Pagination", () => {
 	test("Validate pages by result per page - Default", async () => {
 		const pages = await pagination.calculatePages(dataview_data.resultPerPageDefault);
 		await pagination.paginationValue.click();
-		expect(await (await pagination.getPagesLabel()).textContent()).toContain(`${pages}`);
+		await expect(page.getByText(`of ${pages}`)).toBeVisible();
 	});
 
 	test("Validate pages by result per page - 50", async () => {
 		await pagination.selectResultOption(50);
 		const pages = await pagination.calculatePages(dataview_data.resultPerPage50);
 		await pagination.paginationValue.click();
-		expect(await (await pagination.getPagesLabel()).textContent()).toContain(`${pages}`);
+		await expect(page.getByText(`of ${pages}`)).toBeVisible();
 	});
 
 	test("Validate pages by result per page - 100", async () => {
 		await pagination.selectResultOption(100);
 		const pages = await pagination.calculatePages(dataview_data.resultPerPage100);
 		await pagination.paginationValue.click();
-		expect(await (await pagination.getPagesLabel()).textContent()).toContain(`${pages}`);
+		await expect(page.getByText(`of ${pages}`)).toBeVisible();
 	});
 
 	test("Go to a valid page", async () => {
 		const recordRangePerPage = await pagination.calulateRecordRangePerPage(dataview_data.resultPerPageDefault, 4);
 		await pagination.paginationValue.click();
-		await (await pagination.getPageInput()).type("4");
+		await (await pagination.getPageInput()).fill("4");
 		await (await pagination.getPageGoBtn()).click();
 		expect(await pagination.paginationValue.textContent()).toBe(recordRangePerPage);
 	});
 
 	test("Go to a no existing page", async () => {
 		await pagination.paginationValue.click();
-		await (await pagination.getPageInput()).type("50");
+		await (await pagination.getPageInput()).fill("50");
 		await (await pagination.getPageGoBtn()).click();
-	});
-
-	test("Go to a no valid page", async () => {
-		await pagination.paginationValue.click();
-		await (await pagination.getPageInput()).type("p");
-		await (await pagination.getPageGoBtn()).click();
+		await expect(page.getByText("Number must be less than or equal to 13")).toBeVisible();
 	});
 
 	test("Still same page", async () => {

--- a/containers/mosaic/src/__tests__/components/DataView/DataViewActionsRow/DataViewActionsRow.test.tsx
+++ b/containers/mosaic/src/__tests__/components/DataView/DataViewActionsRow/DataViewActionsRow.test.tsx
@@ -62,7 +62,7 @@ describe(__dirname, () => {
 
 		await setup({ onColumnsChange: onColumnsChangeMock });
 
-		expect(screen.queryByRole("button", { name: "DataView.columns" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Columns" })).toBeInTheDocument();
 	});
 
 	it("should render the sort control for grid displays if both a sort and on sort change handler has been provided", async () => {

--- a/containers/mosaic/src/__tests__/components/DataView/DataViewPagerPopover/DataViewPagerPopover.test.tsx
+++ b/containers/mosaic/src/__tests__/components/DataView/DataViewPagerPopover/DataViewPagerPopover.test.tsx
@@ -12,7 +12,7 @@ async function setup(props: Partial<DataViewPagerPopoverProps & ButtonPopoverCon
 	const onSkipChangeMock = props.onSkipChange || vi.fn();
 	const onCloseMock = props.onClose || vi.fn();
 
-	const renderResult = await act(() => render(
+	const renderResult = await act(async () => await render(
 		<ButtonPopoverContext.Provider value={{ onClose: onCloseMock }}>
 			<DataViewPagerPopover
 				currentPage={1}
@@ -38,6 +38,7 @@ describe(__dirname, () => {
 		expect(screen.queryByRole("textbox")).toBeInTheDocument();
 		expect(screen.queryByText("of 25")).toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Go" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Cancel" })).toBeInTheDocument();
 	});
 
 	it("should invoke the on skip change handler with the correct value when a number is entered and go is clicked", async () => {
@@ -52,6 +53,7 @@ describe(__dirname, () => {
 		expect(input).toBeInTheDocument();
 		expect(button).toBeInTheDocument();
 
+		await user.clear(input);
 		await user.type(input, "5");
 		await user.click(button);
 
@@ -68,49 +70,12 @@ describe(__dirname, () => {
 		const input = screen.queryByRole("textbox");
 		expect(input).toBeInTheDocument();
 
+		await user.clear(input);
 		await user.type(input, "5");
 		await user.keyboard("{Enter}");
 
 		expect(onSkipChangeMock).toBeCalledWith({ skip: 40 });
 		expect(onCloseMock).toBeCalled();
-	});
-
-	it("should do nothing on submission if the value entered into the input is not a valid number", async () => {
-		const onSkipChangeMock = vi.fn();
-		const onCloseMock = vi.fn();
-
-		const { user } = await setup({ onSkipChange: onSkipChangeMock, onClose: onCloseMock });
-
-		const input = screen.queryByRole("textbox");
-		const button = screen.queryByRole("button", { name: "Go" });
-
-		expect(input).toBeInTheDocument();
-		expect(button).toBeInTheDocument();
-
-		await user.type(input, "One");
-		await user.click(button);
-
-		expect(onSkipChangeMock).not.toBeCalled();
-		expect(onCloseMock).not.toBeCalled();
-	});
-
-	it("should do nothing on submission if the value entered is less than 1", async () => {
-		const onSkipChangeMock = vi.fn();
-		const onCloseMock = vi.fn();
-
-		const { user } = await setup({ onSkipChange: onSkipChangeMock, onClose: onCloseMock });
-
-		const input = screen.queryByRole("textbox");
-		const button = screen.queryByRole("button", { name: "Go" });
-
-		expect(input).toBeInTheDocument();
-		expect(button).toBeInTheDocument();
-
-		await user.type(input, "0");
-		await user.click(button);
-
-		expect(onSkipChangeMock).not.toBeCalled();
-		expect(onCloseMock).not.toBeCalled();
 	});
 
 	it("should do nothing on submission if the value entered is more than the total number of pages", async () => {
@@ -128,6 +93,7 @@ describe(__dirname, () => {
 		await user.type(input, "26");
 		await user.click(button);
 
+		expect(screen.queryByText("Number must be less than or equal to 25")).toBeInTheDocument();
 		expect(onSkipChangeMock).not.toBeCalled();
 		expect(onCloseMock).not.toBeCalled();
 	});

--- a/containers/mosaic/src/components/Button/Button.styled.ts
+++ b/containers/mosaic/src/components/Button/Button.styled.ts
@@ -230,8 +230,3 @@ export const StyledIconButton = styled(IconButton)<TransientProps<ButtonProps, "
 		}
 	`;
 });
-
-export const PopoverWrapper = styled.div`
-	font-family: ${theme.fontFamily};
-	padding: 10px;
-`;

--- a/containers/mosaic/src/components/Button/Button.tsx
+++ b/containers/mosaic/src/components/Button/Button.tsx
@@ -8,7 +8,6 @@ import type { ButtonPopoverContextProps, ButtonProps } from "./ButtonTypes";
 
 import { StyledButton, StyledIconButton, StyledWrapper } from "./Button.styled";
 import Menu from "../Menu";
-import { PopoverWrapper } from "./Button.styled";
 import { useToggle } from "@root/utils/toggle";
 import Tooltip, { useTooltip } from "@root/components/Tooltip";
 
@@ -149,11 +148,9 @@ function ButtonWithState(props: ButtonProps) {
 					style={isPopoverOnHover ? { pointerEvents: "none" } : null}
 					{...popoverProps}
 				>
-					<PopoverWrapper>
-						<ButtonPopoverContext.Provider value={{ onClose: closeMenu }}>
-							{props.popover}
-						</ButtonPopoverContext.Provider>
-					</PopoverWrapper>
+					<ButtonPopoverContext.Provider value={{ onClose: closeMenu }}>
+						{props.popover}
+					</ButtonPopoverContext.Provider>
 				</Popover>
 			) : props.menuItems ? (
 				<Menu

--- a/containers/mosaic/src/components/DataView/DataViewPagerPopover/DataViewPagerPopover.tsx
+++ b/containers/mosaic/src/components/DataView/DataViewPagerPopover/DataViewPagerPopover.tsx
@@ -28,11 +28,13 @@ function DataViewPagerPopover({
 			name: "page",
 			label: "Page",
 			type: "number",
+			required: true,
 			inputSettings: {
 				suffix: `of ${totalPages}`,
 				decimalPlaces: 0,
 				sign: "positive",
 			},
+			validators: [{ fn: "validateNumberRange", options: { maxNum: totalPages } }],
 		},
 	], [totalPages]);
 
@@ -41,7 +43,7 @@ function DataViewPagerPopover({
 	}), [currentPage]);
 
 	const onSubmit = handleSubmit(useCallback(({ data: { page } }) => {
-		onSkipChange({ skip : (page - 1) * limit });
+		onSkipChange({ skip : (Number(page) - 1) * limit });
 		onClose();
 	}, [limit, onClose, onSkipChange]));
 

--- a/containers/mosaic/src/components/DataViewFilterMultiselect/DataViewFilterMultiselect.styled.tsx
+++ b/containers/mosaic/src/components/DataViewFilterMultiselect/DataViewFilterMultiselect.styled.tsx
@@ -91,6 +91,7 @@ export const StyledComparisonHeader = styled.div`
 	margin-bottom: 1rem;
 `;
 
-export const PopoverP = styled.p`
-	margin: 0px;
+export const StyledComparisonHelp = styled.div`
+	font-family: ${theme.fontFamily};
+	padding: 10px;
 `;

--- a/containers/mosaic/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectDropdownContent.tsx
+++ b/containers/mosaic/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectDropdownContent.tsx
@@ -17,7 +17,7 @@ import Button from "../Button";
 import ButtonRow from "../ButtonRow";
 import Spinner from "../Spinner";
 import { SubtitleText } from "../Typography";
-import { PopoverP, StyledWrapper, StyledComparisonHeader } from "./DataViewFilterMultiselect.styled";
+import { StyledWrapper, StyledComparisonHeader, StyledComparisonHelp } from "./DataViewFilterMultiselect.styled";
 import { StyledTextField } from "@root/components/Field/FormFieldText/FormFieldText.styled";
 import CheckboxList from "../CheckboxList";
 
@@ -203,20 +203,18 @@ function DataViewFilterMultiselectDropdownContent(props: DataViewFilterMultisele
 						color="blue"
 						mIcon={HelpIcon}
 						popover={(
-							<PopoverP>
-								{
-									menuItems.map((item, id) => (
-										<span key={id}>
-											<b>{item.label}</b>
-											{" "}
-											-
-											{" "}
-											{popoverP[item.label]}
-											<br />
-										</span>
-									))
-								}
-							</PopoverP>
+							<StyledComparisonHelp>
+								{menuItems.map((item, id) => (
+									<span key={id}>
+										<b>{item.label}</b>
+										{" "}
+										-
+										{" "}
+										{popoverP[item.label]}
+										<br />
+									</span>
+								))}
+							</StyledComparisonHelp>
 						)}
 					/>
 				</ButtonRow>

--- a/containers/mosaic/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectDropdownContent.tsx
+++ b/containers/mosaic/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectDropdownContent.tsx
@@ -203,7 +203,7 @@ function DataViewFilterMultiselectDropdownContent(props: DataViewFilterMultisele
 						color="blue"
 						mIcon={HelpIcon}
 						popover={(
-							<StyledComparisonHelp>
+							<StyledComparisonHelp data-testid={testIds.COMPARISON_HELP}>
 								{menuItems.map((item, id) => (
 									<span key={id}>
 										<b>{item.label}</b>

--- a/containers/mosaic/src/components/Form/Form.styled.ts
+++ b/containers/mosaic/src/components/Form/Form.styled.ts
@@ -3,6 +3,7 @@ import theme, { CONTAINERS } from "@root/theme/theme";
 import SideNav from "../SideNav/SideNav";
 import { containerQuery } from "@root/utils/css";
 import type { FormSpacing } from "./FormTypes";
+import Button from "../Button";
 
 export const StyledContainerForm = styled.div<{ $fullHeight?: boolean }>`
 	position: relative;
@@ -60,4 +61,10 @@ export const StyledFormFooter = styled.div<{ $spacing?: FormSpacing }>`
 	border-top: 2px solid ${theme.newColors.grey2[100]};
 	padding: ${({ $spacing }) => $spacing === "compact" ? "16px" : "24px"};
 	display: flex;
+`;
+
+export const StyledFormFooterButton = styled(Button)<{ $push?: "left" | "right"}>`
+	${({ $push }) => $push && `
+		margin-${$push}: auto;
+	`}
 `;

--- a/containers/mosaic/src/components/Form/Form.tsx
+++ b/containers/mosaic/src/components/Form/Form.tsx
@@ -2,7 +2,7 @@ import React, { useLayoutEffect, useState } from "react";
 import { memo, useEffect, useMemo, useRef, useCallback } from "react";
 
 import type { MosaicCSSContainer } from "@root/types";
-import type { FormProps } from "./FormTypes";
+import type { AutofocusOptions, FormProps } from "./FormTypes";
 import type { ButtonProps } from "../Button";
 import type { Item, SideNavArgs } from "../SideNav";
 
@@ -139,6 +139,10 @@ const Form = (props: FormProps) => {
 			return;
 		}
 
+		const autoFocusOptions: AutofocusOptions = typeof autoFocus === "object" ? autoFocus : {
+			selectAll: false,
+		};
+
 		const [firstField] = Object.entries(stable.fields)
 			.filter(([, field]) => stable.mounted[field.name])
 			.map(([, field]) => field)
@@ -156,7 +160,13 @@ const Form = (props: FormProps) => {
 
 		doneAutoFocus.current = true;
 
-		window.requestAnimationFrame(() => mount.inputRef.focus());
+		window.requestAnimationFrame(() => {
+			mount.inputRef.focus();
+
+			if (autoFocusOptions.selectAll && "select" in mount.inputRef) {
+				mount.inputRef.select();
+			}
+		});
 	}, [disabled, loadingInitial, autoFocus, stable.fields, stable.mounted]);
 
 	useEffect(() => {

--- a/containers/mosaic/src/components/Form/FormTypes.tsx
+++ b/containers/mosaic/src/components/Form/FormTypes.tsx
@@ -21,6 +21,10 @@ export interface SectionDef extends Section {
 	gridMinWidth?: string;
 }
 
+export interface AutofocusOptions {
+	selectAll?: boolean;
+}
+
 export interface FormProps {
 	state: FormState;
 	stable: FormStable;
@@ -40,7 +44,7 @@ export interface FormProps {
 	useSectionHash?: string | false;
 	onSubmit?: React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>["onSubmit"];
 	methods: FormMethods;
-	autoFocus?: boolean;
+	autoFocus?: boolean | AutofocusOptions;
 	skeleton?: boolean;
 	bottomSlot?: ReactNode;
 }

--- a/containers/mosaic/src/utils/form/validators.ts
+++ b/containers/mosaic/src/utils/form/validators.ts
@@ -162,13 +162,13 @@ export async function validateDateRange(value: string, data: any, options: Recor
 	return undefined;
 }
 
-export function validateNumberRange(value: string, data: any, { minName, maxName }: { minName?: number; maxName?: number }): string | undefined {
+export function validateNumberRange(value: string, data: any, { minNum, minName, maxNum, maxName }: { minNum?: number; minName?: string; maxNum?: number; maxName?: string }): string | undefined {
 	if (value === undefined) {
 		return;
 	}
 
-	const min = minName && data[minName];
-	const max = maxName && data[maxName];
+	const min = minNum ?? (minName && data[minName]);
+	const max = maxNum ?? (maxName && data[maxName]);
 
 	const numberValue = Number(value);
 	if (Number.isNaN(numberValue) || !Number.isFinite(numberValue)) {

--- a/containers/mosaic/src/utils/testIds.ts
+++ b/containers/mosaic/src/utils/testIds.ts
@@ -10,6 +10,7 @@ const testIds = {
 	CHECKBOX_WRAPPER: "mos:Checkbox:wrapper",
 	CHIP: "mos:Chip:root",
 	CHIP_DELETE_ICON: "mos:Chip:deleteIcon",
+	COMPARISON_HELP: "mos:comparisonHelp",
 	CONTENT: "mos:Content:root",
 	CONTENT_COL: "mos:Content:col",
 	CONTENT_FIELD: "mos:Content:field",


### PR DESCRIPTION
# [MOS-1478](https://simpleviewtools.atlassian.net/browse/MOS-1478)

## Description
- (Button) Removes the outer popover wrapper, allowing individual popover contents to drive their own styles.
- (Form) Adds a way to select all text when using the autofocus mechanic, with a default fallback to only focusing when a boolean is passed.
- (DataView) Utilises the Form component for the pager popover to bring consistency and improved UX.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1478]: https://simpleviewtools.atlassian.net/browse/MOS-1478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ