### PR TITLE
MOS-1478

### DIFF
--- a/containers/e2e-tests/tests/Components/DataView/Pagination.spec.ts
+++ b/containers/e2e-tests/tests/Components/DataView/Pagination.spec.ts
@@ -87,7 +87,7 @@ test.describe("Components - Data View - Pagination", () => {
 		await pagination.paginationValue.click();
 		await (await pagination.getPageInput()).fill("50");
 		await (await pagination.getPageGoBtn()).click();
-		await expect(page.getByText("Number must be less than or equal to 13")).toBeVisible();
+		await expect(page.getByText("Number must be between 1 and 13")).toBeVisible();
 	});
 
 	test("Still same page", async () => {

--- a/containers/mosaic/src/__tests__/components/DataView/DataViewPagerPopover/DataViewPagerPopover.test.tsx
+++ b/containers/mosaic/src/__tests__/components/DataView/DataViewPagerPopover/DataViewPagerPopover.test.tsx
@@ -78,7 +78,7 @@ describe(__dirname, () => {
 		expect(onCloseMock).toBeCalled();
 	});
 
-	it("should do nothing on submission if the value entered is more than the total number of pages", async () => {
+	it("should show error on submission if the value entered is more than the total number of pages", async () => {
 		const onSkipChangeMock = vi.fn();
 		const onCloseMock = vi.fn();
 
@@ -90,6 +90,7 @@ describe(__dirname, () => {
 		expect(input).toBeInTheDocument();
 		expect(button).toBeInTheDocument();
 
+		await user.clear(input);
 		await user.type(input, "26");
 		await user.click(button);
 
@@ -98,7 +99,7 @@ describe(__dirname, () => {
 		expect(onCloseMock).not.toBeCalled();
 	});
 
-	it("should do nothing on submission if the value entered is less than 1", async () => {
+	it("should show error on submission if the value entered is less than 1", async () => {
 		const onSkipChangeMock = vi.fn();
 		const onCloseMock = vi.fn();
 
@@ -110,6 +111,7 @@ describe(__dirname, () => {
 		expect(input).toBeInTheDocument();
 		expect(button).toBeInTheDocument();
 
+		await user.clear(input);
 		await user.type(input, "0");
 		await user.click(button);
 

--- a/containers/mosaic/src/__tests__/components/DataView/DataViewPagerPopover/DataViewPagerPopover.test.tsx
+++ b/containers/mosaic/src/__tests__/components/DataView/DataViewPagerPopover/DataViewPagerPopover.test.tsx
@@ -93,7 +93,27 @@ describe(__dirname, () => {
 		await user.type(input, "26");
 		await user.click(button);
 
-		expect(screen.queryByText("Number must be less than or equal to 25")).toBeInTheDocument();
+		expect(screen.queryByText("Number must be between 1 and 25")).toBeInTheDocument();
+		expect(onSkipChangeMock).not.toBeCalled();
+		expect(onCloseMock).not.toBeCalled();
+	});
+
+	it("should do nothing on submission if the value entered is less than 1", async () => {
+		const onSkipChangeMock = vi.fn();
+		const onCloseMock = vi.fn();
+
+		const { user } = await setup({ onSkipChange: onSkipChangeMock, onClose: onCloseMock });
+
+		const input = screen.queryByRole("textbox");
+		const button = screen.queryByRole("button", { name: "Go" });
+
+		expect(input).toBeInTheDocument();
+		expect(button).toBeInTheDocument();
+
+		await user.type(input, "0");
+		await user.click(button);
+
+		expect(screen.queryByText("Number must be between 1 and 25")).toBeInTheDocument();
 		expect(onSkipChangeMock).not.toBeCalled();
 		expect(onCloseMock).not.toBeCalled();
 	});

--- a/containers/mosaic/src/components/DataView/DataViewPager/DataViewPager.tsx
+++ b/containers/mosaic/src/components/DataView/DataViewPager/DataViewPager.tsx
@@ -25,8 +25,8 @@ function DataViewPager(props: DataViewPagerProps) {
 		props.onSkipChange({ skip });
 	};
 
-	const previousDisabled = currentPage === 1;
-	const nextDisabled = currentPage === totalPages;
+	const previousDisabled = currentPage <= 1;
+	const nextDisabled = currentPage >= totalPages;
 
 	if (totalPages === 0) {
 		return null;

--- a/containers/mosaic/src/components/DataView/DataViewPagerPopover/DataViewPagerPopover.tsx
+++ b/containers/mosaic/src/components/DataView/DataViewPagerPopover/DataViewPagerPopover.tsx
@@ -34,7 +34,7 @@ function DataViewPagerPopover({
 				decimalPlaces: 0,
 				sign: "positive",
 			},
-			validators: [{ fn: "validateNumberRange", options: { maxNum: totalPages } }],
+			validators: [{ fn: "validateNumberRange", options: { maxNum: totalPages, minNum: 1 } }],
 		},
 	], [totalPages]);
 


### PR DESCRIPTION
# [MOS-1478](https://simpleviewtools.atlassian.net/browse/MOS-1478)

## Description
- (DataViewPager) Ensure page selection form cannot accept page number less than 1. Change conditions for disabled navigation buttons.

## Checklist
- [x] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1478]: https://simpleviewtools.atlassian.net/browse/MOS-1478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ