### PR TITLE
MOS-1581

### DIFF
--- a/containers/mosaic/src/__tests__/utils/array/arrayChunks.test.ts
+++ b/containers/mosaic/src/__tests__/utils/array/arrayChunks.test.ts
@@ -1,0 +1,67 @@
+import { arrayChunks } from "@root/utils/array";
+import type { TestDef } from "@simpleview/mochalib";
+
+import { testArray } from "@simpleview/mochalib";
+
+describe(__filename, () => {
+	type Test = {
+		input: string[];
+		chunks: number;
+		spread?: boolean;
+	} & ({
+		result: string[][];
+	} | {
+		error: string;
+	})
+
+	const tests: TestDef<Test>[] = [
+		{
+			name: "should evenly split array of items into specified chunks of divisible items",
+			args: {
+				input: ["Cat", "Dog", "Beaver", "Duck", "Cow", "Rabbit", "Giraffe", "Rhino", "Pig", "Zebra", "Lion", "Spider"],
+				chunks: 3,
+				result: [["Cat", "Dog", "Beaver", "Duck"], ["Cow", "Rabbit", "Giraffe", "Rhino"], ["Pig", "Zebra", "Lion", "Spider"]],
+			},
+		},
+		{
+			name: "should evenly split array of items into specified chunks of non divisible items",
+			args: {
+				input: ["Cat", "Dog", "Beaver", "Duck", "Cow", "Rabbit", "Giraffe", "Rhino", "Pig", "Zebra"],
+				chunks: 3,
+				result: [["Cat", "Dog", "Beaver", "Duck"], ["Cow", "Rabbit", "Giraffe", "Rhino"], ["Pig", "Zebra"]],
+			},
+		},
+		{
+			name: "should leave items in a single chunk if chunk is 1",
+			args: {
+				input: ["Cat", "Dog", "Beaver", "Duck", "Cow", "Rabbit", "Giraffe", "Rhino", "Pig", "Zebra"],
+				chunks: 1,
+				result: [["Cat", "Dog", "Beaver", "Duck", "Cow", "Rabbit", "Giraffe", "Rhino", "Pig", "Zebra"]],
+			},
+		},
+		{
+			name: "should not produce empty chunks",
+			args: {
+				input: ["Cat", "Dog", "Beaver", "Duck"],
+				chunks: 5,
+				result: [["Cat"], ["Dog"], ["Beaver"], ["Duck"]],
+			},
+		},
+		{
+			name: "should throw an error if chunks number provided is less than 1",
+			args: {
+				input: ["Cat", "Dog", "Beaver", "Duck", "Cow", "Rabbit"],
+				chunks: 0,
+				error: "Chunk size should be more than 0, provided 0",
+			},
+		},
+	];
+
+	testArray(tests, ({ input, chunks, result, error }) => {
+		if (error) {
+			expect(() => arrayChunks(input, chunks)).toThrowError(error);
+		} else {
+			expect(arrayChunks(input, chunks)).toStrictEqual(result);
+		}
+	});
+});

--- a/containers/mosaic/src/components/CheckboxList/CheckboxList.styled.tsx
+++ b/containers/mosaic/src/components/CheckboxList/CheckboxList.styled.tsx
@@ -1,0 +1,16 @@
+import FormGroup from "@mui/material/FormGroup";
+import { CONTAINERS } from "@root/theme/theme";
+import { containerQuery } from "@root/utils/css";
+import styled from "styled-components";
+
+export const StyledFormGroup = styled(FormGroup)`
+	container-type: inline-size;
+	container-name: ${CONTAINERS.CHECKBOX_LIST};
+`;
+
+export const StyledGrid = styled.div`
+	${containerQuery("md", "CHECKBOX_LIST")} {
+		display: grid;
+		grid-template-columns: repeat(3,minmax(0,1fr));
+	}
+`;

--- a/containers/mosaic/src/components/CheckboxList/CheckboxList.tsx
+++ b/containers/mosaic/src/components/CheckboxList/CheckboxList.tsx
@@ -1,13 +1,14 @@
 import type { ReactElement, HTMLAttributes, ChangeEventHandler } from "react";
 
-import React from "react";
+import React, { useMemo } from "react";
 import { useId, useCallback } from "react";
 import toggle from "@root/utils/array/toggle";
 
 import type { CheckboxListProps } from "./CheckboxListTypes";
 
 import Checkbox from "@root/components/Checkbox";
-import FormGroup from "@mui/material/FormGroup";
+import { arrayChunks } from "@root/utils/array";
+import { StyledFormGroup, StyledGrid } from "./CheckboxList.styled";
 
 const CheckboxList = (props: CheckboxListProps & Omit<HTMLAttributes<HTMLInputElement>, "onChange">): ReactElement => {
 	const fallbackId = useId();
@@ -20,6 +21,7 @@ const CheckboxList = (props: CheckboxListProps & Omit<HTMLAttributes<HTMLInputEl
 		onChange,
 		options,
 		style,
+		itemsPerColumn = 8,
 	} = props;
 
 	const handleToggle = useCallback<ChangeEventHandler<HTMLInputElement>>(({ target }) => {
@@ -34,20 +36,43 @@ const CheckboxList = (props: CheckboxListProps & Omit<HTMLAttributes<HTMLInputEl
 		onChange(newChecked);
 	}, [checked, onChange, options]);
 
+	const columns = useMemo<CheckboxListProps["options"][]>(() => {
+		if (options.length > itemsPerColumn * 2) {
+			return arrayChunks(options, 3);
+		}
+
+		if (options.length > itemsPerColumn) {
+			return arrayChunks(options, 2);
+		}
+
+		return [options];
+	}, [itemsPerColumn, options]);
+
 	return (
-		<FormGroup className={`${className ?? ""} listItem`} onBlur={onBlur} style={style}>
-			{(options || []).map(({ value, label }, i) => (
-				<Checkbox
-					checked={(checked || []).some((option) => option.value === value)}
-					label={label}
-					disabled={disabled}
-					key={`${value}-${i}`}
-					id={`${id}-${i}`}
-					onChange={handleToggle}
-					value={value}
-				/>
-			))}
-		</FormGroup>
+		<StyledFormGroup
+			className={`${className ?? ""} listItem`}
+			onBlur={onBlur}
+			style={style}
+		>
+			<StyledGrid>
+				{columns.map((options, index) => (
+					<div key={index}>
+						{(options || []).map(({ value, label }, i) => (
+							<div key={value}>
+								<Checkbox
+									checked={(checked || []).some((option) => option.value === value)}
+									label={label}
+									disabled={disabled}
+									id={`${id}-${i}`}
+									onChange={handleToggle}
+									value={value}
+								/>
+							</div>
+						))}
+					</div>
+				))}
+			</StyledGrid>
+		</StyledFormGroup>
 	);
 };
 export default CheckboxList;

--- a/containers/mosaic/src/components/CheckboxList/CheckboxListTypes.ts
+++ b/containers/mosaic/src/components/CheckboxList/CheckboxListTypes.ts
@@ -23,4 +23,10 @@ export interface CheckboxListProps {
 	 * current checkbox can be selected or not
 	 */
 	disabled?: boolean;
+	/**
+	 * Checkboxes are split into up to 3 columns with the maximum
+	 * number of items in each column being itemsPerColumn. Pass -1
+	 * to prevent columns. Defaults to 8.
+	 */
+	itemsPerColumn?: number;
 }

--- a/containers/mosaic/src/components/Field/FormFieldCheckbox/FormFieldCheckbox.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldCheckbox/FormFieldCheckbox.tsx
@@ -28,6 +28,7 @@ const FormFieldCheckbox = (
 		inputSettings: {
 			getOptions: optionsAsync,
 			options: providedOptions = optionsAsync,
+			itemsPerColumn,
 		} = {},
 	} = fieldDef;
 
@@ -55,6 +56,7 @@ const FormFieldCheckbox = (
 			style={fieldDef.style}
 			className={fieldDef.className}
 			id={id}
+			itemsPerColumn={itemsPerColumn}
 		/>
 	);
 };

--- a/containers/mosaic/src/components/Field/FormFieldCheckbox/FormFieldCheckboxTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldCheckbox/FormFieldCheckboxTypes.tsx
@@ -1,7 +1,8 @@
+import type { CheckboxListProps } from "@root/components/CheckboxList";
 import type { FieldDefBase } from "@root/components/Field";
 import type { MosaicLabelValue } from "@root/types";
 
-interface FormFieldCheckboxLocalOptions {
+interface FormFieldCheckboxLocalOptions extends Pick<CheckboxListProps, "itemsPerColumn"> {
 	/**
 	* List of options
 	*/

--- a/containers/mosaic/src/components/Field/fieldUtils.ts
+++ b/containers/mosaic/src/components/Field/fieldUtils.ts
@@ -3,7 +3,7 @@ import type { FieldDef, FieldDefCustom } from "./FieldTypes";
 
 export const defaultFieldSizeMap: Record<Exclude<FieldDef["type"], FieldDefCustom["type"]>, Sizes> = {
 	text: Sizes.md,
-	checkbox: Sizes.md,
+	checkbox: Sizes.full,
 	chip: Sizes.md,
 	dropdown: Sizes.md,
 	phone: Sizes.sm,

--- a/containers/mosaic/src/mock/options.ts
+++ b/containers/mosaic/src/mock/options.ts
@@ -55,8 +55,72 @@ export const mockOptions: MosaicLabelValue[] = [
 		value: "giraffe",
 	},
 	{
-		label: "Panda",
-		value: "panda",
+		label: "Shark",
+		value: "shark",
+	},
+	{
+		label: "Otter",
+		value: "otter",
+	},
+	{
+		label: "Hippopotamus",
+		value: "hippopotamus",
+	},
+	{
+		label: "Sheep",
+		value: "sheep",
+	},
+	{
+		label: "Squirrel",
+		value: "squirrel",
+	},
+	{
+		label: "Donkey",
+		value: "donkey",
+	},
+	{
+		label: "Meerkat",
+		value: "meerkat",
+	},
+	{
+		label: "Hedgehog",
+		value: "hedgehog",
+	},
+	{
+		label: "Hyena",
+		value: "hyena",
+	},
+	{
+		label: "Lynx",
+		value: "lynx",
+	},
+	{
+		label: "Camel",
+		value: "camel",
+	},
+	{
+		label: "Bat",
+		value: "bat",
+	},
+	{
+		label: "Seal",
+		value: "seal",
+	},
+	{
+		label: "Dolphin",
+		value: "dolphin",
+	},
+	{
+		label: "Walrus",
+		value: "walrus",
+	},
+	{
+		label: "Duck",
+		value: "duck",
+	},
+	{
+		label: "Snail",
+		value: "snail",
 	},
 ];
 

--- a/containers/mosaic/src/theme/theme.ts
+++ b/containers/mosaic/src/theme/theme.ts
@@ -18,6 +18,7 @@ export const CONTAINERS = {
 	CONTENT: "content",
 	FORM: "form",
 	FORM_COL: "form_column",
+	CHECKBOX_LIST: "checkbox_list",
 };
 
 export enum Views {

--- a/containers/mosaic/src/utils/array/arrayChunks.ts
+++ b/containers/mosaic/src/utils/array/arrayChunks.ts
@@ -1,0 +1,22 @@
+function arrayChunks<T>(input: T[], chunks: number): T[][] {
+	if (chunks < 1) {
+		throw new Error(`Chunk size should be more than 0, provided ${chunks}`);
+	}
+
+	const result: T[][] = [];
+	const itemsPerChunk = Math.ceil(input.length / chunks);
+
+	for (let i = 0; i < chunks; i++) {
+		const chunkItems = input.slice(i * itemsPerChunk, (i + 1) * itemsPerChunk);
+
+		if (!chunkItems.length) {
+			return result;
+		}
+
+		result.push(chunkItems);
+	}
+
+	return result;
+}
+
+export default arrayChunks;

--- a/containers/mosaic/src/utils/array/index.ts
+++ b/containers/mosaic/src/utils/array/index.ts
@@ -1,3 +1,4 @@
 export { default as arrayIntersect } from "./arrayIntersect";
 export { default as arrayDifference } from "./arrayDifference";
 export { default as toggle } from "./toggle";
+export { default as arrayChunks } from "./arrayChunks";

--- a/containers/sb-8/stories/components/Field/FormFieldCheckbox/FormFieldCheckbox.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldCheckbox/FormFieldCheckbox.stories.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement } from "react";
 
 import React, { useMemo } from "react";
-import type { FieldDef } from "@root/components/Field";
+import type { FormFieldCheckboxInputSettings } from "@root/components/Field";
+import { type FieldDef } from "@root/components/Field";
 
 import Form, { useForm } from "@root/components/Form";
 import { commonFieldControls, renderButtons } from "../../../../utils";
@@ -21,9 +22,22 @@ export const Playground = ({
 	prepop,
 	prepopData,
 	optionsType,
+	optionCount,
+	itemsPerColumn,
 }: typeof Playground.args): ReactElement => {
 	const controller = useForm();
 	const { state, handleSubmit } = controller;
+
+	const options = useMemo<FormFieldCheckboxInputSettings["options"]>(() => {
+		if (optionsType === "Synchronous") {
+			return mockOptions.slice(0, optionCount);
+		}
+
+		return async () => {
+			const result = await getOptions();
+			return result.slice(0, optionCount);
+		};
+	}, [optionCount, optionsType]);
 
 	const fields = useMemo(
 		(): FieldDef[] =>
@@ -35,13 +49,14 @@ export const Playground = ({
 					required,
 					disabled,
 					inputSettings: {
-						options: optionsType === "Synchronous" ? mockOptions : getOptions,
+						options,
+						itemsPerColumn: Number(itemsPerColumn),
 					},
 					helperText,
 					instructionText,
 				},
 			] as FieldDef[],
-		[required, disabled, label, instructionText, helperText, optionsType],
+		[label, required, disabled, options, helperText, instructionText, itemsPerColumn],
 	);
 
 	const getFormValues = useMemo(() => prepop
@@ -73,6 +88,8 @@ Playground.args = {
 		],
 	},
 	optionsType: "Synchronous",
+	optionCount: 25,
+	itemsPerColumn: 8,
 };
 
 Playground.argTypes = {
@@ -81,6 +98,12 @@ Playground.argTypes = {
 		name: "Options Type",
 		options: ["Synchronous", "Asynchronous"],
 		control: { type: "select" },
+	},
+	optionCount: {
+		name: "Number of Options",
+	},
+	itemsPerColumn: {
+		name: "Items per Column",
 	},
 };
 


### PR DESCRIPTION
# [MOS-1581](https://simpleviewtools.atlassian.net/browse/MOS-1581)

## Description
- (util) Adds a utility that can split an array up into a specified number of chunks.
- (CheckboxList) Adds support to split checkbox items into up to 3 columns based on a number of items per column. The number of items per column can be dictated by the `itemsPerColumn` property. This property defaults to 8. 0 or less can be provided to prevent columns altogether.
- (CheckboxField) Introduce the `itemsPerColumn` input setting to be passed down to the underlying CheckboxList.

## Checklist
- [x] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes