### PR TITLE
MOS-1576

### DIFF
--- a/containers/mosaic/src/components/Form/Form.tsx
+++ b/containers/mosaic/src/components/Form/Form.tsx
@@ -58,6 +58,7 @@ const Form = (props: FormProps) => {
 		autoFocus,
 		skeleton: providedSkeleton,
 		bottomSlot = null,
+		hideSectionNav,
 	} = props;
 
 	const formContextValue = useMemo(() => ({ methods, state }), [methods, state]);
@@ -323,12 +324,13 @@ const Form = (props: FormProps) => {
 							description={description}
 							buttons={buttonsWithDisable}
 							bottomBorder={sideNavItems.length < 2}
+							hideSectionNav={hideSectionNav}
 							collapse={topCollapseContainer}
 							skeleton={skeleton}
 						/>
 					)}
 					<StyledFormPrimary className="form-primary">
-						{sideNavItems.length > 1 && (
+						{!hideSectionNav && sideNavItems.length > 1 && (
 							<StyledSideNav
 								items={[sideNavItems]}
 								active={String(activeSection)}

--- a/containers/mosaic/src/components/Form/FormTypes.tsx
+++ b/containers/mosaic/src/components/Form/FormTypes.tsx
@@ -47,6 +47,7 @@ export interface FormProps {
 	autoFocus?: boolean | AutofocusOptions;
 	skeleton?: boolean;
 	bottomSlot?: ReactNode;
+	hideSectionNav?: boolean;
 }
 
 export interface FieldError {

--- a/containers/mosaic/src/components/Form/Top/Top.tsx
+++ b/containers/mosaic/src/components/Form/Top/Top.tsx
@@ -33,11 +33,15 @@ const Top = (props: TopProps): ReactElement => {
 		backLabel,
 		bottomBorder,
 		collapse,
+		hideSectionNav,
 		skeleton,
 	} = props;
 
 	return (
-		<TopRoot $bottomBorder={bottomBorder}>
+		<TopRoot
+			$bottomBorder={bottomBorder}
+			$hideSectionNav={hideSectionNav}
+		>
 			<TopWrapper>
 				<Heading>
 					<Title>

--- a/containers/mosaic/src/components/Form/Top/TopStyled.tsx
+++ b/containers/mosaic/src/components/Form/Top/TopStyled.tsx
@@ -6,28 +6,36 @@ import theme from "@root/theme/theme";
 import { Description } from "@root/components/Title/TitleWrapper.styled";
 import { containerQuery } from "@root/utils/css";
 
-export const TopRoot = styled.div<{ $bottomBorder?: boolean }>`
-	border-bottom: 2px solid ${theme.newColors.grey2["100"]};
-	padding: 0 24px 24px;
+export const TopRoot = styled.div<{ $bottomBorder?: boolean; $hideSectionNav?: boolean }>`
+	padding: 0 24px;
+
+	${({ $hideSectionNav }) => !$hideSectionNav && `
+		padding-bottom: 24px;
+		border-bottom: 2px solid ${theme.newColors.grey2["100"]};
+	`}
 
 	${containerQuery("sm", "FORM")} {
 		padding-top: 24px;
 	}
 
-	${({ $bottomBorder }) => !$bottomBorder && `
+	${({ $bottomBorder, $hideSectionNav }) => !$bottomBorder && `
 		${containerQuery("sm", "FORM")} {
 			border-bottom: 0;
 			padding-bottom: 0;
 		}
 
-		${containerQuery("xl", "FORM")} {
-			padding-bottom: 24px;
-		}
+		${!$hideSectionNav && `
+			${containerQuery("xl", "FORM")} {
+				padding-bottom: 24px;
+			}
+		`}
 	`}
 
-	${containerQuery("xl", "FORM")} {
-		border-bottom: 2px solid ${theme.newColors.grey2["100"]};
-	}
+	${({ $hideSectionNav }) => !$hideSectionNav && `
+		${containerQuery("xl", "FORM")} {
+			border-bottom: 2px solid ${theme.newColors.grey2["100"]};
+		}
+	`}
 `;
 
 export const TopWrapper = styled.div`

--- a/containers/mosaic/src/components/Form/Top/TopTypes.ts
+++ b/containers/mosaic/src/components/Form/Top/TopTypes.ts
@@ -31,4 +31,6 @@ export interface TopProps {
 	collapse?: MosaicCSSContainer;
 
 	skeleton?: boolean;
+
+	hideSectionNav?: boolean;
 }

--- a/containers/sb-8/stories/components/Form/Form.mdx
+++ b/containers/sb-8/stories/components/Form/Form.mdx
@@ -91,6 +91,7 @@ This is the top level component that will render the various parts of your form,
 | `spacing` |  | `"normal"` or `"compact"` | What spacing to use for the form. Defaults to `"normal"` |
 | `useSectionHash` |  | `string` or `false` | The string that should be used to prefix the section index in the URL hash when scrolling. Provide `false` to disable the URL hash mechanic entirely. |
 | `autoFocus` |  | `boolean` | If true, once mounted, `Form` will attempt to automatically focus the user's cursor on the first field but only the first field is one of the following field types: `date`, `dropdown`, `numberTable`, `phone`, `text`, `textEditor`, `time`.. |
+| `hideSectionNav` |  | `boolean` | If true, regardless of the number of sections defined, the section navigation will not be rendered. Defaults to false. |
 
 ## Basic Usage
 In its simplest usage, the `Form` only needs an instance of the controller and an array of fields to work.

--- a/containers/sb-8/stories/components/Form/Profile.stories.tsx
+++ b/containers/sb-8/stories/components/Form/Profile.stories.tsx
@@ -572,6 +572,9 @@ Profile.argTypes = {
 	showState: {
 		name: "Show state",
 	},
+	hideSectionNav: {
+		name: "Hide Section Navigation",
+	},
 	height: {
 		name: "Height",
 	},

--- a/containers/sb-8/stories/components/Form/Profile.stories.tsx
+++ b/containers/sb-8/stories/components/Form/Profile.stories.tsx
@@ -48,6 +48,7 @@ const getFormValues = async () => ({
 
 export const Profile = ({
 	showState,
+	hideSectionNav,
 	height,
 	section1Fields,
 	showFirstName,
@@ -539,6 +540,7 @@ export const Profile = ({
 					fields={fields}
 					skeleton={skeleton}
 					getFormValues={getFormValues}
+					hideSectionNav={hideSectionNav}
 				/>
 			</div>
 		</>
@@ -553,6 +555,7 @@ export const Profile = ({
 
 Profile.args = {
 	showState: false,
+	hideSectionNav: false,
 	height: "100vh",
 	section1Fields: initialSection1Fields,
 	showFirstName: true,


### PR DESCRIPTION
# [MOS-1576](https://simpleviewtools.atlassian.net/browse/MOS-1576)

## Description
- (Form) Introduce a `hideSectionNav` form prop that gives product a way to always hide the section navigation, regardless of how many sections are defined.

## Checklist
- [ ] I have written new tests to cover the changes
- [x] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1576]: https://simpleviewtools.atlassian.net/browse/MOS-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ