### PR TITLE
MOS-1585

### DIFF
--- a/containers/mosaic/src/__tests__/components/ChipList/ChipList.test.tsx
+++ b/containers/mosaic/src/__tests__/components/ChipList/ChipList.test.tsx
@@ -37,6 +37,14 @@ describe(__dirname, () => {
 		})).not.toThrow();
 	});
 
+	it("should throw an error if a max initial chips number provided is less than 1", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => null);
+
+		await expect(() => setup({
+			maxInitialChips: 0,
+		})).rejects.toThrow("ChipList `maxInitialChips` prop must be more than 0.");
+	});
+
 	it("should fire on delete handler with reduced chips when delete icon is clicked", async () => {
 		const onDeleteMock = vi.fn();
 		const { user } = await setup({

--- a/containers/mosaic/src/components/ChipList/ChipList.tsx
+++ b/containers/mosaic/src/components/ChipList/ChipList.tsx
@@ -18,6 +18,10 @@ const ChipList = forwardRef<HTMLDivElement, ChipListProps>((props, ref): ReactEl
 		maxInitialChips = 8,
 	} = props;
 
+	if (maxInitialChips < 1) {
+		throw new Error("ChipList `maxInitialChips` prop must be more than 0.");
+	}
+
 	const [showMore, setShowMore] = useState(false);
 
 	const _onDelete = useMemo(() => {

--- a/containers/sb-8/stories/components/ChipList/ChipList.stories.tsx
+++ b/containers/sb-8/stories/components/ChipList/ChipList.stories.tsx
@@ -16,7 +16,7 @@ export const Playground = ({
 	hasOnDelete,
 }: typeof Playground.args): ReactElement => {
 	const options = useMemo<ChipListProps["options"]>(() => {
-		return mockOptions.slice(0, optionCount);
+		return optionCount >= 0 ? mockOptions.slice(0, optionCount) : mockOptions;
 	}, [optionCount]);
 
 	const onDelete = useMemo(() => {
@@ -45,6 +45,7 @@ Playground.args = {
 Playground.argTypes = {
 	optionCount: {
 		name: "Number of Options",
+		control: { min: 0 },
 	},
 	maxInitialChips: {
 		name: "Maximum Initial Chips",


### PR DESCRIPTION
# [MOS-1585](https://simpleviewtools.atlassian.net/browse/MOS-1585)

## Description
- (ChipList) Throw an error if a number less than 1 is provided for maxInitialChips. Ignore optionCount control if it's less than 0.

## Checklist
- [x] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1585]: https://simpleviewtools.atlassian.net/browse/MOS-1585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ