### PR TITLE
MOS-1512

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.styled.ts
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.styled.ts
@@ -209,6 +209,10 @@ export const Editor = styled(EditorContent)<{ $minHeight?: string | number; $max
             border-bottom: 1px solid #fff;
             box-shadow: 0 1px 0 #008DA8;
         }
+
+        table th {
+            text-align: start;
+        }
     }
 `;
 


### PR DESCRIPTION
# [MOS-1512](https://simpleviewtools.atlassian.net/browse/MOS-1512)

## Description
- (TextEditor) Resets the text alignment of table header cells.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1512]: https://simpleviewtools.atlassian.net/browse/MOS-1512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ