### PR TITLE
MOS-1461

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
@@ -121,8 +121,10 @@ export interface TextEditorUpdateLinkValues {
 }
 
 export type TextEditorUpdateLink = (params: TextEditorUpdateLinkValues) => void;
+export type TextEditorRemoveLink = () => void;
 export type TextEditorOnLinkParams = Partial<TextEditorUpdateLinkValues> & {
 	updateLink: TextEditorUpdateLink;
+	removeLink: TextEditorRemoveLink;
 	isTextBased?: boolean;
 };
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/predefinedControls.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/predefinedControls.tsx
@@ -320,6 +320,10 @@ export const controlLink: Control = {
 
 				chain.run();
 			},
+			removeLink: () => editor.chain().focus()
+				.extendMarkRange("link")
+				.unsetLink()
+				.run(),
 		});
 	},
 	Icon: LinkIcon,

--- a/containers/sb-8/stories/components/Field/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
@@ -80,15 +80,7 @@ export const Playground = ({
 								},
 							});
 						} : undefined,
-						onLink: customLinkHandler ? ({ updateLink, ...params }) => {
-							setLinkDrawer({
-								...params,
-								updateLink: (params) => {
-									updateLink(params);
-									onClose();
-								},
-							});
-						} : undefined,
+						onLink: customLinkHandler ? setLinkDrawer : undefined,
 						maxCharacters,
 						minHeight: !minHeight ? undefined : minHeight,
 						maxHeight: !maxHeight ? undefined : maxHeight,

--- a/containers/sb-8/stories/components/Field/FormFieldTextEditor/LinkLibraryDrawer.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldTextEditor/LinkLibraryDrawer.tsx
@@ -93,7 +93,7 @@ function LinkSelectionField(props: any) {
 	);
 }
 
-export function LinkLibraryDrawer({ onClose, updateLink, url, newTab, text }: LinkLibraryDrawerProps): ReactElement {
+export function LinkLibraryDrawer({ onClose, updateLink, removeLink, url, newTab, text }: LinkLibraryDrawerProps): ReactElement {
 	const controller = useForm();
 	const { handleSubmit } = controller;
 
@@ -118,6 +118,15 @@ export function LinkLibraryDrawer({ onClose, updateLink, url, newTab, text }: Li
 
 	const buttons: ButtonProps[] = useMemo(() => [
 		{
+			label: "Remove",
+			onClick: () => {
+				removeLink();
+				onClose();
+			},
+			color: "red",
+			variant: "outlined",
+		},
+		{
 			label: "Cancel",
 			onClick: onClose,
 			color: "gray",
@@ -129,13 +138,14 @@ export function LinkLibraryDrawer({ onClose, updateLink, url, newTab, text }: Li
 			color: "yellow",
 			variant: "contained",
 		},
-	], [onClose]);
+	], [removeLink, onClose]);
 
 	const onSubmit = handleSubmit(({ data }) => {
 		if (!updateLink) {
 			throw new Error("Update image callback was not provided");
 		}
 
+		onClose();
 		updateLink({
 			url: data.url,
 			newTab: data.newTab,


### PR DESCRIPTION
# [MOS-1461](https://simpleviewtools.atlassian.net/browse/MOS-1461)

## Description
- (TextEditor) Provides a way for any custom link implementation to easily remove the current link.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1461]: https://simpleviewtools.atlassian.net/browse/MOS-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ