### PR TITLE
MOS-1583

### DIFF
--- a/containers/mosaic/src/components/FieldWrapper/FieldWrapper.styled.ts
+++ b/containers/mosaic/src/components/FieldWrapper/FieldWrapper.styled.ts
@@ -26,8 +26,8 @@ export const StyledFieldWrapper = styled.div<{ $error?: boolean; $spacing?: Form
 
 	${({ $error, $spacing }) => $error && `
 		background-color: ${theme.newColors.darkRed["5"]};
-		margin: ${$spacing === "compact" ? "-4px -4px -6px" : "-4px -12px -8px"};
-		padding: ${$spacing === "compact" ? "4px 4px 6px" : "4px 12px 8px"};
+		margin: ${$spacing === "compact" ? "-4px -4px -6px" : "-4px -11px -6px"};
+		padding: ${$spacing === "compact" ? "4px 4px 6px" : "4px 11px 6px"};
 	`}
 `;
 


### PR DESCRIPTION
# [MOS-1583](https://simpleviewtools.atlassian.net/browse/MOS-1583)

## Description
- (Form) Employ a thin space between errored fields that are adjacent to make it easier to distinguish them from one another.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1583]: https://simpleviewtools.atlassian.net/browse/MOS-1583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ