### PR TITLE
MOS-1574

### DIFF
--- a/containers/mosaic/src/__tests__/components/Field/FormFieldTextEditor/FormFieldTextEditor.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldTextEditor/FormFieldTextEditor.test.tsx
@@ -58,12 +58,18 @@ describe(__dirname, () => {
 		controlTestId: string;
 		menuTestId?: string;
 	} & ({
+		/**
+		 * This formatting option mutates an inline-level element like `<strong></strong>`
+		 */
 		inline: true;
 		result: {
 			formatAndType: string;
 			selectAndFormat: string;
 		};
 	} | {
+		/**
+		 * This formatting option mutates a block-level element like `<h1></h1>`
+		 */
 		inline: false;
 		result: string;
 	})
@@ -152,7 +158,7 @@ describe(__dirname, () => {
 		{
 			name: "should render the correct elements when heading 1 is chosen",
 			args: {
-				controlTestId: `${testIds.TEXT_EDITOR_HEADING_CONTROL}-1`,
+				controlTestId: `${testIds.TEXT_EDITOR_CONTROL}:heading-1`,
 				menuTestId: testIds.TEXT_EDITOR_HEADING_MENU,
 				inline: false,
 				result: "<h1>Test</h1>",
@@ -161,7 +167,7 @@ describe(__dirname, () => {
 		{
 			name: "should render the correct elements when heading 2 is chosen",
 			args: {
-				controlTestId: `${testIds.TEXT_EDITOR_HEADING_CONTROL}-2`,
+				controlTestId: `${testIds.TEXT_EDITOR_CONTROL}:heading-2`,
 				menuTestId: testIds.TEXT_EDITOR_HEADING_MENU,
 				inline: false,
 				result: "<h2>Test</h2>",
@@ -170,7 +176,7 @@ describe(__dirname, () => {
 		{
 			name: "should render the correct elements when heading 3 is chosen",
 			args: {
-				controlTestId: `${testIds.TEXT_EDITOR_HEADING_CONTROL}-3`,
+				controlTestId: `${testIds.TEXT_EDITOR_CONTROL}:heading-3`,
 				menuTestId: testIds.TEXT_EDITOR_HEADING_MENU,
 				inline: false,
 				result: "<h3>Test</h3>",
@@ -179,7 +185,7 @@ describe(__dirname, () => {
 		{
 			name: "should render the correct elements when heading 4 is chosen",
 			args: {
-				controlTestId: `${testIds.TEXT_EDITOR_HEADING_CONTROL}-4`,
+				controlTestId: `${testIds.TEXT_EDITOR_CONTROL}:heading-4`,
 				menuTestId: testIds.TEXT_EDITOR_HEADING_MENU,
 				inline: false,
 				result: "<h4>Test</h4>",
@@ -188,7 +194,7 @@ describe(__dirname, () => {
 		{
 			name: "should render the correct elements when heading 5 is chosen",
 			args: {
-				controlTestId: `${testIds.TEXT_EDITOR_HEADING_CONTROL}-5`,
+				controlTestId: `${testIds.TEXT_EDITOR_CONTROL}:heading-5`,
 				menuTestId: testIds.TEXT_EDITOR_HEADING_MENU,
 				inline: false,
 				result: "<h5>Test</h5>",
@@ -197,7 +203,7 @@ describe(__dirname, () => {
 		{
 			name: "should render the correct elements when heading 6 is chosen",
 			args: {
-				controlTestId: `${testIds.TEXT_EDITOR_HEADING_CONTROL}-6`,
+				controlTestId: `${testIds.TEXT_EDITOR_CONTROL}:heading-6`,
 				menuTestId: testIds.TEXT_EDITOR_HEADING_MENU,
 				inline: false,
 				result: "<h6>Test</h6>",

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.styled.ts
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditor.styled.ts
@@ -5,6 +5,7 @@ import styled, { css } from "styled-components";
 
 import theme from "@root/theme";
 import MenuBase from "@root/components/MenuBase";
+import MenuItem from "@root/components/MenuItem";
 
 const h1Size = css`font-size: font-size: 28px;`;
 const h2Size = css`font-size: font-size: 36px;`;
@@ -12,21 +13,6 @@ const h3Size = css`font-size: font-size: 22px;`;
 const h4Size = css`font-size: font-size: 14px;`;
 const h5Size = css`font-size: font-size: 12px;`;
 const h6Size = css`font-size: font-size: 12px;`;
-
-export const controlColors = css<{ $active?: boolean }>`
-    &:disabled {
-        color: ${theme.colors.gray400};
-    }
-
-    &:not(:disabled):hover {
-        color: ${theme.colors.gray800};
-    }
-
-    ${({ $active }) => `
-        color: ${$active ? theme.colors.gray700 : theme.colors.gray600};
-        background-color: ${$active ? theme.newColors.simplyGold["40"] : "transparent"};
-    `}
-`;
 
 const selectedNode = css`
     outline: 1px solid ${theme.newColors.almostBlack["100"]};
@@ -311,7 +297,19 @@ export const StyledControlButton = styled.button.attrs<{ $active?: boolean; $squ
         width: 32px;
     `}
 
-    ${controlColors}
+    &:disabled {
+        color: ${theme.colors.gray400};
+    }
+
+
+    ${({ $active }) => `
+        color: ${$active ? theme.colors.gray700 : theme.colors.gray600};
+
+        ${$active && `
+            background-color: ${theme.newColors.simplyGold["40"]};
+        `}
+
+    `}
 `;
 
 export const StyledTextStyleMenuButton = styled(StyledControlButton)`
@@ -381,24 +379,31 @@ export const StyledControlMenu = styled(MenuBase)`
     }
 `;
 
-export const StyledMenuItem = styled.button<{ $active?: boolean }>`
-    background: none;
-    border: 0;
-    border-radius: 0;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: start;
-    gap: 12px;
-    width: 100%;
-    padding: 8px 12px;
+export const StyledMenuItem = styled(MenuItem)<{ $active?: boolean }>`
+    && {
+        display: flex;
+        align-items: center;
+        justify-content: start;
+        gap: 12px;
+        width: 100%;
+        padding: 8px 12px;
 
-    ${controlColors}
+        h1, h2, h3, h4, h5, h6 {
+            margin: 0;
+        }
 
+        &:disabled {
+            color: ${theme.colors.gray400};
+        }
 
+        ${({ $active }) => $active && `
+            background-color: ${theme.newColors.simplyGold["40"]};
 
-    h1, h2, h3, h4, h5, h6 {
-        margin: 0;
+            &:focus-visible,
+            &:hover {
+                background-color: ${theme.newColors.simplyGold["60"]};
+            }
+        `}
     }
 `;
 

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
@@ -75,7 +75,7 @@ export type ControlWithProps = ControlBase & {
 
 export type ControlComponentProps = {
 	editor: Editor;
-	onClose?: () => void;
+	onSelected?: () => void;
 	inputSettings: TextEditorInputSettings;
 	disabled?: boolean;
 } & Omit<ControlWithComponent, "component">;

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlHeadings.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlHeadings.tsx
@@ -13,13 +13,13 @@ import type { MenuItemProps } from "@mui/material/MenuItem";
 
 type ControlHeadingProps = Omit<ControlWithComponent, "component"> & MenuItemProps & {
 	editor: Editor;
-	onClose?: () => void;
+	onSelected?: () => void;
 };
 
 export function ControlHeading({
 	editor,
 	level,
-	onClose,
+	onSelected,
 	shortcut,
 	value: _value,
 	show: _show,
@@ -27,7 +27,7 @@ export function ControlHeading({
 }: ControlHeadingProps & { level: Level }): ReactElement {
 	const onClick = () => {
 		editor.chain().focus().toggleHeading({ level }).run();
-		onClose && onClose();
+		onSelected && onSelected();
 	};
 
 	return (
@@ -51,7 +51,7 @@ export function ControlHeading({
 
 export function ControlNormalText({
 	editor,
-	onClose,
+	onSelected,
 	shortcut,
 	value: _value,
 	show: _show,
@@ -59,7 +59,7 @@ export function ControlNormalText({
 }: ControlHeadingProps): ReactElement {
 	const onClick = () => {
 		editor.chain().focus().setParagraph().run();
-		onClose && onClose();
+		onSelected && onSelected();
 	};
 
 	return (

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlHeadings.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlHeadings.tsx
@@ -9,13 +9,22 @@ import type { ControlWithComponent } from "../../FormFieldTextEditorTypes";
 import testIds from "@root/utils/testIds";
 import { MenuItemLabel, MenuItemShortcut, StyledMenuItem } from "../../FormFieldTextEditor.styled";
 import { Shortcut } from "../Shortcut";
+import type { MenuItemProps } from "@mui/material/MenuItem";
 
-type ControlHeadingProps = Omit<ControlWithComponent, "component"> & {
+type ControlHeadingProps = Omit<ControlWithComponent, "component"> & MenuItemProps & {
 	editor: Editor;
 	onClose?: () => void;
 };
 
-export function ControlHeading({ editor, level, onClose, shortcut }: ControlHeadingProps & { level: Level }): ReactElement {
+export function ControlHeading({
+	editor,
+	level,
+	onClose,
+	shortcut,
+	value: _value,
+	show: _show,
+	...props
+}: ControlHeadingProps & { level: Level }): ReactElement {
 	const onClick = () => {
 		editor.chain().focus().toggleHeading({ level }).run();
 		onClose && onClose();
@@ -26,6 +35,7 @@ export function ControlHeading({ editor, level, onClose, shortcut }: ControlHead
 			onClick={onClick}
 			$active={editor.isActive("heading", { level })}
 			data-testid={`${testIds.TEXT_EDITOR_HEADING_CONTROL}-${level}`}
+			{...props}
 		>
 			<MenuItemLabel>
 				{React.createElement(`h${level}`, null, `Heading ${level}`)}
@@ -39,7 +49,14 @@ export function ControlHeading({ editor, level, onClose, shortcut }: ControlHead
 	);
 }
 
-export function ControlNormalText({ editor, onClose, shortcut }: ControlHeadingProps): ReactElement {
+export function ControlNormalText({
+	editor,
+	onClose,
+	shortcut,
+	value: _value,
+	show: _show,
+	...props
+}: ControlHeadingProps): ReactElement {
 	const onClick = () => {
 		editor.chain().focus().setParagraph().run();
 		onClose && onClose();
@@ -49,6 +66,7 @@ export function ControlNormalText({ editor, onClose, shortcut }: ControlHeadingP
 		<StyledMenuItem
 			onClick={onClick}
 			$active={editor.isActive("paragraph")}
+			{...props}
 		>
 			<MenuItemLabel>Normal Text</MenuItemLabel>
 			{shortcut && (

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlHeadings.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlHeadings.tsx
@@ -6,7 +6,6 @@ import React from "react";
 
 import type { ControlWithComponent, TextEditorInputSettings } from "../../FormFieldTextEditorTypes";
 
-import testIds from "@root/utils/testIds";
 import { MenuItemLabel, MenuItemShortcut, StyledMenuItem } from "../../FormFieldTextEditor.styled";
 import { Shortcut } from "../Shortcut";
 import type { MenuItemProps } from "@mui/material/MenuItem";
@@ -37,7 +36,6 @@ export function ControlHeading({
 		<StyledMenuItem
 			onClick={onClick}
 			$active={editor.isActive("heading", { level })}
-			data-testid={`${testIds.TEXT_EDITOR_HEADING_CONTROL}-${level}`}
 			{...props}
 		>
 			<MenuItemLabel>

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlHeadings.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlHeadings.tsx
@@ -4,7 +4,7 @@ import type { Level } from "@tiptap/extension-heading";
 
 import React from "react";
 
-import type { ControlWithComponent } from "../../FormFieldTextEditorTypes";
+import type { ControlWithComponent, TextEditorInputSettings } from "../../FormFieldTextEditorTypes";
 
 import testIds from "@root/utils/testIds";
 import { MenuItemLabel, MenuItemShortcut, StyledMenuItem } from "../../FormFieldTextEditor.styled";
@@ -14,6 +14,7 @@ import type { MenuItemProps } from "@mui/material/MenuItem";
 type ControlHeadingProps = Omit<ControlWithComponent, "component"> & MenuItemProps & {
 	editor: Editor;
 	onSelected?: () => void;
+	inputSettings: TextEditorInputSettings;
 };
 
 export function ControlHeading({
@@ -23,6 +24,8 @@ export function ControlHeading({
 	shortcut,
 	value: _value,
 	show: _show,
+	Component: _Component,
+	inputSettings: _inputSettings,
 	...props
 }: ControlHeadingProps & { level: Level }): ReactElement {
 	const onClick = () => {
@@ -55,6 +58,8 @@ export function ControlNormalText({
 	shortcut,
 	value: _value,
 	show: _show,
+	Component: _Component,
+	inputSettings: _inputSettings,
 	...props
 }: ControlHeadingProps): ReactElement {
 	const onClick = () => {

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenu.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenu.tsx
@@ -36,6 +36,10 @@ export function ControlMenuDropdown({
 
 	const onClose = () => {
 		setAnchorEl(null);
+	};
+
+	const onSelected = () => {
+		onClose();
 		editor.chain().focus();
 	};
 
@@ -68,7 +72,7 @@ export function ControlMenuDropdown({
 				{controls.map((control, index) => "Component" in control ? (
 					<control.Component
 						{...control}
-						onClose={onClose}
+						onSelected={onSelected}
 						editor={editor}
 						key={index}
 						inputSettings={inputSettings}
@@ -78,7 +82,7 @@ export function ControlMenuDropdown({
 				) : (
 					<ControlMenuItem
 						{...control}
-						onClose={onClose}
+						onSelected={onSelected}
 						editor={editor}
 						inputSettings={inputSettings}
 						key={index}

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenuItem.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenuItem.tsx
@@ -52,24 +52,4 @@ export function ControlMenuItem({
 			)}
 		</StyledMenuItem>
 	);
-
-	// return (
-	// 	<li>
-	// 		<StyledMenuItem
-	// 			onClick={onClick}
-	// 			$active={editor.isActive(name)}
-	// 			data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${name}`}
-	// 		>
-	// 			<MenuItemLabel>
-	// 				{Icon && <Icon />}
-	// 				{label}
-	// 			</MenuItemLabel>
-	// 			{shortcut && (
-	// 				<MenuItemShortcut>
-	// 					<Shortcut shortcut={shortcut} />
-	// 				</MenuItemShortcut>
-	// 			)}
-	// 		</StyledMenuItem>
-	// 	</li>
-	// );
 }

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenuItem.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenuItem.tsx
@@ -8,8 +8,9 @@ import type { ControlWithProps, TextEditorInputSettings } from "../../FormFieldT
 import { MenuItemLabel, MenuItemShortcut, StyledMenuItem } from "../../FormFieldTextEditor.styled";
 import testIds from "@root/utils/testIds";
 import { Shortcut } from "../Shortcut";
+import type { MenuItemProps } from "@mui/material/MenuItem";
 
-type ControlMenuItemProps = ControlWithProps & {
+type ControlMenuItemProps = ControlWithProps & MenuItemProps & {
 	editor: Editor;
 	inputSettings: TextEditorInputSettings;
 	onClose: () => void;
@@ -24,6 +25,9 @@ export function ControlMenuItem({
 	editor,
 	onClose,
 	inputSettings,
+	value: _value,
+	show: _show,
+	...props
 }: ControlMenuItemProps): ReactElement {
 	const onClick = (event: MouseEvent<HTMLButtonElement>) => {
 		cmd({ editor, inputSettings, event });
@@ -31,22 +35,41 @@ export function ControlMenuItem({
 	};
 
 	return (
-		<li>
-			<StyledMenuItem
-				onClick={onClick}
-				$active={editor.isActive(name)}
-				data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${name}`}
-			>
-				<MenuItemLabel>
-					{Icon && <Icon />}
-					{label}
-				</MenuItemLabel>
-				{shortcut && (
-					<MenuItemShortcut>
-						<Shortcut shortcut={shortcut} />
-					</MenuItemShortcut>
-				)}
-			</StyledMenuItem>
-		</li>
+		<StyledMenuItem
+			{...props}
+			onClick={onClick}
+			$active={editor.isActive(name)}
+			data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${name}`}
+		>
+			<MenuItemLabel>
+				{Icon && <Icon />}
+				{label}
+			</MenuItemLabel>
+			{shortcut && (
+				<MenuItemShortcut>
+					<Shortcut shortcut={shortcut} />
+				</MenuItemShortcut>
+			)}
+		</StyledMenuItem>
 	);
+
+	// return (
+	// 	<li>
+	// 		<StyledMenuItem
+	// 			onClick={onClick}
+	// 			$active={editor.isActive(name)}
+	// 			data-testid={`${testIds.TEXT_EDITOR_CONTROL}:${name}`}
+	// 		>
+	// 			<MenuItemLabel>
+	// 				{Icon && <Icon />}
+	// 				{label}
+	// 			</MenuItemLabel>
+	// 			{shortcut && (
+	// 				<MenuItemShortcut>
+	// 					<Shortcut shortcut={shortcut} />
+	// 				</MenuItemShortcut>
+	// 			)}
+	// 		</StyledMenuItem>
+	// 	</li>
+	// );
 }

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenuItem.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/Toolbar/Controls/ControlMenuItem.tsx
@@ -13,7 +13,7 @@ import type { MenuItemProps } from "@mui/material/MenuItem";
 type ControlMenuItemProps = ControlWithProps & MenuItemProps & {
 	editor: Editor;
 	inputSettings: TextEditorInputSettings;
-	onClose: () => void;
+	onSelected: () => void;
 };
 
 export function ControlMenuItem({
@@ -23,7 +23,7 @@ export function ControlMenuItem({
 	shortcut,
 	cmd,
 	editor,
-	onClose,
+	onSelected,
 	inputSettings,
 	value: _value,
 	show: _show,
@@ -31,7 +31,7 @@ export function ControlMenuItem({
 }: ControlMenuItemProps): ReactElement {
 	const onClick = (event: MouseEvent<HTMLButtonElement>) => {
 		cmd({ editor, inputSettings, event });
-		onClose();
+		onSelected();
 	};
 
 	return (

--- a/containers/mosaic/src/components/MenuItem/MenuItem.tsx
+++ b/containers/mosaic/src/components/MenuItem/MenuItem.tsx
@@ -10,14 +10,18 @@ export default function MenuItem({
 	color = "black",
 	attrs: providedAttrs,
 	title,
-	label,
 	onClick,
 	disabled,
 	selected = false,
 	truncateText,
 	autoFocus,
 	tabIndex,
+	className,
+	...props
 }: MenuItemProps): ReactElement {
+	const children = "children" in props ? props.children : null;
+	const label = "label" in props ? props.label : "";
+
 	if (!colors.includes(color)) {
 		throw new Error(
 			"The menu item component only accepts the following colors: " +
@@ -39,24 +43,28 @@ export default function MenuItem({
 			onClick={onClick}
 			disabled={disabled}
 			selected={selected}
-			className="menu-item"
+			className={["menu-item", className].filter(Boolean).join(" ")}
 			disableRipple={true}
 			$truncateText={truncateText}
 			autoFocus={autoFocus}
 			tabIndex={tabIndex}
 			aria-selected={selected}
 		>
-			{Icon && (
-				<StyledIcon
-					className="icon"
-					$color={color}
-				>
-					<Icon />
-				</StyledIcon>
+			{children ?? (
+				<>
+					{Icon && (
+						<StyledIcon
+							className="icon"
+							$color={color}
+						>
+							<Icon />
+						</StyledIcon>
+					)}
+					<div className="menuLabel">
+						<span>{label}</span>
+					</div>
+				</>
 			)}
-			<div className="menuLabel">
-				<span>{label}</span>
-			</div>
 		</StyledMenuItem>
 	);
 }

--- a/containers/mosaic/src/components/MenuItem/MenuItem.tsx
+++ b/containers/mosaic/src/components/MenuItem/MenuItem.tsx
@@ -49,6 +49,7 @@ export default function MenuItem({
 			autoFocus={autoFocus}
 			tabIndex={tabIndex}
 			aria-selected={selected}
+			{...props}
 		>
 			{children ?? (
 				<>

--- a/containers/mosaic/src/components/MenuItem/MenuItemTypes.ts
+++ b/containers/mosaic/src/components/MenuItem/MenuItemTypes.ts
@@ -1,8 +1,7 @@
 import type { MosaicObject, MosaicToggle, SvgIconComponent } from "@root/types";
 import type { colors } from "./MenuItem.styled";
-
-export interface MenuItemProps {
-	label: string | JSX.Element;
+import type { PropsWithChildren } from "react";
+export interface MenuItemBaseProps {
 	value?: string;
 	color?: (typeof colors)[number];
 	mIcon?: SvgIconComponent;
@@ -22,4 +21,9 @@ export interface MenuItemProps {
 	title?: boolean | string;
 	tabIndex?: number;
 	autoFocus?: boolean;
+	className?: string;
 }
+
+export type MenuItemProps = PropsWithChildren<MenuItemBaseProps> | (MenuItemBaseProps & {
+	label: string | JSX.Element;
+})

--- a/containers/mosaic/src/utils/testIds.ts
+++ b/containers/mosaic/src/utils/testIds.ts
@@ -63,7 +63,6 @@ const testIds = {
 	TEXT_EDITOR_CODE: "mos:TextEditor:code",
 	TEXT_EDITOR_CONTROL: "mos:TextEditor:control",
 	TEXT_EDITOR_FLOATING_TOOLBAR: "mos:TextEditor:floatingToolbar",
-	TEXT_EDITOR_HEADING_CONTROL: "mos:TextEditor:headingControl",
 	TEXT_EDITOR_HEADING_MENU: "mos:TextEditor:headingMenu",
 	TEXT_EDITOR_NODE_FORM: "mos:TextEditor:nodeForm",
 	TEXT_EDITOR_PRIMARY_TOOLBAR: "mos:TextEditor:primaryToolbar",


### PR DESCRIPTION
# [MOS-1574](https://simpleviewtools.atlassian.net/browse/MOS-1574)

## Description
- (TextEditor) Accessibility improvements to ensure control menus can be navigated using the keyboard.
- (TextEditor) Remove dead code.
- (TextEditor) Ensure the text editor canvas only receives focus if a control menu item is selected and not if the menu is merely closed.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1574]: https://simpleviewtools.atlassian.net/browse/MOS-1574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ