### PR TITLE
MOS-1588

### DIFF
--- a/containers/mosaic/src/__tests__/components/Field/FormFieldNumberTable/FormFieldNumberTable.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldNumberTable/FormFieldNumberTable.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import type { ReactElement } from "react";
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import {
 	act,
 	cleanup,
@@ -27,7 +27,9 @@ const NumberTableExample = ({
 	displaySumRow?: boolean;
 	useNumberFormatter?: boolean;
 }): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: {
+		numberTable: numberTableDefaultValue,
+	} });
 	const { handleSubmit } = controller;
 
 	const onSubmit = handleSubmit((data) => alert("Form submitted with the following data: " + JSON.stringify(data, null, " ")));
@@ -62,10 +64,6 @@ const NumberTableExample = ({
 		},
 	];
 
-	const getFormValues = useCallback(async () => ({
-		numberTable: numberTableDefaultValue,
-	}), []);
-
 	return (
 		<Form
 			{...controller}
@@ -73,7 +71,6 @@ const NumberTableExample = ({
 			title="Form Title"
 			description="This is a description example"
 			fields={fields}
-			getFormValues={getFormValues}
 		/>
 	);
 };

--- a/containers/mosaic/src/__tests__/components/Field/FormFieldNumberTable/FormFieldNumberTable.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldNumberTable/FormFieldNumberTable.test.tsx
@@ -11,12 +11,8 @@ import {
 import Form, { useForm } from "@root/components/Form";
 import type { FieldDef } from "@root/components/Field/FieldTypes";
 import type { ButtonProps } from "@root/components/Button";
-import {
-	columns,
-	isValidRowCol,
-	numberTableDefaultValue,
-	rows,
-} from "@root/components/Field/FormFieldNumberTable/numberTableUtils";
+import { isValidRowCol } from "@root/components/Field/FormFieldNumberTable/numberTableUtils";
+import { columns, mockNumberTableData, rows } from "@root/mock/numberTable";
 
 const NumberTableExample = ({
 	displaySumColumn = true,
@@ -28,7 +24,7 @@ const NumberTableExample = ({
 	useNumberFormatter?: boolean;
 }): ReactElement => {
 	const controller = useForm({ data: {
-		numberTable: numberTableDefaultValue,
+		numberTable: mockNumberTableData,
 	} });
 	const { handleSubmit } = controller;
 
@@ -52,7 +48,7 @@ const NumberTableExample = ({
 				},
 			},
 		],
-		[numberTableDefaultValue, rows, columns],
+		[mockNumberTableData, rows, columns],
 	);
 
 	const buttons: ButtonProps[] = [

--- a/containers/mosaic/src/__tests__/components/Form/useForm/getFieldPaths.test.ts
+++ b/containers/mosaic/src/__tests__/components/Form/useForm/getFieldPaths.test.ts
@@ -3,7 +3,7 @@ import { testArray } from "@simpleview/mochalib";
 import type { FieldObj, FieldPath } from "@root/components";
 
 import defaultHasValue from "@root/utils/form/defaultHasValue";
-import defaultResolver from "@root/utils/form/defaultResolver";
+import { externalToInternalValue, internalToExternalValue } from "@root/utils/form/defaultValueTransform";
 import getFieldPaths from "@root/components/Form/useForm/utils/getFieldPaths";
 
 const fieldObjects: FieldObj[] = [
@@ -11,7 +11,8 @@ const fieldObjects: FieldObj[] = [
 		name: "field1",
 		label: "Field 1",
 		type: "text",
-		getResolvedValue: defaultResolver,
+		externalToInternalValue,
+		internalToExternalValue,
 		hasValue: defaultHasValue,
 		order: 1,
 	},
@@ -19,7 +20,8 @@ const fieldObjects: FieldObj[] = [
 		name: "field2",
 		label: "Field 2",
 		type: "text",
-		getResolvedValue: defaultResolver,
+		externalToInternalValue,
+		internalToExternalValue,
 		hasValue: defaultHasValue,
 		order: 1,
 	},
@@ -27,7 +29,8 @@ const fieldObjects: FieldObj[] = [
 		name: "field3",
 		label: "Field 3",
 		type: "text",
-		getResolvedValue: defaultResolver,
+		externalToInternalValue,
+		internalToExternalValue,
 		hasValue: defaultHasValue,
 		order: 1,
 	},
@@ -35,7 +38,8 @@ const fieldObjects: FieldObj[] = [
 		name: "group1",
 		label: "Group 1",
 		type: "group",
-		getResolvedValue: defaultResolver,
+		externalToInternalValue,
+		internalToExternalValue,
 		hasValue: defaultHasValue,
 		order: 1,
 	},
@@ -43,7 +47,8 @@ const fieldObjects: FieldObj[] = [
 		name: "group2",
 		label: "Group 2",
 		type: "group",
-		getResolvedValue: defaultResolver,
+		externalToInternalValue,
+		internalToExternalValue,
 		hasValue: defaultHasValue,
 		order: 1,
 	},

--- a/containers/mosaic/src/__tests__/utils/date/dateToTimeString.test.ts
+++ b/containers/mosaic/src/__tests__/utils/date/dateToTimeString.test.ts
@@ -1,0 +1,45 @@
+import dateToTimeString from "@root/utils/date/dateToTimeString";
+import type { TestDef } from "@simpleview/mochalib";
+import { testArray } from "@simpleview/mochalib";
+
+describe(__filename, () => {
+	type Test = {
+		input: Date;
+	} & ({
+		result: string;
+	} | {
+		error: string;
+	})
+
+	const tests: TestDef<Test>[] = [
+		{
+			name: "should return a valid 24-hr time string from a given date object",
+			args: {
+				input: new Date(2025, 2, 31, 15, 31),
+				result: "15:31",
+			},
+		},
+		{
+			name: "should return a valid 24-hr time with padded time parts",
+			args: {
+				input: new Date(2025, 2, 31, 3, 9),
+				result: "03:09",
+			},
+		},
+		{
+			name: "should throw an error if the date object provided is invalid",
+			args: {
+				input: new Date("Foo"),
+				error: "Date provided to dateToTimeString is invalid.",
+			},
+		},
+	];
+
+	testArray(tests, ({ input, ...rest }) => {
+		if ("error" in rest) {
+			expect(() => dateToTimeString(input)).toThrowError(rest.error);
+		} else {
+			expect(dateToTimeString(input)).toBe(rest.result);
+		}
+	});
+});

--- a/containers/mosaic/src/components/DataView/DataViewPagerPopover/DataViewPagerPopover.tsx
+++ b/containers/mosaic/src/components/DataView/DataViewPagerPopover/DataViewPagerPopover.tsx
@@ -20,7 +20,7 @@ function DataViewPagerPopover({
 	totalPages,
 }: DataViewPagerPopoverProps) {
 	const { onClose } = useContext(ButtonPopoverContext);
-	const controller = useForm();
+	const controller = useForm({ data: { page: currentPage } });
 	const { handleSubmit } = controller;
 
 	const fields = useMemo<FieldDef[]>(() => [
@@ -38,10 +38,6 @@ function DataViewPagerPopover({
 		},
 	], [totalPages]);
 
-	const getFormValues = useCallback(async () => ({
-		page: currentPage,
-	}), [currentPage]);
-
 	const onSubmit = handleSubmit(useCallback(({ data: { page } }) => {
 		onSkipChange({ skip : (Number(page) - 1) * limit });
 		onClose();
@@ -54,7 +50,6 @@ function DataViewPagerPopover({
 				autoFocus={autoFocusOptions}
 				fields={fields}
 				spacing="compact"
-				getFormValues={getFormValues}
 				onSubmit={onSubmit}
 				bottomSlot={(
 					<StyledFormFooter $spacing="compact">

--- a/containers/mosaic/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
+++ b/containers/mosaic/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
@@ -49,18 +49,16 @@ const sections: SectionDef[] = [
 ];
 
 export default function DataViewFilterDateDropdownContent(props: DataViewFilterDateDropdownContentProps): ReactElement {
-	const controller = useForm();
+	const controller = useForm({
+		data: {
+			rangeStart: "rangeStart" in props ? props.rangeStart : undefined,
+			rangeEnd: "rangeEnd" in props ? props.rangeEnd : undefined,
+		},
+	});
 	const { state, methods: { setFormValues } } = controller;
 	const { rangeStart, rangeEnd } = state.data;
 
 	const [selectedOption, setSelectedOption] = useState("selectedOption" in props ? props.selectedOption : undefined);
-
-	const getFormValues = useCallback(async () => {
-		return {
-			rangeStart: "rangeStart" in props ? props.rangeStart : undefined,
-			rangeEnd: "rangeEnd" in props ? props.rangeEnd : undefined,
-		};
-	}, [props]);
 
 	const fields = useMemo<FieldDef[]>(() => [
 		{
@@ -152,7 +150,6 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 						sections={sections}
 						fullHeight={false}
 						spacing="compact"
-						getFormValues={getFormValues}
 					/>
 				</div>
 				<DataViewFilterDropdownButtons

--- a/containers/mosaic/src/components/DataViewFilterNumber/DataViewFilterNumberDropdownContent.tsx
+++ b/containers/mosaic/src/components/DataViewFilterNumber/DataViewFilterNumberDropdownContent.tsx
@@ -29,7 +29,12 @@ export default function DataViewFilterNumberDropdownContent({
 	onChange,
 	onClose,
 }: DataViewFilterNumberDropdownContentProps): ReactElement {
-	const controller = useForm();
+	const controller = useForm({
+		data: {
+			min: initialMin,
+			max: initialMax,
+		},
+	});
 	const {
 		state: {
 			data: {
@@ -42,13 +47,6 @@ export default function DataViewFilterNumberDropdownContent({
 			setFormValues,
 		},
 	} = controller;
-
-	const getFormValues = useCallback(async () => {
-		return {
-			min: initialMin,
-			max: initialMax,
-		};
-	}, [initialMin, initialMax]);
 
 	const onClear = useCallback(() => {
 		setFormValues({
@@ -104,7 +102,6 @@ export default function DataViewFilterNumberDropdownContent({
 				sections={sections}
 				fullHeight={false}
 				spacing="compact"
-				getFormValues={getFormValues}
 			/>
 			<DataViewFilterDropdownButtons
 				onApply={onApply}

--- a/containers/mosaic/src/components/Field/FieldTypes.tsx
+++ b/containers/mosaic/src/components/Field/FieldTypes.tsx
@@ -19,7 +19,7 @@ import type { FieldDefToggle } from "@root/components/Field/FormFieldToggle";
 import type { FieldDefUpload } from "@root/components/Field/FormFieldUpload";
 import type { MosaicToggle } from "@root/types";
 import type { ElementType, HTMLAttributes, MemoExoticComponent, MutableRefObject, ReactNode } from "react";
-import type { FieldValueResolver, FormSpacing } from "../Form";
+import type { ExternalToInternalValue, FormSpacing, InternalToExternalValue } from "../Form";
 import type { FieldPath, FormMethods, FormState, Validator } from "../Form/useForm/types";
 import type { FieldDefGroup } from "./FormFieldGroup/FormFieldGroupTypes";
 
@@ -196,10 +196,19 @@ export interface FieldDefBase<Type, T = any> {
 	 */
 	show?: MosaicToggle<FormState>;
 	/**
-	 * How to resolve the field's value from the internal value. Defaults
-	 * to an function that returns a like-for-like value
+	 * How to transform a field's value into an internal value
+	 * that will be consumed by the field component. By default,
+	 * no transformation will be applied and it'll result in the
+	 * same value.
 	 */
-	getResolvedValue?: FieldValueResolver;
+	externalToInternalValue?: ExternalToInternalValue;
+	/**
+	 * How to transform a field's internal value into its external
+	 * value that will be exposed to the consumer. By default,
+	 * no transformation will be applied and it'll result in the
+	 * same value.
+	 */
+	internalToExternalValue?: InternalToExternalValue;
 	/**
 	 * How to decide whether or not the field has a value
 	 */
@@ -232,8 +241,9 @@ export type FieldDef =
 	| FieldDefRaw
 	| FieldDefGroup;
 
-export type FieldObj = Omit<FieldDef, "getResolvedValue" | "fields" | "required"> & {
-	getResolvedValue: (value: any) => { internalValue: any; value: any };
+export type FieldObj = Omit<FieldDef, "" | "fields" | "required"> & {
+	externalToInternalValue: (value: any) => any;
+	internalToExternalValue: (value: any) => any;
 	order: number;
 	fields?: Record<string, FieldObj>;
 	hasValue: FieldHasValue;
@@ -249,7 +259,8 @@ export type FieldHasValue = ({ value, internalValue }: { value: any; internalVal
 export interface FieldConfig {
 	Component: ElementType;
 	validate: FieldValidateOn;
-	getResolvedValue: FieldValueResolver;
+	externalToInternalValue: ExternalToInternalValue;
+	internalToExternalValue: InternalToExternalValue;
 	hasValue: FieldHasValue;
 }
 

--- a/containers/mosaic/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 
 import React, { useCallback, useEffect, useMemo } from "react";
 
-import type { AddressDrawerProps, IAddress } from "../AddressTypes";
+import type { AddressDrawerProps } from "../AddressTypes";
 import type { FieldDef } from "@root/components/Field/FieldTypes";
 import type { ButtonProps } from "@root/components/Button";
 import type { SectionDef } from "@root/components/Form";
@@ -27,7 +27,20 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 		googleMapsApiKey,
 	} = props;
 
-	const controller = useForm();
+	const controller = useForm({
+		data: addressToEdit ? {
+			address1: addressToEdit.address1,
+			address2: addressToEdit.address2,
+			address3: addressToEdit.address3,
+			city: addressToEdit.city,
+			state: addressToEdit.state,
+			postalCode: addressToEdit.postalCode,
+			country: addressToEdit.country,
+			...(addressTypes ? {
+				types: addressToEdit.types,
+			} : {}),
+		} : {},
+	});
 	const { state, handleSubmit } = controller;
 
 	useEffect(() => {
@@ -114,28 +127,6 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 		[getOptionsCountries, getOptionsStates, googleMapsApiKey, typesField],
 	);
 
-	const getFormValues = useCallback(async () => {
-		if (!addressToEdit) {
-			return {};
-		}
-
-		const values: Omit<IAddress, "types"> & { types?: IAddress["types"] } = {
-			address1: addressToEdit.address1,
-			address2: addressToEdit.address2,
-			address3: addressToEdit.address3,
-			city: addressToEdit.city,
-			state: addressToEdit.state,
-			postalCode: addressToEdit.postalCode,
-			country: addressToEdit.country,
-		};
-
-		if (addressTypes) {
-			values.types = addressToEdit.types;
-		}
-
-		return values;
-	}, [addressToEdit, addressTypes]);
-
 	const buttons = useMemo<ButtonProps[]>(() => [
 		{
 			label: "Cancel",
@@ -165,7 +156,6 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 				fields={fields}
 				dialogOpen={dialogOpen}
 				handleDialogClose={handleDialogClose}
-				getFormValues={getFormValues}
 			/>
 		</FormDrawerWrapper>
 	);

--- a/containers/mosaic/src/components/Field/FormFieldMapCoordinates/MapCoordinatesDrawer/MapCoordinatesDrawer.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldMapCoordinates/MapCoordinatesDrawer/MapCoordinatesDrawer.tsx
@@ -38,14 +38,16 @@ const MapCoordinatesDrawer = (props: MapCoordinatesDrawerProps): ReactElement =>
 		googleMapsApiKey,
 	} = props;
 
-	const getFormValues = useCallback(async () => {
-		const lat = value ? value.lat : undefined;
-		const lng = value ? value.lng : undefined;
-
-		return { lat, lng, placesList: { lat, lng } };
-	}, [value]);
-
-	const controller = useForm();
+	const controller = useForm({
+		data: {
+			lat: value ? value.lat : undefined,
+			lng: value ? value.lng : undefined,
+			placesList: {
+				lat: value ? value.lat : undefined,
+				lng: value ? value.lng : undefined,
+			},
+		},
+	});
 	const { state, methods: { setFieldValue, setFormValues }, handleSubmit } = controller;
 
 	const parentLatLng = useMemo(() => isValidLatLng(value) ? value : undefined, [value]);
@@ -244,7 +246,6 @@ const MapCoordinatesDrawer = (props: MapCoordinatesDrawerProps): ReactElement =>
 				fields={fields}
 				dialogOpen={dialogOpen}
 				handleDialogClose={handleDialogClose}
-				getFormValues={getFormValues}
 			/>
 		</FormDrawerWrapper>
 	);

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/FormFieldTextEditorTypes.tsx
@@ -4,7 +4,7 @@ import type { Editor, Extensions } from "@tiptap/core";
 import type { FieldDefBase } from "@root/components/Field";
 import type { MosaicObject, MosaicToggle, SvgIconComponent } from "@root/types";
 import type { PopperProps } from "@mui/material/Popper";
-import type { FormProps } from "@root/components/Form";
+import type { FormState } from "@root/components/Form";
 
 export type SelectionType =
 	| "formatting"
@@ -36,7 +36,7 @@ export type FloatingToolbarProps = ToolbarControlsProps & FloatingToolbarState &
 export interface NodeFormTypeProps {
 	editor: Editor;
 	onClose: () => void;
-	getFormValues: FormProps["getFormValues"];
+	data: FormState["data"];
 }
 
 export type NodeFormState = {

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeForm.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeForm.tsx
@@ -1,6 +1,6 @@
 import type { Editor } from "@tiptap/react";
 
-import React, { useCallback } from "react";
+import React from "react";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 
 import type { NodeFormState } from "../FormFieldTextEditorTypes";
@@ -37,14 +37,6 @@ export function NodeForm(props: NodeFormProps) {
 
 	const { onClose } = rest;
 
-	const getFormValues = useCallback(async () => {
-		if (!values) {
-			return {};
-		}
-
-		return values;
-	}, [values]);
-
 	return (
 		<StyledPopper
 			anchorEl={anchorEl}
@@ -56,13 +48,13 @@ export function NodeForm(props: NodeFormProps) {
 				<StyledNodeForm>
 					{type === "link" ? (
 						<NodeFormLink
-							getFormValues={getFormValues}
+							data={values || {}}
 							update={update}
 							{...rest}
 						/>
 					) : type === "image" ? (
 						<NodeFormImage
-							getFormValues={getFormValues}
+							data={values || {}}
 							update={update}
 							{...rest}
 						/>

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormImage.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormImage.tsx
@@ -12,8 +12,8 @@ type NodeFormImageProps = NodeFormTypeProps & {
 	update: TextEditorUpdateImage;
 };
 
-export function NodeFormImage({ getFormValues, update }: NodeFormImageProps): ReactElement {
-	const controller = useForm();
+export function NodeFormImage({ data, update }: NodeFormImageProps): ReactElement {
+	const controller = useForm({ data });
 	const { handleSubmit } = controller;
 
 	const onSubmit = handleSubmit(useCallback(({ data: { alt, src } }) => {
@@ -42,7 +42,6 @@ export function NodeFormImage({ getFormValues, update }: NodeFormImageProps): Re
 			fields={fields}
 			spacing="compact"
 			autoFocus
-			getFormValues={getFormValues}
 			onSubmit={onSubmit}
 			bottomSlot={<NodeFormFooter />}
 		/>

--- a/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormLink.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTextEditor/NodeForm/NodeFormLink.tsx
@@ -14,8 +14,8 @@ type NodeFormLinkProps = NodeFormTypeProps & {
 	isTextBased?: boolean;
 };
 
-export function NodeFormLink({ editor, isTextBased, getFormValues, onClose, update }: NodeFormLinkProps): ReactElement {
-	const controller = useForm();
+export function NodeFormLink({ editor, isTextBased, data, onClose, update }: NodeFormLinkProps): ReactElement {
+	const controller = useForm({ data });
 	const { state: { data: { url } }, handleSubmit } = controller;
 
 	const onSubmit = handleSubmit(useCallback(({ data: { url, newTab, text } }) => {
@@ -66,7 +66,6 @@ export function NodeFormLink({ editor, isTextBased, getFormValues, onClose, upda
 			fields={fields}
 			spacing="compact"
 			autoFocus
-			getFormValues={getFormValues}
 			onSubmit={onSubmit}
 			bottomSlot={(
 				<NodeFormFooter onRemove={onRemove} />

--- a/containers/mosaic/src/components/Form/Form.tsx
+++ b/containers/mosaic/src/components/Form/Form.tsx
@@ -46,7 +46,6 @@ const Form = (props: FormProps) => {
 		sections,
 		dialogOpen = false,
 		description,
-		getFormValues,
 		handleDialogClose,
 		scrollSpyThreshold = 0.15,
 		fullHeight = true,
@@ -56,15 +55,14 @@ const Form = (props: FormProps) => {
 		methods,
 		stable,
 		autoFocus,
-		skeleton: providedSkeleton,
 		bottomSlot = null,
 		hideSectionNav,
 	} = props;
 
 	const formContextValue = useMemo(() => ({ methods, state }), [methods, state]);
 	const fields = useMemo(() => sanitizeFieldDefs(providedFields, sections), [providedFields, sections]);
-	const { init, setFormValues, setSubmitWarning, disableForm } = methods;
-	const { errors, loadingInitial, disabled } = state;
+	const { init, setSubmitWarning } = methods;
+	const { errors, disabled } = state;
 	const { moveToError } = stable;
 
 	const [sectionRefs, setSectionRefs] = useState<HTMLElement[]>([]);
@@ -136,7 +134,7 @@ const Form = (props: FormProps) => {
 	const doneAutoFocus = useRef(false);
 
 	useEffect(() => {
-		if (disabled || loadingInitial || !autoFocus || doneAutoFocus.current) {
+		if (disabled || state.skeleton || !autoFocus || doneAutoFocus.current) {
 			return;
 		}
 
@@ -168,7 +166,7 @@ const Form = (props: FormProps) => {
 				mount.inputRef.select();
 			}
 		});
-	}, [disabled, loadingInitial, autoFocus, stable.fields, stable.mounted]);
+	}, [disabled, state.skeleton, autoFocus, stable.fields, stable.mounted]);
 
 	useEffect(() => {
 		if (!useSectionHash) {
@@ -260,31 +258,9 @@ const Form = (props: FormProps) => {
 		},
 	];
 
-	/**
-	 * Loading state
-	 */
-	const isBusy = state.disabled || state.waits.length > 0;
-	const skeleton = providedSkeleton || loadingInitial;
-
 	useLayoutEffect(() => {
 		init({ fields, sections });
 	}, [init, fields, sections]);
-
-	useEffect(() => {
-		(async () => {
-			disableForm({
-				disabled: true,
-				initial: true,
-			});
-
-			const values = getFormValues ? (await getFormValues()) : {};
-
-			setFormValues({
-				values,
-				initial: true,
-			});
-		})();
-	}, [disableForm, getFormValues, setFormValues]);
 
 	const onSubmitProxy = useCallback<FormProps["onSubmit"]>((e) => {
 		e.preventDefault();
@@ -306,7 +282,7 @@ const Form = (props: FormProps) => {
 			<StyledContainerForm
 				data-testid="form-test-id"
 				ref={formContainerRef}
-				aria-busy={isBusy ? "true" : "false"}
+				aria-busy={state.skeleton}
 				role="form"
 				aria-label={title}
 				$fullHeight={fullHeight}
@@ -326,7 +302,7 @@ const Form = (props: FormProps) => {
 							bottomBorder={sideNavItems.length < 2}
 							hideSectionNav={hideSectionNav}
 							collapse={topCollapseContainer}
-							skeleton={skeleton}
+							skeleton={state.skeleton}
 						/>
 					)}
 					<StyledFormPrimary className="form-primary">
@@ -345,7 +321,7 @@ const Form = (props: FormProps) => {
 								sections={shownSections}
 								spacing={spacing}
 								methods={methods}
-								skeleton={skeleton}
+								skeleton={state.skeleton}
 							/>
 						</StyledFormContent>
 					</StyledFormPrimary>

--- a/containers/mosaic/src/components/Form/FormTypes.tsx
+++ b/containers/mosaic/src/components/Form/FormTypes.tsx
@@ -52,7 +52,9 @@ export interface FieldError {
 	message: string;
 }
 
-export type FieldValueResolver = (value: any, fieldDef: FieldDef) => { internalValue: any; value: any };
+export type ExternalToInternalValue = (value: any, fieldDef: FieldDef) => any;
+
+export type InternalToExternalValue = (value: any, fieldDef: FieldDef) => any;
 
 export interface FormContextState {
 	state: FormState;

--- a/containers/mosaic/src/components/Form/FormTypes.tsx
+++ b/containers/mosaic/src/components/Form/FormTypes.tsx
@@ -1,7 +1,7 @@
 import type { ButtonProps } from "@root/components/Button";
 import type { FieldDef } from "@root/components/Field";
 import type { TitleWrapperProps } from "@root/components/Title";
-import type { MosaicGridConfig, MosaicObject, MosaicToggle } from "@root/types";
+import type { MosaicGridConfig, MosaicToggle } from "@root/types";
 import type { FormMethods, FormStable, FormState } from "./useForm/types";
 import type { ReactNode } from "react";
 
@@ -35,7 +35,6 @@ export interface FormProps {
 	sections?: SectionDef[];
 	dialogOpen?: boolean;
 	description?: string;
-	getFormValues?(): Promise<MosaicObject>;
 	handleDialogClose?: (val: boolean) => void;
 	buttons?: ButtonProps[];
 	scrollSpyThreshold?: number;
@@ -45,7 +44,6 @@ export interface FormProps {
 	onSubmit?: React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>["onSubmit"];
 	methods: FormMethods;
 	autoFocus?: boolean | AutofocusOptions;
-	skeleton?: boolean;
 	bottomSlot?: ReactNode;
 	hideSectionNav?: boolean;
 }

--- a/containers/mosaic/src/components/Form/useForm/initial.ts
+++ b/containers/mosaic/src/components/Form/useForm/initial.ts
@@ -5,11 +5,11 @@ export function getInitialState(): FormState {
 		internalData: {},
 		data: {},
 		errors: {},
-		disabled: true,
+		disabled: false,
 		touched: {},
 		submitWarning: { open: false, lead: "", reasons: [] },
 		waits: [],
-		loadingInitial: true,
+		skeleton: false,
 	};
 }
 
@@ -22,9 +22,9 @@ export function getInitialStable(): FormStable {
 		hasBlurred: {},
 		hasSubmitted: false,
 		moveToError: false,
-		loadingInitial: true,
 		hooks: {
 			setFieldValueData: [],
 		},
+		skeleton: false,
 	};
 }

--- a/containers/mosaic/src/components/Form/useForm/reducers.ts
+++ b/containers/mosaic/src/components/Form/useForm/reducers.ts
@@ -19,10 +19,10 @@ export function reducer(state: FormState, action: FormAction): FormState {
 	case "SET_FIELD_VALUES": {
 		return {
 			...state,
-			data: action.values,
+			data: action.values !== undefined ? action.values : state.data,
 			internalData: action.internalValues,
 			touched: action.touched || state.touched,
-			loadingInitial: action.loadingInitial !== undefined ? action.loadingInitial : state.loadingInitial,
+			skeleton: action.skeleton !== undefined ? action.skeleton : state.skeleton,
 			disabled: action.disabled !== undefined ? action.disabled : state.disabled,
 		};
 	}
@@ -38,14 +38,12 @@ export function reducer(state: FormState, action: FormAction): FormState {
 			data: action.data,
 			internalData: action.internalData,
 			disabled: false,
-			loadingInitial: false,
 		};
 	}
 	case "FORM_DISABLE": {
 		return {
 			...state,
 			disabled: action.disabled,
-			loadingInitial: action.loadingInitial !== undefined ? action.loadingInitial : state.loadingInitial,
 		};
 	}
 	// LEGACY

--- a/containers/mosaic/src/components/Form/useForm/types.ts
+++ b/containers/mosaic/src/components/Form/useForm/types.ts
@@ -30,11 +30,11 @@ export interface ActionSetFieldErrors {
 
 export interface ActionSetFieldValues {
 	type: "SET_FIELD_VALUES";
-	values: MosaicObject<string>;
+	values?: MosaicObject<string>;
 	internalValues: MosaicObject<string>;
 	merge?: boolean;
 	touched?: FormState["touched"];
-	loadingInitial?: boolean;
+	skeleton?: boolean;
 	disabled?: boolean;
 }
 
@@ -56,7 +56,6 @@ export type ActionSetSubmitWarning = FormState["submitWarning"] & {
 export interface ActionDisable {
 	type: "FORM_DISABLE";
 	disabled: boolean;
-	loadingInitial?: boolean;
 }
 
 export type FormAction =
@@ -90,7 +89,8 @@ export type FormHandleSubmit = (onSuccess: OnSubmitSuccess, onError?: OnSubmitEr
 export interface SetFormValuesParams {
 	values: MosaicObject<any>;
 	path?: FieldPath;
-	initial?: boolean;
+	skeleton?: boolean;
+	disabled?: boolean;
 	validate?: boolean;
 }
 
@@ -137,7 +137,6 @@ export type AddWait = (params?: AddWaitParams) => AddWaitResult;
 
 export interface DisableFormParams {
 	disabled?: boolean;
-	initial?: boolean;
 }
 
 export type DisableForm = (params: DisableFormParams) => void;
@@ -201,9 +200,10 @@ export interface FormState {
 	touched: MosaicObject<boolean | FormTouched>;
 	submitWarning: { open: boolean; lead: string; reasons: string[] };
 	waits: FormWait[];
-	loadingInitial: boolean;
+	skeleton?: boolean;
 }
 
+export type UseFormParams = Partial<Pick<FormState, "disabled" | "skeleton" | "data">>;
 export interface UseFormReturn {
 	state: FormState;
 	stable: FormStable;

--- a/containers/mosaic/src/components/Form/useForm/utils.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils.ts
@@ -27,7 +27,7 @@ export function stateFromStable({
 	touched,
 	submitWarning,
 	waits,
-	loadingInitial,
+	skeleton,
 }: FormStable): FormState {
 	return {
 		internalData,
@@ -37,7 +37,7 @@ export function stateFromStable({
 		touched,
 		submitWarning,
 		waits,
-		loadingInitial,
+		skeleton,
 	};
 }
 

--- a/containers/mosaic/src/components/Form/useForm/utils/createFieldStore.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/createFieldStore.ts
@@ -19,12 +19,14 @@ function createFieldStore({
 
 	return fields.reduce((prev, field, index) => {
 		const fieldConfig = getFieldConfig(field.type);
-		const valueResolver = field.getResolvedValue || fieldConfig.getResolvedValue;
+		const externalToInternalValue = field.externalToInternalValue || fieldConfig.externalToInternalValue;
+		const internalToExternalValue = field.internalToExternalValue || fieldConfig.internalToExternalValue;
 
 		const result: FieldObj = {
 			...field,
 			validateOn: field.validateOn || fieldConfig.validate,
-			getResolvedValue: (value) => valueResolver(value, field),
+			externalToInternalValue: (value) => externalToInternalValue(value, field),
+			internalToExternalValue: (value) => internalToExternalValue(value, field),
 			hasValue: field.hasValue || fieldConfig.hasValue,
 			order: (fieldsBySection ? fieldsBySection.indexOf(field.name) : index) + 1,
 			fields: field.type === "group" ? createFieldStore({ fields: field.inputSettings.fields, stable }) : undefined,

--- a/containers/mosaic/src/components/Form/useForm/utils/getFieldInternalValues.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/getFieldInternalValues.ts
@@ -10,9 +10,9 @@ function getFieldInternalValues(values: FormStable["data"], fields: FormStable["
 		}
 
 		if ("fields" in field && field.fields) {
-			result[name] = getFieldInternalValues(field.getResolvedValue(values[name]).internalValue, field.fields);
+			result[name] = getFieldInternalValues(field.externalToInternalValue(values[name]), field.fields);
 		} else {
-			result[name] = field.getResolvedValue(values[name]).internalValue;
+			result[name] = field.externalToInternalValue(values[name]);
 		}
 	}
 

--- a/containers/mosaic/src/components/Form/useForm/utils/getFieldValue.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/getFieldValue.ts
@@ -64,15 +64,20 @@ function getFieldValue({
 
 		return {
 			internalValue: result.internalValue,
-			value: field.getResolvedValue(result.value).value,
+			value: field.internalToExternalValue(result.value),
 		};
 	}
 
 	const isTarget = target.join(".") === [...path, fieldName].join(".");
-	return field.getResolvedValue(
-		isTarget ?
-			(typeof value === "function" ? value(get(stable.internalData, [...path, fieldName])) : value) :
-			currentValues.internalValues[fieldName]);
+
+	const internalValue = isTarget ?
+		(typeof value === "function" ? value(get(stable.internalData, [...path, fieldName])) : value) :
+		currentValues.internalValues[fieldName];
+
+	return {
+		internalValue,
+		value: field.internalToExternalValue(internalValue),
+	};
 }
 
 export default getFieldValue;

--- a/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
@@ -3,6 +3,7 @@ import getAddressFields, { defaultAddressFields } from "@root/components/Field/F
 import { Sizes } from "@root/theme";
 import { matchTime } from "@root/utils/date";
 import type { SectionDef } from "../../FormTypes";
+import dateToTimeString from "@root/utils/date/dateToTimeString";
 
 // TODO Factor this out to the same place at which we create the sanitized field object store
 function sanitizeFieldDefs(fields: FieldDef[], sections?: SectionDef[]): FieldDefSanitized[] {
@@ -115,25 +116,22 @@ function sanitizeFieldDefs(fields: FieldDef[], sections?: SectionDef[]): FieldDe
 					],
 					layout: [[["date"], ["time"]]],
 				},
-				getResolvedValue: (value) => {
-					if (value instanceof Date) {
-						return {
-							internalValue: {
-								date: { date: value, keyboardInputValue: undefined },
-								time: { time: value, keyboardInputValue: undefined, usingDefaultTime: false },
-							},
-							value,
-						};
-					}
-
-					if (!value || !value.date || !value.time) {
-						return { internalValue: value, value: undefined };
+				externalToInternalValue: (value: Date | undefined) => {
+					if (!value || !(value instanceof Date)) {
+						return undefined;
 					}
 
 					return {
-						internalValue: value,
-						value: matchTime(value.date, value.time),
+						date: value,
+						time: dateToTimeString(value),
 					};
+				},
+				internalToExternalValue: (value: {date: Date | undefined; time: Date | undefined} | undefined) => {
+					if (!value?.date || !value?.time) {
+						return undefined;
+					}
+
+					return matchTime(value.date, value.time);
 				},
 			};
 		}

--- a/containers/mosaic/src/mock/numberTable.ts
+++ b/containers/mosaic/src/mock/numberTable.ts
@@ -1,0 +1,52 @@
+import type { Row, Col } from "@root/components/Field/FormFieldNumberTable/FormFieldNumberTableTypes";
+
+export const rows: Row[] = [
+	{ name: "2023_02_10", title: "Shoulder Before" },
+	{ name: "2023_02_11", title: "Day 1", subtitle: "Thu, Jan 05 2023" },
+	{ name: "2023_02_12", title: "Day 2", subtitle: "Fri, Jan 06 2023" },
+	{ name: "2023_02_13", title: "Day 3", subtitle: "Sat, Jan 07 2023" },
+];
+
+export const columns: Col[] = [
+	{ name: "single", title: "Single" },
+	{ name: "double", title: "Double" },
+	{ name: "queen", title: "Queen" },
+	{ name: "king", title: "King" },
+	{ name: "suite", title: "Suite" },
+	{ name: "any", title: "Any" },
+];
+
+export const mockNumberTableData = {
+	"2023_02_10": {
+		single: "12",
+		double: "13",
+		queen: "14",
+		king: "15",
+		suite: "16",
+		any: "17",
+	},
+	"2023_02_11": {
+		single: "18",
+		double: "19",
+		queen: "20",
+		king: "21",
+		suite: "22",
+		any: "23",
+	},
+	"2023_02_12": {
+		single: "12",
+		double: "13",
+		queen: "14",
+		king: "15",
+		suite: "16",
+		any: "20",
+	},
+	"2023_02_13": {
+		single: "1",
+		double: "1",
+		queen: "1",
+		king: "1",
+		suite: "1",
+		any: "1",
+	},
+};

--- a/containers/mosaic/src/utils/date/dateToTimeString.ts
+++ b/containers/mosaic/src/utils/date/dateToTimeString.ts
@@ -1,0 +1,14 @@
+import isValidDate from "./isValidDate";
+
+function dateToTimeString(date: Date): string {
+	if (!isValidDate(date)) {
+		throw new Error("Date provided to dateToTimeString is invalid.");
+	}
+
+	const hours = date.getHours().toString().padStart(2, "0");
+	const minutes = date.getMinutes().toString().padStart(2, "0");
+
+	return `${hours}:${minutes}`;
+}
+
+export default dateToTimeString;

--- a/containers/mosaic/src/utils/form/defaultResolver.ts
+++ b/containers/mosaic/src/utils/form/defaultResolver.ts
@@ -1,7 +1,0 @@
-import cleanValue from "./cleanValue";
-
-export function defaultResolver(value: any) {
-	return { internalValue: value, value: cleanValue(value) };
-}
-
-export default defaultResolver;

--- a/containers/mosaic/src/utils/form/defaultValueTransform.ts
+++ b/containers/mosaic/src/utils/form/defaultValueTransform.ts
@@ -1,0 +1,9 @@
+import cleanValue from "./cleanValue";
+
+export function externalToInternalValue(value: any) {
+	return value;
+}
+
+export function internalToExternalValue(value: any) {
+	return cleanValue(value);
+}

--- a/containers/mosaic/src/utils/form/getFieldConfig.ts
+++ b/containers/mosaic/src/utils/form/getFieldConfig.ts
@@ -29,7 +29,8 @@ import FormFieldNumber from "@root/components/Field/FormFieldNumber/FormFieldNum
 import FormFieldNumberTable from "@root/components/Field/FormFieldNumberTable/FormFieldNumberTable";
 import FormFieldGroup from "@root/components/Field/FormFieldGroup/FormFieldGroup";
 import defaultHasValue from "./defaultHasValue";
-import { matchTime } from "../date";
+import { matchTime, textIsValidDate } from "../date";
+import { DATE_FORMAT_FULL } from "@root/constants";
 
 type FieldConfigMap = Partial<Record<Exclude<FieldDef["type"], FieldDefCustom["type"]>, FieldConfig>>;
 
@@ -101,7 +102,6 @@ function getFieldConfigMapMemo(): () => FieldConfigMap {
 					internalValue: DateData | undefined;
 					value: Date | undefined;
 				} => {
-
 					if (value instanceof Date ) {
 						return {
 							internalValue: { date: value },
@@ -111,6 +111,16 @@ function getFieldConfigMapMemo(): () => FieldConfigMap {
 						if (!value || !value.date) {
 							return {
 								internalValue: undefined,
+								value: undefined,
+							};
+						}
+
+						if (
+							isNaN(value.date.getTime()) ||
+							(value.keyboardInputValue && !textIsValidDate(value.keyboardInputValue, DATE_FORMAT_FULL))
+						) {
+							return {
+								internalValue: value,
 								value: undefined,
 							};
 						}

--- a/containers/mosaic/src/utils/form/getFieldConfig.ts
+++ b/containers/mosaic/src/utils/form/getFieldConfig.ts
@@ -1,11 +1,10 @@
 import type { FieldConfig, FieldDef, FieldDefCustom } from "@root/components/Field";
 
 import type { DateData } from "@root/components/Field/FormFieldDate";
-import type { TimeData } from "@root/components/Field/FormFieldTime/TimeField";
 import type { UploadData, UploadDataPending } from "@root/components/Field/FormFieldUpload";
 
 import { isPendingUploadData } from "@root/components/Field/FormFieldUpload/FormFieldUploadTypes";
-import defaultResolver from "./defaultResolver";
+import { externalToInternalValue, internalToExternalValue } from "./defaultValueTransform";
 import cleanValue from "./cleanValue";
 
 import FormFieldText from "@root/components/Field/FormFieldText/FormFieldText";
@@ -18,6 +17,7 @@ import FormFieldRaw from "@root/components/Field/FormFieldRaw/FormFieldRaw";
 import FormFieldToggle from "@root/components/Field/FormFieldToggle/FormFieldToggle";
 import FormFieldColor from "@root/components/Field/FormFieldColor/FormFieldColor";
 import FormFieldDate from "@root/components/Field/FormFieldDate";
+import type { TimeData } from "@root/components/Field/FormFieldTime/TimeField";
 import FormFieldTime from "@root/components/Field/FormFieldTime/TimeField";
 import FormFieldAddress from "@root/components/Field/FormFieldAddress/FormFieldAddress";
 import { FormFieldTextEditor } from "@root/components/Field/FormFieldTextEditor/FormFieldTextEditor";
@@ -50,86 +50,84 @@ function getFieldConfigMapMemo(): () => FieldConfigMap {
 			text: {
 				Component: FormFieldText,
 				validate: "onBlurAmend",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			checkbox: {
 				Component: FormFieldCheckbox,
 				validate: "onChange",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			chip: {
 				Component: FormFieldChips,
 				validate: "onChange",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			dropdown: {
 				Component: FormFieldDropdown,
 				validate: "onChange",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			phone: {
 				Component: FormFieldPhone,
 				validate: "onBlurAmend",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			radio: {
 				Component: FormFieldRadio,
 				validate: "onChange",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			toggle: {
 				Component: FormFieldToggle,
 				validate: "onChange",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			color: {
 				Component: FormFieldColor,
 				validate: "onBlur",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			date: {
 				Component: FormFieldDate,
 				validate: "onBlurAmend",
-				getResolvedValue: (value: DateData | Date | undefined, fieldDef): {
-					internalValue: DateData | undefined;
-					value: Date | undefined;
-				} => {
-					if (value instanceof Date ) {
-						return {
-							internalValue: { date: value },
-							value,
-						};
-					} else {
-						if (!value || !value.date) {
-							return {
-								internalValue: undefined,
-								value: undefined,
-							};
-						}
-
-						if (
-							isNaN(value.date.getTime()) ||
-							(value.keyboardInputValue && !textIsValidDate(value.keyboardInputValue, DATE_FORMAT_FULL))
-						) {
-							return {
-								internalValue: value,
-								value: undefined,
-							};
-						}
-
-						return {
-							internalValue: value,
-							value: matchTime(value.date, fieldDef?.inputSettings?.fixedTime || [0, 0, 0, 0]),
-						};
+				externalToInternalValue: (value: Date | undefined) => {
+					if (!value || !(value instanceof Date)) {
+						return { date: undefined };
 					}
+
+					return {
+						date: value,
+					};
+				},
+				internalToExternalValue: (value: DateData | undefined, fieldDef) => {
+					if (!value || !value.date) {
+						return undefined;
+					}
+
+					if (
+						isNaN(value.date.getTime()) ||
+						(value.keyboardInputValue && !textIsValidDate(value.keyboardInputValue, DATE_FORMAT_FULL))
+					) {
+						return undefined;
+					}
+
+					return matchTime(value.date, fieldDef?.inputSettings?.fixedTime || [0, 0, 0, 0]);
 				},
 				hasValue: ({ internalValue }) => {
 					return Boolean(internalValue && internalValue.date);
@@ -138,41 +136,27 @@ function getFieldConfigMapMemo(): () => FieldConfigMap {
 			time: {
 				Component: FormFieldTime,
 				validate: "onBlurAmend",
-				getResolvedValue: (
-					value: TimeData | string | undefined,
-				): {
-					internalValue: TimeData | undefined;
-					value: string | undefined;
-				} => {
-					if (typeof value === "string") {
-						const date = new Date();
-						const [hrs, mins] = value.split(":");
-
-						date.setHours(Number(hrs));
-						date.setMinutes(Number(mins));
-
-						return {
-							internalValue: {
-								time: date,
-								keyboardInputValue: undefined,
-							},
-							value,
-						};
-					} else {
-						if (!value || !value.time) {
-							return {
-								internalValue: undefined,
-								value: undefined,
-							};
-						}
-
-						const time = !isNaN(value.time.getTime()) ? [
-							String(value.time.getHours()).padStart(2, "0"),
-							String(value.time.getMinutes()).padStart(2, "0"),
-						].join(":") : undefined;
-
-						return { internalValue: value, value: time };
+				externalToInternalValue: (value: string | undefined) => {
+					if (!value) {
+						return undefined;
 					}
+
+					const time = new Date();
+					const [hrs, mins] = value.split(":");
+
+					time.setHours(Number(hrs));
+					time.setMinutes(Number(mins));
+
+					return {
+						time,
+					};
+				},
+				internalToExternalValue: (value: TimeData | undefined) => {
+					if (!value || !value.time) {
+						return undefined;
+					}
+
+					return value.time;
 				},
 				hasValue: ({ internalValue }) => {
 					return Boolean(internalValue && internalValue.time);
@@ -181,68 +165,73 @@ function getFieldConfigMapMemo(): () => FieldConfigMap {
 			address: {
 				Component: FormFieldAddress,
 				validate: "onBlur",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			textEditor: {
 				Component: FormFieldTextEditor,
 				validate: "onBlurAmend",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			advancedSelection: {
 				Component: FormFieldAdvancedSelection,
 				validate: "onBlur",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			mapCoordinates: {
 				Component: FormFieldMapCoordinates,
 				validate: "onBlur",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			matrix: {
 				Component: FormFieldMatrix,
 				validate: "onChange",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			upload: {
 				Component: FormFieldUpload,
 				validate: "onChange",
-				getResolvedValue: (
-					value: (UploadData | UploadDataPending)[] = [],
-				) => {
-					return {
-						value: cleanValue(value.filter((item) => !isPendingUploadData(item) && !item.isDeleting)),
-						internalValue: value || [],
-					};
+				externalToInternalValue,
+				internalToExternalValue: (value: (UploadData | UploadDataPending)[]) => {
+					return cleanValue(value.filter((item) => !isPendingUploadData(item) && !item.isDeleting));
 				},
 				hasValue: defaultHasValue,
 			},
 			number: {
 				Component: FormFieldNumber,
 				validate: "onBlurAmend",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			numberTable: {
 				Component: FormFieldNumberTable,
 				validate: "onChange",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			raw: {
 				Component: FormFieldRaw,
 				validate: "onChange",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 			group: {
 				Component: FormFieldGroup,
 				validate: "onSubmit",
-				getResolvedValue: defaultResolver,
+				externalToInternalValue,
+				internalToExternalValue,
 				hasValue: defaultHasValue,
 			},
 		};
@@ -260,7 +249,8 @@ export function getFieldConfig(type: FieldDef["type"]): FieldConfig {
 		return {
 			Component: type,
 			validate: "onBlur",
-			getResolvedValue: defaultResolver,
+			externalToInternalValue,
+			internalToExternalValue,
 			hasValue: defaultHasValue,
 		};
 	}
@@ -269,7 +259,8 @@ export function getFieldConfig(type: FieldDef["type"]): FieldConfig {
 		return {
 			Component: null,
 			validate: "onBlur",
-			getResolvedValue: defaultResolver,
+			externalToInternalValue,
+			internalToExternalValue,
 			hasValue: defaultHasValue,
 		};
 	}

--- a/containers/sb-8/.storybook/mosaic-preview.css
+++ b/containers/sb-8/.storybook/mosaic-preview.css
@@ -1,0 +1,5 @@
+code {
+	max-width: 400px !important;
+  	white-space: normal !important;
+  	line-height: 1.4em !important;
+}

--- a/containers/sb-8/.storybook/mosaic-theme.css
+++ b/containers/sb-8/.storybook/mosaic-theme.css
@@ -14,3 +14,4 @@
 .sidebar-header [title="Mosaic"]::after {
 	content: "Mosaic";
 }
+

--- a/containers/sb-8/.storybook/preview.ts
+++ b/containers/sb-8/.storybook/preview.ts
@@ -1,5 +1,7 @@
 import type { Preview } from "@storybook/react";
 
+import "./mosaic-preview.css";
+
 const preview: Preview = {
 	parameters: {
 		layout: "fullscreen",

--- a/containers/sb-8/stories/components/Field/FormFieldAddress/Address.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldAddress/Address.stories.tsx
@@ -1,10 +1,11 @@
 import type { ReactElement } from "react";
 import React, { useMemo } from "react";
 import { commonFieldControls, renderButtons } from "../../../../utils";
-import type { AddressData, FieldDefAddress } from "@root/components/Field/FormFieldAddress";
+import type { FieldDefAddress } from "@root/components/Field/FormFieldAddress";
 import Form, { useForm } from "@root/components/Form";
 import type { FieldDef } from "@root/components/Field";
 import { getOptionsCountries, getOptionsStates } from "@root/mock/options";
+import { mockAddresses } from "@root/mock";
 
 export default {
 	title: "FormFields/FormFieldAddress",
@@ -27,63 +28,19 @@ const commonInputSettings = {
 
 const defaultGoogleKey = "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac";
 
-const addresses: AddressData = [
-	{
-		id: 1,
-		address1: "137 Teaticket Highway",
-		address2: "",
-		city: "Falmouth",
-		state: {
-			label: "Massachusetts",
-			value: "MA",
-		},
-		postalCode: "02536",
-		country: {
-			label: "United States",
-			value: "US",
-		},
-		types: [
-			{
-				label: "Physical",
-				value: "physical",
-			},
-		],
-	},
-	{
-		id: 2,
-		address1: "555 East Main Street",
-		address2: "",
-		city: "Norfolk",
-		state: {
-			label: "Virginia",
-			value: "VA",
-		},
-		postalCode: "23510",
-		country: {
-			label: "United States",
-			value: "US",
-		},
-		types: [
-			{
-				label: "Physical",
-				value: "physical",
-			},
-		],
-	},
-];
-
 export const Playground = ({
 	label,
 	disabled,
 	required,
 	prepop,
+	prepopData,
 	amountPerType,
 	amountShipping,
 	amountPhysical,
 	amountBilling,
 	googleKey,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm({ data: prepop ? { address: addresses } : {} });
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, handleSubmit } = controller;
 
 	const fields = useMemo(
@@ -123,7 +80,9 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: { address: mockAddresses },
+	}),
 	amountPerType: "undefined",
 	amountShipping: "undefined",
 	amountPhysical: "undefined",
@@ -163,10 +122,11 @@ export const Single = ({
 	disabled,
 	required,
 	prepop,
+	prepopData,
 	subFields,
 	googleKey,
 }: typeof Single.args): ReactElement => {
-	const controller = useForm({ data: prepop ? { address: addresses[0] } : {} });
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, handleSubmit } = controller;
 
 	const fields = useMemo(
@@ -203,7 +163,9 @@ export const Single = ({
 };
 
 Single.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: { address: mockAddresses[0] },
+	}),
 	subFields: ["address1", "address2", "address3", "country", "city", "state", "postalCode"],
 	googleKey: defaultGoogleKey,
 };

--- a/containers/sb-8/stories/components/Field/FormFieldAddress/Address.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldAddress/Address.stories.tsx
@@ -76,7 +76,6 @@ export const Playground = ({
 	label,
 	disabled,
 	required,
-	skeleton,
 	prepop,
 	amountPerType,
 	amountShipping,
@@ -84,12 +83,8 @@ export const Playground = ({
 	amountBilling,
 	googleKey,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? { address: addresses } : {} });
 	const { state, handleSubmit } = controller;
-
-	const getFormValues = useMemo(() => (prepop ? async () => {
-		return { address: addresses };
-	} : undefined), [prepop]);
 
 	const fields = useMemo(
 		() : FieldDef[] => (
@@ -121,8 +116,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Address field"
 				fields={fields}
-				skeleton={skeleton}
-				getFormValues={getFormValues}
 			/>
 			<pre>{JSON.stringify(state, null, "  ")}</pre>
 		</>
@@ -169,17 +162,12 @@ export const Single = ({
 	label,
 	disabled,
 	required,
-	skeleton,
-	prepopulate,
+	prepop,
 	subFields,
 	googleKey,
 }: typeof Single.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? { address: addresses[0] } : {} });
 	const { state, handleSubmit } = controller;
-
-	const getFormValues = useMemo(() => (prepopulate ? async () => {
-		return { address: addresses[0] };
-	} : undefined), [prepopulate]);
 
 	const fields = useMemo(
 		() : FieldDef[] => (
@@ -208,8 +196,6 @@ export const Single = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Address Single field"
 				fields={fields}
-				skeleton={skeleton}
-				getFormValues={getFormValues}
 			/>
 			<pre>{JSON.stringify(state, null, "  ")}</pre>
 		</>
@@ -217,31 +203,13 @@ export const Single = ({
 };
 
 Single.args = {
-	label: "Label",
-	disabled: false,
-	required: false,
-	skeleton: false,
-	prepopulate: false,
+	...commonFieldControls.args,
 	subFields: ["address1", "address2", "address3", "country", "city", "state", "postalCode"],
 	googleKey: defaultGoogleKey,
 };
 
 Single.argTypes = {
-	label: {
-		name: "Label",
-	},
-	disabled: {
-		name: "Disabled",
-	},
-	required: {
-		name: "Required",
-	},
-	skeleton: {
-		name: "Skeleton",
-	},
-	prepopulate: {
-		name: "Prepopulate",
-	},
+	...commonFieldControls.argTypes,
 	subFields: {
 		name: "Sub-Fields",
 		control: { type: "object" },

--- a/containers/sb-8/stories/components/Field/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
@@ -19,6 +19,8 @@ export default {
 export const Playground = ({
 	label,
 	required,
+	prepop,
+	prepopData,
 	disabled,
 	instructionText,
 	helperText,
@@ -27,7 +29,7 @@ export const Playground = ({
 	createNewOptionsKnob,
 	selectLimit,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, handleSubmit } = controller;
 
 	const options: MosaicLabelValue[] = mockOptions ? mockOptions : [];
@@ -114,7 +116,9 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: { advancedSelection: mockOptions.slice(0, 3) },
+	}),
 	optionsOrigin: "Local",
 	getOptionsLimit: 5,
 	createNewOptionsKnob: true,

--- a/containers/sb-8/stories/components/Field/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldAdvancedSelection/AdvancedSelection.stories.tsx
@@ -19,7 +19,6 @@ export default {
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
@@ -109,7 +108,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Advanced Selection Field"
 				fields={fields}
-				skeleton={skeleton}
 			/>
 		</>
 	);

--- a/containers/sb-8/stories/components/Field/FormFieldCheckbox/FormFieldCheckbox.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldCheckbox/FormFieldCheckbox.stories.tsx
@@ -15,7 +15,6 @@ export default {
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
@@ -25,7 +24,7 @@ export const Playground = ({
 	optionCount,
 	itemsPerColumn,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, handleSubmit } = controller;
 
 	const options = useMemo<FormFieldCheckboxInputSettings["options"]>(() => {
@@ -59,11 +58,6 @@ export const Playground = ({
 		[label, required, disabled, options, helperText, instructionText, itemsPerColumn],
 	);
 
-	const getFormValues = useMemo(() => prepop
-		? async () => prepopData
-		: undefined,
-	[prepop, prepopData]);
-
 	return (
 		<>
 			<pre>{JSON.stringify(state, null, "  ")}</pre>
@@ -72,8 +66,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Checkbox Field"
 				fields={fields}
-				skeleton={skeleton}
-				getFormValues={getFormValues}
 			/>
 		</>
 	);

--- a/containers/sb-8/stories/components/Field/FormFieldCheckbox/FormFieldCheckbox.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldCheckbox/FormFieldCheckbox.stories.tsx
@@ -72,13 +72,14 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
-	prepopData: {
-		checkbox: [
-			{ value: "option_1-cat_1", label: "Option 1" },
-			{ value: "foo", label: "Foo" },
-		],
-	},
+	...commonFieldControls.args({
+		prepopData: {
+			checkbox: [
+				{ value: "option_1-cat_1", label: "Option 1" },
+				{ value: "foo", label: "Foo" },
+			],
+		},
+	}),
 	optionsType: "Synchronous",
 	optionCount: 25,
 	itemsPerColumn: 8,

--- a/containers/sb-8/stories/components/Field/FormFieldChips/FormFieldChips.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldChips/FormFieldChips.stories.tsx
@@ -56,10 +56,11 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
-	prepopData: {
-		chip: { value: "option_1-cat_1", label: "Option 1" },
-	},
+	...commonFieldControls.args({
+		prepopData: {
+			chip: { value: "option_1-cat_1", label: "Option 1" },
+		},
+	}),
 	optionsType: "Synchronous",
 };
 

--- a/containers/sb-8/stories/components/Field/FormFieldChips/FormFieldChips.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldChips/FormFieldChips.stories.tsx
@@ -13,7 +13,6 @@ export default {
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
@@ -21,7 +20,7 @@ export const Playground = ({
 	prepopData,
 	optionsType,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, handleSubmit } = controller;
 
 	const fields = useMemo(
@@ -43,11 +42,6 @@ export const Playground = ({
 		[label, helperText, instructionText, required, disabled, optionsType],
 	);
 
-	const getFormValues = useMemo(() => prepop
-		? async () => prepopData
-		: undefined,
-	[prepop, prepopData]);
-
 	return (
 		<>
 			<pre>{JSON.stringify(state, null, "  ")}</pre>
@@ -56,8 +50,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Chips Field"
 				fields={fields}
-				skeleton={skeleton}
-				getFormValues={getFormValues}
 			/>
 		</>
 	);

--- a/containers/sb-8/stories/components/Field/FormFieldColor/FormFieldColor.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldColor/FormFieldColor.stories.tsx
@@ -13,8 +13,10 @@ export const Playground = ({
 	label,
 	required,
 	disabled,
+	prepop,
+	prepopData,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, handleSubmit } = controller;
 
 	const fields = useMemo(
@@ -47,7 +49,11 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: {
+			color: "#ff0000",
+		},
+	}),
 };
 
 Playground.argTypes = {

--- a/containers/sb-8/stories/components/Field/FormFieldColor/FormFieldColor.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldColor/FormFieldColor.stories.tsx
@@ -12,7 +12,6 @@ export default {
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 }: typeof Playground.args): ReactElement => {
 	const controller = useForm();
@@ -41,7 +40,6 @@ export const Playground = ({
 					buttons={renderButtons(handleSubmit)}
 					title="Color Field"
 					fields={fields}
-					skeleton={skeleton}
 				/>
 			</div>
 		</>

--- a/containers/sb-8/stories/components/Field/FormFieldDate/DateField.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldDate/DateField.stories.tsx
@@ -10,14 +10,13 @@ export default {
 	title: "FormFields/FormFieldDateField",
 };
 
-const prepopulateData = {
+const prepopData = {
 	date: new Date(2024, 12, 25, 11, 30),
 };
 
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	prepop,
@@ -26,13 +25,8 @@ export const Playground = ({
 	minDateStr,
 	defaultTime: defaultTimeStr,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, handleSubmit } = controller;
-
-	const getFormValues = useMemo(() => prepop ?
-		async () => prepopulateData :
-		undefined,
-	[prepop]);
 
 	const minDate = useMemo(() => {
 		if (!minDateStr || !textIsValidDate(minDateStr, DATE_FORMAT_FULL)) {
@@ -66,6 +60,7 @@ export const Playground = ({
 					showTime,
 					minDate,
 					defaultTime,
+					fixedTime: [23, 59, 59, 999],
 				},
 			},
 		],
@@ -80,8 +75,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Date Field"
 				fields={fields}
-				skeleton={skeleton}
-				getFormValues={getFormValues}
 			/>
 		</>
 	);
@@ -105,12 +98,6 @@ Playground.argTypes = {
 	defaultTime: {
 		name: "Default Time",
 	},
-};
-
-const getFormValues = async () => {
-	return {
-		dateTimePrefilled: new Date("2023-07-31T14:00:00.000Z"),
-	};
 };
 
 export const KitchenSink = (): ReactElement => {
@@ -182,7 +169,6 @@ export const KitchenSink = (): ReactElement => {
 				title="Date Field Calendar"
 				description="This is a description example"
 				fields={fields}
-				getFormValues={getFormValues}
 			/>
 			<h3>Date.toString()</h3>
 			<pre>

--- a/containers/sb-8/stories/components/Field/FormFieldDate/DateField.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldDate/DateField.stories.tsx
@@ -2,16 +2,12 @@ import type { ReactElement } from "react";
 import React, { useMemo } from "react";
 import type { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
-import { commonFieldControls, renderButtons } from "../../../../utils";
+import { commonFieldControls, renderButtons, parseDateControl } from "../../../../utils";
 import { textIsValidDate } from "@root/utils/date";
 import { DATE_FORMAT_FULL } from "@root/constants";
 
 export default {
 	title: "FormFields/FormFieldDateField",
-};
-
-const prepopData = {
-	date: new Date(2024, 12, 25, 11, 30),
 };
 
 export const Playground = ({
@@ -20,12 +16,13 @@ export const Playground = ({
 	disabled,
 	instructionText,
 	prepop,
+	prepopData,
 	helperText,
 	showTime,
 	minDateStr,
 	defaultTime: defaultTimeStr,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm({ data: prepop ? prepopData : {} });
+	const controller = useForm({ data: prepop ? { ...prepopData, date: parseDateControl(prepopData?.date) } : {} });
 	const { state, handleSubmit } = controller;
 
 	const minDate = useMemo(() => {
@@ -81,7 +78,11 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: {
+			date: "2024-12-25-11-30",
+		},
+	}),
 	showTime: false,
 	minDateStr: "",
 	defaultTime: "",

--- a/containers/sb-8/stories/components/Field/FormFieldDropdown/FormFieldDropdown.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldDropdown/FormFieldDropdown.stories.tsx
@@ -15,7 +15,6 @@ export default {
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
@@ -25,7 +24,7 @@ export const Playground = ({
 	placeholder,
 	size,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, handleSubmit } = controller;
 
 	const fields = useMemo(
@@ -49,11 +48,6 @@ export const Playground = ({
 		[label, required, disabled, size, optionsType, placeholder, helperText, instructionText],
 	);
 
-	const getFormValues = useMemo(() => prepop
-		? async () => prepopData
-		: undefined,
-	[prepop, prepopData]);
-
 	return (
 		<>
 			<pre>{JSON.stringify(state, null, "  ")}</pre>
@@ -62,8 +56,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Dropdown Field"
 				fields={fields}
-				skeleton={skeleton}
-				getFormValues={getFormValues}
 			/>
 		</>
 	);

--- a/containers/sb-8/stories/components/Field/FormFieldDropdown/FormFieldDropdown.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldDropdown/FormFieldDropdown.stories.tsx
@@ -15,11 +15,11 @@ export default {
 export const Playground = ({
 	label,
 	required,
+	prepop,
+	prepopData,
 	disabled,
 	instructionText,
 	helperText,
-	prepop,
-	prepopData,
 	optionsType,
 	placeholder,
 	size,
@@ -62,10 +62,11 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
-	prepopData: {
-		dropdown: { value: "option_1-cat_1", label: "Option 1" },
-	},
+	...commonFieldControls.args({
+		prepopData: {
+			dropdown: { value: "option_1-cat_1", label: "Option 1" },
+		},
+	}),
 	optionsType: "Synchronous",
 	size: "sm",
 	placeholder: "Choose a movie..",

--- a/containers/sb-8/stories/components/Field/FormFieldMapCoordinates/MapCoordinates.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldMapCoordinates/MapCoordinates.stories.tsx
@@ -11,13 +11,6 @@ export default {
 	title: "FormFields/FormFieldMapCoordinates",
 };
 
-const getFormValues = async () => ({
-	map: {
-		lat: 32.369247319672866,
-		lng: -110.96678114089914,
-	},
-});
-
 // Liverpool Office: 53.37997840196994, -2.9729752639886544
 // Tucson Office: 32.369247319672866, -110.96678114089914
 // Eiffel Tower: 48.858321470423576, 2.2945004162050564
@@ -26,14 +19,18 @@ const getFormValues = async () => ({
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	initialCenterKnob,
 	zoom,
 	focusZoom,
 	prepop,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? {
+		map: {
+			lat: 32.369247319672866,
+			lng: -110.96678114089914,
+		},
+	} : {} });
 	const { state, handleSubmit } = controller;
 
 	const fields = useMemo(
@@ -63,8 +60,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Map Coordinates Field"
 				fields={fields}
-				getFormValues={prepop ? getFormValues : undefined}
-				skeleton={skeleton}
 			/>
 			<pre>{JSON.stringify(state, null, "  ")}</pre>
 		</>

--- a/containers/sb-8/stories/components/Field/FormFieldMapCoordinates/MapCoordinates.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldMapCoordinates/MapCoordinates.stories.tsx
@@ -4,7 +4,6 @@ import { useMemo } from "react";
 import type { FieldDef } from "@root/components/Field";
 import { commonFieldControls, renderButtons } from "../../../../utils";
 
-// Components
 import Form, { useForm } from "@root/components/Form";
 
 export default {
@@ -19,18 +18,14 @@ export default {
 export const Playground = ({
 	label,
 	required,
+	prepop,
+	prepopData,
 	disabled,
 	initialCenterKnob,
 	zoom,
 	focusZoom,
-	prepop,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm({ data: prepop ? {
-		map: {
-			lat: 32.369247319672866,
-			lng: -110.96678114089914,
-		},
-	} : {} });
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, handleSubmit } = controller;
 
 	const fields = useMemo(
@@ -67,7 +62,14 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: {
+			map: {
+				lat: 32.369247319672866,
+				lng: -110.96678114089914,
+			},
+		},
+	}),
 	initialCenterKnob: { lat: 48.858321470423576, lng: 2.2945004162050564 },
 	zoom: 7,
 	focusZoom: 11,

--- a/containers/sb-8/stories/components/Field/FormFieldMatrix/FormFieldMatrix.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldMatrix/FormFieldMatrix.stories.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState, useCallback } from "react";
 import type { FieldDef } from "@root/components/Field";
 
 // Components
-import type { FormProps } from "@root/components/Form";
+import type { FormState } from "@root/components/Form";
 import Form, { useForm } from "@root/components/Form";
 import AddIcon from "@mui/icons-material/Add";
 import CreateIcon from "@mui/icons-material/Create";
@@ -28,15 +28,15 @@ const DrawerEditForm = ({
 	onSave,
 	title,
 	fields,
-	getFormValues,
+	data,
 }: {
 	onClose: () => void;
 	onSave: (data: any) => void;
 	title: string;
 	fields: FieldDef[];
-	getFormValues: FormProps["getFormValues"];
+	data: FormState["data"];
 }): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: data || {} });
 	const { state } = controller;
 
 	const onSaveClick = () => onSave(state.data);
@@ -61,7 +61,6 @@ const DrawerEditForm = ({
 			title={title}
 			fields={fields}
 			onBack={onClose}
-			getFormValues={getFormValues}
 		/>
 	);
 };
@@ -69,7 +68,6 @@ const DrawerEditForm = ({
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
@@ -140,7 +138,7 @@ export const Playground = ({
 		removeDrawer();
 	};
 
-	const onAddClick = () =>
+	const onAddClick = useCallback(() =>
 		addDrawer({
 			config: {
 				type: "form",
@@ -158,9 +156,9 @@ export const Playground = ({
 					},
 				],
 			},
-		});
+		}), [addDrawer]);
 
-	const gridConfig: DataViewProps = {
+	const gridConfig = useMemo<DataViewProps>(() => ({
 		noResults: (
 			<div style={{ padding: "1rem 0.5rem", alignItems: "center", justifyContent: "center", display: "flex", flexDirection: "column", gap: 10 }}>
 				<div>
@@ -201,10 +199,10 @@ export const Playground = ({
 									type: "text",
 								},
 							],
-							getFormValues: async () => ({
+							data: {
 								title: rowToEdit[0].title,
 								description: rowToEdit[0].description,
-							}),
+							},
 						},
 					});
 				},
@@ -239,7 +237,7 @@ export const Playground = ({
 		},
 		display: "list",
 		activeColumns: ["id", "title", "description"],
-	};
+	}), [addDrawer, onAddClick, setFieldValue, state.data.formMatrix]);
 
 	const fields: FieldDef[] = useMemo(
 		() =>
@@ -266,7 +264,7 @@ export const Playground = ({
 					},
 				},
 			],
-		[required, disabled, instructionText, helperText, label, gridConfig, isEditing, indexEdit],
+		[label, required, disabled, helperText, instructionText, gridConfig, onAddClick],
 	);
 
 	const mosaicSettings = useMosaicSettings();
@@ -279,7 +277,6 @@ export const Playground = ({
 					buttons={renderButtons(handleSubmit)}
 					title="Matrix Field"
 					fields={fields}
-					skeleton={skeleton}
 				/>
 			</MosaicContext.Provider>
 			<Drawers drawers={drawerState.drawers}>
@@ -290,7 +287,7 @@ export const Playground = ({
 							onClose={removeDrawer}
 							onSave={addOrEdit}
 							title={drawerDef.config.title}
-							getFormValues={drawerDef.config.getFormValues}
+							data={drawerDef.config.data}
 						/>
 					);
 				}}

--- a/containers/sb-8/stories/components/Field/FormFieldMatrix/FormFieldMatrix.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldMatrix/FormFieldMatrix.stories.tsx
@@ -68,6 +68,8 @@ const DrawerEditForm = ({
 export const Playground = ({
 	label,
 	required,
+	prepop,
+	prepopData,
 	disabled,
 	instructionText,
 	helperText,
@@ -75,7 +77,7 @@ export const Playground = ({
 	const [isEditing, setIsEditing] = useState(false);
 	const [indexEdit, setIndexEdit] = useState(null);
 
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, methods: { setFieldValue }, handleSubmit } = controller;
 
 	const [drawerState, setDrawerState] = useState({
@@ -297,7 +299,15 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: {
+			formMatrix: [{
+				id:"ide6c8d48be717c8",
+				title:"Dog",
+				description:"A four legged animal with a tail that comes in a number of different breeds.",
+			}],
+		},
+	}),
 	optionsOrigin: "Local",
 	size: "sm",
 	placeholder: "Choose a movie..",

--- a/containers/sb-8/stories/components/Field/FormFieldNumber/FormFieldNumber.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldNumber/FormFieldNumber.stories.tsx
@@ -12,6 +12,8 @@ export default {
 export const Playground = ({
 	label,
 	required,
+	prepop,
+	prepopData,
 	disabled,
 	instructionText,
 	helperText,
@@ -22,14 +24,14 @@ export const Playground = ({
 	suffix,
 	sign,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { handleSubmit, state } = controller;
 
 	const fields: FieldDef[] = useMemo(
 		(): FieldDef[] =>
 			[
 				{
-					name: "numberfield",
+					name: "number",
 					label,
 					type: "number",
 					required,
@@ -75,7 +77,9 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: { number: "-1.337" },
+	}),
 	size: "sm",
 	placeholder: "placeholder",
 	decimalPlaces: -1,

--- a/containers/sb-8/stories/components/Field/FormFieldNumber/FormFieldNumber.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldNumber/FormFieldNumber.stories.tsx
@@ -12,7 +12,6 @@ export default {
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
@@ -69,7 +68,6 @@ export const Playground = ({
 				title="Number Field"
 				fields={fields}
 				{...controller}
-				skeleton={skeleton}
 			/>
 			<pre>{JSON.stringify(state, null, "  ")}</pre>
 		</>

--- a/containers/sb-8/stories/components/Field/FormFieldNumberTable/FormFieldNumberTable.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldNumberTable/FormFieldNumberTable.stories.tsx
@@ -15,7 +15,6 @@ export default {
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
@@ -88,7 +87,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Number Table Field"
 				fields={fields}
-				skeleton={skeleton}
 			/>
 		</>
 	);

--- a/containers/sb-8/stories/components/Field/FormFieldNumberTable/FormFieldNumberTable.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldNumberTable/FormFieldNumberTable.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import type { ReactElement } from "react";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import type { FieldDef } from "@root/components/Field";
 import { commonFieldControls, renderButtons } from "../../../../utils";
 
 // Components
 import Form, { useForm } from "@root/components/Form";
-import { columns, numberTableDefaultValue, rows } from "@root/components/Field/FormFieldNumberTable/numberTableUtils";
+import { rows, columns, mockNumberTableData } from "@root/mock/numberTable";
 
 export default {
 	title: "FormFields/FormFieldNumberTable",
@@ -15,6 +15,8 @@ export default {
 export const Playground = ({
 	label,
 	required,
+	prepop,
+	prepopData,
 	disabled,
 	instructionText,
 	helperText,
@@ -23,24 +25,10 @@ export const Playground = ({
 	topLeftLabel,
 	displayColumnsSums,
 	displayRowsSums,
-	prepop,
 	formatOptions,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
-	const { state, methods: { setFieldValue }, handleSubmit } = controller;
-
-	useEffect(() => {
-		if (!prepop)
-			setFieldValue({
-				name: "numberTable",
-				value: undefined,
-			});
-		else
-			setFieldValue({
-				name: "numberTable",
-				value: numberTableDefaultValue,
-			});
-	}, [prepop]);
+	const controller = useForm({ data: prepop ? prepopData : {} });
+	const { state, handleSubmit } = controller;
 
 	const fields = useMemo(
 		(): FieldDef[] => [
@@ -93,7 +81,11 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: {
+			numberTable: mockNumberTableData,
+		},
+	}),
 	rowTotalLabel: "TOTAL",
 	columnTotalLabel: "No. Rooms",
 	topLeftLabel: "Day",

--- a/containers/sb-8/stories/components/Field/FormFieldPhone/FormFieldPhone.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldPhone/FormFieldPhone.stories.tsx
@@ -12,7 +12,6 @@ export default {
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
@@ -48,7 +47,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Phone Field"
 				fields={fields}
-				skeleton={skeleton}
 			/>
 		</>
 	);

--- a/containers/sb-8/stories/components/Field/FormFieldPhone/FormFieldPhone.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldPhone/FormFieldPhone.stories.tsx
@@ -12,12 +12,14 @@ export default {
 export const Playground = ({
 	label,
 	required,
+	prepop,
+	prepopData,
 	disabled,
 	instructionText,
 	helperText,
 	country,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, handleSubmit } = controller;
 
 	const fields = useMemo(
@@ -53,7 +55,11 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: {
+			phone: "+15205302271",
+		},
+	}),
 	country: "",
 };
 

--- a/containers/sb-8/stories/components/Field/FormFieldRadio/FormFieldRadio.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldRadio/FormFieldRadio.stories.tsx
@@ -15,7 +15,6 @@ export default {
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
@@ -23,7 +22,7 @@ export const Playground = ({
 	prepopData,
 	optionsType,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, handleSubmit } = controller;
 
 	const fields = useMemo(
@@ -45,11 +44,6 @@ export const Playground = ({
 		[label, required, disabled, instructionText, helperText, optionsType],
 	);
 
-	const getFormValues = useMemo(() => prepop
-		? async () => prepopData
-		: undefined,
-	[prepop, prepopData]);
-
 	return (
 		<>
 			<pre>{JSON.stringify(state, null, "  ")}</pre>
@@ -58,8 +52,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Radio Field"
 				fields={fields}
-				skeleton={skeleton}
-				getFormValues={getFormValues}
 			/>
 		</>
 	);

--- a/containers/sb-8/stories/components/Field/FormFieldRadio/FormFieldRadio.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldRadio/FormFieldRadio.stories.tsx
@@ -15,11 +15,11 @@ export default {
 export const Playground = ({
 	label,
 	required,
+	prepop,
+	prepopData,
 	disabled,
 	instructionText,
 	helperText,
-	prepop,
-	prepopData,
 	optionsType,
 }: typeof Playground.args): ReactElement => {
 	const controller = useForm({ data: prepop ? prepopData : {} });
@@ -58,10 +58,11 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
-	prepopData: {
-		radio: { value: "option_1-cat_1", label: "Option 1" },
-	},
+	...commonFieldControls.args({
+		prepopData: {
+			radio: { value: "option_1-cat_1", label: "Option 1" },
+		},
+	}),
 	optionsType: "Synchronous",
 };
 

--- a/containers/sb-8/stories/components/Field/FormFieldRaw/FormFieldRaw.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldRaw/FormFieldRaw.stories.tsx
@@ -11,7 +11,7 @@ export default {
 	title: "FormFields/FormFieldRaw",
 };
 
-export const RawValueWrapper = styled.div`
+const RawValueWrapper = styled.div`
     background-color: #aa1919;
     border: 3px solid #570202;
     color: white;
@@ -27,12 +27,6 @@ function RawValue() {
 	);
 }
 
-async function getFormValues() {
-	return {
-		raw: <RawValue />,
-	};
-}
-
 export const Playground = ({
 	label,
 	required,
@@ -40,7 +34,7 @@ export const Playground = ({
 	instructionText,
 	helperText,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: { raw: <RawValue /> } });
 	const { handleSubmit } = controller;
 
 	const fields: FieldDef[] = useMemo(
@@ -66,7 +60,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Raw Field"
 				fields={fields}
-				getFormValues={getFormValues}
 			/>
 		</>
 	);

--- a/containers/sb-8/stories/components/Field/FormFieldRaw/FormFieldRaw.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldRaw/FormFieldRaw.stories.tsx
@@ -66,7 +66,7 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args(),
 };
 
 Playground.argTypes = {

--- a/containers/sb-8/stories/components/Field/FormFieldText/FormFieldText.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldText/FormFieldText.stories.tsx
@@ -16,7 +16,6 @@ export const Playground = ({
 	label,
 	hideLabel,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
@@ -81,7 +80,6 @@ export const Playground = ({
 				title="Text Field"
 				fields={fields}
 				{...controller}
-				skeleton={skeleton}
 			/>
 			<pre>{JSON.stringify(state, null, "  ")}</pre>
 		</>

--- a/containers/sb-8/stories/components/Field/FormFieldText/FormFieldText.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldText/FormFieldText.stories.tsx
@@ -16,6 +16,8 @@ export const Playground = ({
 	label,
 	hideLabel,
 	required,
+	prepop,
+	prepopData,
 	disabled,
 	instructionText,
 	helperText,
@@ -28,14 +30,14 @@ export const Playground = ({
 	maxRows,
 	withIcon,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { handleSubmit, state } = controller;
 
 	const fields: FieldDef[] = useMemo(
 		(): FieldDef[] =>
 			[
 				{
-					name: "textfield",
+					name: "text",
 					label,
 					hideLabel,
 					type: "text",
@@ -87,7 +89,11 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: {
+			text: "Rover",
+		},
+	}),
 	size: "sm",
 	type: "text",
 	placeholder: "placeholder",

--- a/containers/sb-8/stories/components/Field/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
@@ -31,6 +31,8 @@ export const Playground = ({
 	label,
 	disabled,
 	required,
+	prepop,
+	prepopData,
 	instructionText,
 	forceInstructionTooltip,
 	helperText,
@@ -44,7 +46,7 @@ export const Playground = ({
 	minHeight,
 	maxHeight,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const [mediaDrawer, setMediaDrawer] = useState<null | TextEditorOnImageParams>(null);
 	const [linkDrawer, setLinkDrawer] = useState<null | TextEditorOnLinkParams>(null);
 
@@ -146,7 +148,11 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: {
+			textEditor: "<h1>My Cat</h1><p><strong>Purchase</strong> the story of my cat <a target=\"\" rel=\"noopener noreferrer nofollow\" href=\"https://google.com\">here</a>!</p><p><img src=\"https://weareallaboutcats.com/wp-content/uploads/2017/09/happy-cat-300x200.jpg\" alt=\"Cat\"></p>",
+		},
+	}),
 	maxCharacters: 100,
 	autolink: true,
 	size: "lg",
@@ -159,7 +165,7 @@ Playground.args = {
 };
 
 Playground.argTypes = {
-	...commonFieldControls.args,
+	...commonFieldControls.argTypes,
 	maxCharacters: {
 		name: "Maximum Characters",
 	},

--- a/containers/sb-8/stories/components/Field/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldTextEditor/FormFieldTextEditor.stories.tsx
@@ -31,7 +31,6 @@ export const Playground = ({
 	label,
 	disabled,
 	required,
-	skeleton,
 	instructionText,
 	forceInstructionTooltip,
 	helperText,
@@ -118,7 +117,6 @@ export const Playground = ({
 				title="Text Editor Tiptap"
 				fields={tiptapFields}
 				buttons={renderButtons(handleSubmit)}
-				skeleton={skeleton}
 				fullHeight
 			/>
 			<Drawer

--- a/containers/sb-8/stories/components/Field/FormFieldTextEditor/LinkLibraryDrawer.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldTextEditor/LinkLibraryDrawer.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import React, { useCallback, useMemo } from "react";
+import React, { useMemo } from "react";
 import BulletinIcon from "@mui/icons-material/PushPin";
 import CalendarIcon from "@mui/icons-material/CalendarMonth";
 import ContactIcon from "@mui/icons-material/PermContactCalendar";
@@ -94,7 +94,11 @@ function LinkSelectionField(props: any) {
 }
 
 export function LinkLibraryDrawer({ onClose, updateLink, removeLink, url, newTab, text }: LinkLibraryDrawerProps): ReactElement {
-	const controller = useForm();
+	const controller = useForm({ data: {
+		newTab,
+		url,
+		text,
+	} });
 	const { handleSubmit } = controller;
 
 	const fields: FieldDef[] = useMemo(() => [
@@ -153,14 +157,6 @@ export function LinkLibraryDrawer({ onClose, updateLink, removeLink, url, newTab
 		});
 	});
 
-	const getFormValues = useCallback(async () => {
-		return {
-			newTab,
-			url,
-			text,
-		};
-	}, [newTab, url]);
-
 	return (
 		<DrawerWrapper>
 			<Form
@@ -169,7 +165,6 @@ export function LinkLibraryDrawer({ onClose, updateLink, removeLink, url, newTab
 				onBack={onClose}
 				buttons={buttons}
 				onSubmit={onSubmit}
-				getFormValues={getFormValues}
 				{...controller}
 			/>
 		</DrawerWrapper>

--- a/containers/sb-8/stories/components/Field/FormFieldTextEditor/MediaGalleryDrawer.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldTextEditor/MediaGalleryDrawer.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import React, { useCallback, useMemo } from "react";
+import React, { useMemo } from "react";
 import { DrawerWrapper, MediaGalleryChecked, MediaGalleryImage, MediaGalleryItem } from "./MediaGalleryDrawer.styled";
 import type { FieldDef, TextEditorOnImageParams } from "@root/components/Field";
 import Grid from "@mui/material/Grid";
@@ -68,7 +68,10 @@ function ImageSelectionField(props: any) {
 }
 
 export function MediaGalleryDrawer({ onClose, updateImage, alt, src }: MediaGalleryDrawerProps): ReactElement {
-	const controller = useForm();
+	const controller = useForm({ data: {
+		alt,
+		src,
+	} });
 	const { handleSubmit } = controller;
 
 	const fields: FieldDef[] = useMemo(() => [
@@ -111,13 +114,6 @@ export function MediaGalleryDrawer({ onClose, updateImage, alt, src }: MediaGall
 		});
 	});
 
-	const getFormValues = useCallback(async () => {
-		return {
-			alt,
-			src,
-		};
-	}, [alt, src]);
-
 	return (
 		<DrawerWrapper>
 			<Form
@@ -126,7 +122,6 @@ export function MediaGalleryDrawer({ onClose, updateImage, alt, src }: MediaGall
 				onBack={onClose}
 				buttons={buttons}
 				onSubmit={onSubmit}
-				getFormValues={getFormValues}
 				{...controller}
 			/>
 		</DrawerWrapper>

--- a/containers/sb-8/stories/components/Field/FormFieldTime/TimeField.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldTime/TimeField.stories.tsx
@@ -12,7 +12,6 @@ export default {
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
@@ -43,7 +42,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Time Field"
 				fields={fields}
-				skeleton={skeleton}
 			/>
 		</>
 	);

--- a/containers/sb-8/stories/components/Field/FormFieldTime/TimeField.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldTime/TimeField.stories.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from "react";
 import { useMemo } from "react";
 import type { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
-import { commonFieldControls, renderButtons } from "../../../../utils";
+import { commonFieldControls, parseDateControl, renderButtons } from "../../../../utils";
 
 export default {
 	title: "FormFields/FormFieldTimeField",
@@ -12,11 +12,13 @@ export default {
 export const Playground = ({
 	label,
 	required,
+	prepop,
+	prepopData,
 	disabled,
 	instructionText,
 	helperText,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? { ...prepopData, time: parseDateControl(prepopData?.time) } : {} });
 	const { state, handleSubmit } = controller;
 
 	const fields = useMemo(
@@ -48,7 +50,11 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: {
+			time: "11-30",
+		},
+	}),
 };
 
 Playground.argTypes = {

--- a/containers/sb-8/stories/components/Field/FormFieldToggle/FormFieldToggle.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldToggle/FormFieldToggle.stories.tsx
@@ -14,7 +14,6 @@ export default {
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
@@ -50,7 +49,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Toggle Field"
 				fields={fields}
-				skeleton={skeleton}
 			/>
 		</>
 	);

--- a/containers/sb-8/stories/components/Field/FormFieldToggle/FormFieldToggle.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldToggle/FormFieldToggle.stories.tsx
@@ -14,12 +14,14 @@ export default {
 export const Playground = ({
 	label,
 	required,
+	prepop,
+	prepopData,
 	disabled,
 	instructionText,
 	helperText,
 	toggleLabel,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, handleSubmit } = controller;
 
 	const fields: FieldDef[] = useMemo(
@@ -55,7 +57,11 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: {
+			toggle: true,
+		},
+	}),
 	toggleLabel: "Toggle Label",
 };
 

--- a/containers/sb-8/stories/components/Field/FormFieldUpload/FormFieldUpload.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldUpload/FormFieldUpload.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import type { ReactElement } from "react";
-import { useMemo, useCallback, useEffect, useState } from "react";
+import { useMemo, useCallback } from "react";
 import type { FieldDef } from "@root/components/Field";
 import Form, { useForm } from "@root/components/Form";
 import { commonFieldControls, renderButtons } from "../../../../utils";
@@ -11,41 +11,15 @@ export default {
 	title: "FormFields/FormFieldUpload",
 };
 
-const initialValues = {
-	uploadField: [
-		{
-			id: 0,
-			fileUrl: "https://res.cloudinary.com/simpleview/image/upload/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
-			thumbnailUrl: "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
-			size: 2630000,
-			name: "antiques.jpg",
-		},
-		{
-			id: 1,
-			fileUrl: "https://res.cloudinary.com/simpleview/image/upload/v1470248934/clients/grandrapids/042_3_0916_jpeg_ff098b68-f123-4354-b615-9b8301289103.jpg",
-			thumbnailUrl: "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1470248934/clients/grandrapids/042_3_0916_jpeg_ff098b68-f123-4354-b615-9b8301289103.jpg",
-			size: 760760,
-			name: "beer-flight.jpg",
-		},
-		{
-			id: 2,
-			fileUrl: "https://res.cloudinary.com/simpleview/image/upload/v1525706786/clients/grandrapids/IMG_4156_7a1894a8-6c36-43fa-87c2-f9593a9ccef2.jpg",
-			thumbnailUrl: "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1525706786/clients/grandrapids/IMG_4156_7a1894a8-6c36-43fa-87c2-f9593a9ccef2.jpg",
-			size: 1.67e+7,
-			name: "Bridges.jpg",
-		},
-	],
-};
-
 export const Playground = ({
 	label,
 	required,
-	skeleton,
 	disabled,
 	instructionText,
 	helperText,
 	limit,
 	prepop,
+	prepopData,
 	timeToLoad,
 	timeToDelete,
 	thumbnailUrl,
@@ -56,25 +30,10 @@ export const Playground = ({
 	maxFileSize,
 	maxTotalSize,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
-	const { state, handleSubmit, methods: { reset } } = controller;
+	const controller = useForm({ data: prepop ? prepopData : {} });
+	const { state, handleSubmit } = controller;
 
 	const accept = acceptCsv.trim() ? acceptCsv.split(",") : undefined;
-
-	const [loadReady, setLoadReady] = useState(false);
-
-	useEffect(() => {
-		const resetForm = async () => {
-			reset();
-			setLoadReady(true);
-		};
-
-		if (prepop) {
-			resetForm();
-		} else {
-			setLoadReady(false);
-		}
-	}, [reset, prepop]);
 
 	const onFileAdd: UploadFieldInputSettings["onFileAdd"] = useCallback(async ({ file, onChunkComplete, onUploadComplete }) => {
 		for (let i = 0; i < 10; i++) {
@@ -112,10 +71,6 @@ export const Playground = ({
 	const onFileDelete = useCallback(async () => {
 		await new Promise((resolve) => setTimeout(() => resolve(null), timeToDelete * 1000));
 	}, [timeToDelete]);
-
-	const getFormValues = useCallback(async () => ({
-		...initialValues,
-	}), []);
 
 	const fields = useMemo(
 		(): FieldDef[] =>
@@ -160,8 +115,6 @@ export const Playground = ({
 				buttons={renderButtons(handleSubmit)}
 				title="Upload Field"
 				fields={fields}
-				getFormValues={loadReady && getFormValues}
-				skeleton={skeleton}
 			/>
 			<pre>{JSON.stringify(state, null, "  ")}</pre>
 		</>
@@ -180,6 +133,31 @@ Playground.args = {
 	acceptCsv: "",
 	maxFileSize: "",
 	maxTotalSize: "",
+	prepopData: {
+		uploadField: [
+			{
+				id: 0,
+				fileUrl: "https://res.cloudinary.com/simpleview/image/upload/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
+				thumbnailUrl: "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
+				size: 2630000,
+				name: "antiques.jpg",
+			},
+			{
+				id: 1,
+				fileUrl: "https://res.cloudinary.com/simpleview/image/upload/v1470248934/clients/grandrapids/042_3_0916_jpeg_ff098b68-f123-4354-b615-9b8301289103.jpg",
+				thumbnailUrl: "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1470248934/clients/grandrapids/042_3_0916_jpeg_ff098b68-f123-4354-b615-9b8301289103.jpg",
+				size: 760760,
+				name: "beer-flight.jpg",
+			},
+			{
+				id: 2,
+				fileUrl: "https://res.cloudinary.com/simpleview/image/upload/v1525706786/clients/grandrapids/IMG_4156_7a1894a8-6c36-43fa-87c2-f9593a9ccef2.jpg",
+				thumbnailUrl: "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1525706786/clients/grandrapids/IMG_4156_7a1894a8-6c36-43fa-87c2-f9593a9ccef2.jpg",
+				size: 1.67e+7,
+				name: "Bridges.jpg",
+			},
+		],
+	},
 };
 
 Playground.argTypes = {

--- a/containers/sb-8/stories/components/Field/FormFieldUpload/FormFieldUpload.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldUpload/FormFieldUpload.stories.tsx
@@ -122,7 +122,33 @@ export const Playground = ({
 };
 
 Playground.args = {
-	...commonFieldControls.args,
+	...commonFieldControls.args({
+		prepopData: {
+			uploadField: [
+				{
+					id: 0,
+					fileUrl: "https://res.cloudinary.com/simpleview/image/upload/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
+					thumbnailUrl: "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
+					size: 2630000,
+					name: "antiques.jpg",
+				},
+				{
+					id: 1,
+					fileUrl: "https://res.cloudinary.com/simpleview/image/upload/v1470248934/clients/grandrapids/042_3_0916_jpeg_ff098b68-f123-4354-b615-9b8301289103.jpg",
+					thumbnailUrl: "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1470248934/clients/grandrapids/042_3_0916_jpeg_ff098b68-f123-4354-b615-9b8301289103.jpg",
+					size: 760760,
+					name: "beer-flight.jpg",
+				},
+				{
+					id: 2,
+					fileUrl: "https://res.cloudinary.com/simpleview/image/upload/v1525706786/clients/grandrapids/IMG_4156_7a1894a8-6c36-43fa-87c2-f9593a9ccef2.jpg",
+					thumbnailUrl: "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1525706786/clients/grandrapids/IMG_4156_7a1894a8-6c36-43fa-87c2-f9593a9ccef2.jpg",
+					size: 1.67e+7,
+					name: "Bridges.jpg",
+				},
+			],
+		},
+	}),
 	limit: "No limit",
 	timeToLoad: 2,
 	timeToDelete: 2,
@@ -133,31 +159,6 @@ Playground.args = {
 	acceptCsv: "",
 	maxFileSize: "",
 	maxTotalSize: "",
-	prepopData: {
-		uploadField: [
-			{
-				id: 0,
-				fileUrl: "https://res.cloudinary.com/simpleview/image/upload/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
-				thumbnailUrl: "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1434940819/clients/grandrapids/Bluedoor%20Antiques-1_c08c7c71-ac14-43df-81a1-30909c362030.jpg",
-				size: 2630000,
-				name: "antiques.jpg",
-			},
-			{
-				id: 1,
-				fileUrl: "https://res.cloudinary.com/simpleview/image/upload/v1470248934/clients/grandrapids/042_3_0916_jpeg_ff098b68-f123-4354-b615-9b8301289103.jpg",
-				thumbnailUrl: "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1470248934/clients/grandrapids/042_3_0916_jpeg_ff098b68-f123-4354-b615-9b8301289103.jpg",
-				size: 760760,
-				name: "beer-flight.jpg",
-			},
-			{
-				id: 2,
-				fileUrl: "https://res.cloudinary.com/simpleview/image/upload/v1525706786/clients/grandrapids/IMG_4156_7a1894a8-6c36-43fa-87c2-f9593a9ccef2.jpg",
-				thumbnailUrl: "https://res.cloudinary.com/simpleview/image/upload/c_fill,h_75,w_75/v1525706786/clients/grandrapids/IMG_4156_7a1894a8-6c36-43fa-87c2-f9593a9ccef2.jpg",
-				size: 1.67e+7,
-				name: "Bridges.jpg",
-			},
-		],
-	},
 };
 
 Playground.argTypes = {

--- a/containers/sb-8/stories/components/Form/DrawerForm.stories.tsx
+++ b/containers/sb-8/stories/components/Form/DrawerForm.stories.tsx
@@ -75,16 +75,6 @@ const Heading = styled.h2`
 	}
 `;
 
-async function getFormValues() {
-	return {
-		petsHeading: <Heading>Pets</Heading>,
-		destinationsHeading: <Heading>Destinations</Heading>,
-		novaScotia: { lat: 44.64933472911243, lng: -63.615047475871876 },
-		eiffelTower: { lat: 48.858348895100555, lng: 2.294492026111051 },
-		lochNessMonster: { lat: 57.27050873488408, lng: -4.493444954407284 },
-	};
-}
-
 const sections: SectionDef[] = [
 	{
 		title: "Text field sizes",
@@ -125,7 +115,13 @@ export const DrawerForm = ({
 	showSections,
 	drawWidth,
 }: typeof DrawerForm.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: {
+		petsHeading: <Heading>Pets</Heading>,
+		destinationsHeading: <Heading>Destinations</Heading>,
+		novaScotia: { lat: 44.64933472911243, lng: -63.615047475871876 },
+		eiffelTower: { lat: 48.858348895100555, lng: 2.294492026111051 },
+		lochNessMonster: { lat: 57.27050873488408, lng: -4.493444954407284 },
+	} });
 	const { handleSubmit } = controller;
 
 	const fields = useMemo<FieldDef[]>(() => [
@@ -363,7 +359,6 @@ export const DrawerForm = ({
 						fields={fields}
 						onBack={onCancel}
 						sections={showSections ? sections : undefined}
-						getFormValues={getFormValues}
 					/>
 				</div>
 			</Drawer>

--- a/containers/sb-8/stories/components/Form/Form.mdx
+++ b/containers/sb-8/stories/components/Form/Form.mdx
@@ -8,6 +8,7 @@ import * as stories from './Playground.stories';
 
 #### On this page
 * [Hook: useForm](#hook-useform)
+  * [Interface: `UseFormParams`](#interface-useformparams)
   * [Interface: `FormController`](#interface-formcontroller)
   * [The Form State](#the-form-state)
     * [Interface: `FormState`](#interface-formstate)
@@ -18,6 +19,9 @@ import * as stories from './Playground.stories';
 * [Basic Usage](#basic-usage)
   * [Submission](#submission)
     * [External Submission](#external-submission)
+  * [Prepopulated Values](#prepopulated-values)
+    * [Synchronous population](#synchronous-population)
+    * [Asynchronous population](#asynchronous-population)
   * [Layout](#layout)
     * [Interface: `SectionDef`](#interface-sectiondef)
 * [Form Fields](#form-fields)
@@ -29,7 +33,14 @@ import * as stories from './Playground.stories';
 The `Form` component should be used in conjunction with the `useForm` hook which provides a form controller instance for the form and its fields to work with. The form controller contains a number of methods that can be used to manipulate the state of the form as well as the state object itself to provide a way of performing side effects based on changes.
 
 ## Hook: useForm
-Invoking `useForm` returns an object that implements the `FormController` interface. The properties of the form controller should be spread into the `Form` component.
+Invoking `useForm` returns an object that implements the `FormController` interface. The properties of the form controller should be spread into the `Form` component. The `useForm` hook accepts a single parameter that meets the `UseFormParams` contract.
+
+#### Interface: UseFormParams
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `data` | `any` | The form values to be provided as initial `data` state. |
+| `skeleton` | `boolean` | Whether or not the form should be initially rendered in a "skeletonized" state. This value would likely be `true` if you intend to asynchronously load form data after the form has rendered. |
+| `disabled` | `boolean` | Whether or not the form should be initially rendered in a disabled state. This value would likely be `true` if you intend to asynchronously load form data after the form has rendered. |
 
 #### Interface: FormController
 | Name | Type | Description |
@@ -58,7 +69,7 @@ There is a `methods` object available on the form controller that contains a num
 #### Interface: FormMethods
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `setFormValues` | `(params: { values:  MosaicObject<any>; initial?: boolean }) => void` | Set the form values using an object of key-value pairs. Optionally have the form use these as initial values. |
+| `setFormValues` | `(params: { values: MosaicObject<any>; path?: FieldPath; skeleton?: boolean; disabled?: boolean; validate?: boolean; }) => void` | Set the form values using an object of key-value pairs. Optionally update some state values, for example to turn off skeletonization or re-enable the form after values have been fetched. |
 | `setFieldValue` | `(params: { name: string; value: unknown \| ((current: unknown) => unknown); validate?: boolean; touched?: boolean; }) => void` | Set the value for a given field. `value` can be a callback which returns the new value whose parameter is the current field value. Optionally validate the value after it has been set. Optionally mark the field as touched. |
 | `disableForm` | `(params: { disable?: boolean; }) => void` | Disables the form if `disable` is true and enables it if not. |
 | `addWait` | `(params?: { name: string; message: string; disableForm: boolean; }) => { remove: () => void }` | Adds a wait to the form, preventing submission with a message as a reason for prevention. Optionally disables the form whilst waiting. Returns an object containing a `remove` method which, when invoked, will remove the added wait. |
@@ -84,7 +95,6 @@ This is the top level component that will render the various parts of your form,
 | `sections` |  | `SectionDef[]` | Object containing all the configuration for every section of the form, including the layout in which fields will render. When no sections get passed fields will render 1 per row (see [SectionDef subsection](#sectiondef)). |
 | `dialogOpen` |  | `boolean` | When true, this flag will render a dialog with the message "You have unsaved changes. If you leave all your changes will be lost." This only works when the prop type = "drawer". |
 | `handleDialogClose` |  | `boolean` | Function that will get called when closing the dialog (see explanaition of the dialogOpen prop) |
-| `getFormValues` |  | `() => Promise<MosaicObject<any>>` | Function that should return an object representing the initial field values |
 | `buttons` |  | `ButtonProps[]` | Array of buttons that will be rendered at the top of the form, adjacent to the title (if one is provided). |
 | `scrollSpyThreshold` |  | `number` | The threshold at which the scroll spy should consider a section "active". Defaults to 0.15, meaning whenever the top of a section intersects the top 15% of the form's scrollable area. |
 | `fullHeight` |  | `boolean` | Whether to have the form stretch to the full height of it's parent. (`height: 100%`). Defaults to true. |
@@ -202,6 +212,78 @@ export default function App() {
         Click here to submit
       </button>
     </>
+  );
+}
+```
+
+### Prepopulated Values
+In some cases, you may need to prepopulate the form with values, for example if the form is used for editing an existing entry. There are two ways to populate the form values: synchronously and asynchronously.
+
+#### Synchronous population
+Use this method if the form values are readily-available by the time you are rendering the form component. This data will be used as the initial data in state only, so changes to this object will not result in the state changing to reflect it.
+
+```ts
+import { Form, useForm, FieldDef } from "@simpleview/sv-mosaic";
+
+const fields: FieldDef[] = [
+  {
+    name: "firstName",
+    label: "First Name",
+    type: "text",
+  },
+];
+
+export default function App() {
+  const controller = useForm({
+    data: {
+      firstName: "Terrence",
+    }
+  });
+
+  return (
+	<Form
+		{...controller}
+		fields={fields}
+	/>
+  );
+}
+```
+
+#### Asynchronous population
+Use this method if you need to run a query inside a side effect before populating the values. It's advised (though not required) to pass the `{ skeleton: true, disabled: true }` properties to your call to `useForm` to ensure the form is not interactable whilst you are performing your query. You can then re-enable the form and make it interactable through the use of `setFormValues`.
+
+```ts
+import { Form, useForm, FieldDef } from "@simpleview/sv-mosaic";
+
+const fields: FieldDef[] = [
+  {
+    name: "firstName",
+    label: "First Name",
+    type: "text",
+  },
+];
+
+export default function App() {
+  const controller = useForm({ skeleton: true, disabled: true });
+  const { methods: { setFormValues } } = controller;
+
+  useEffect(() => {
+    const prepopulate = async () => {
+      const data = await fetchMyFormValues();
+
+      setFormValues({
+        data,
+        skeleton: false,
+        disabled: false,
+      });
+    }
+  }, [setFormValues]);
+
+  return (
+	<Form
+		{...controller}
+		fields={fields}
+	/>
   );
 }
 ```

--- a/containers/sb-8/stories/components/Form/Playground.stories.tsx
+++ b/containers/sb-8/stories/components/Form/Playground.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import type { ReactElement } from "react";
-import { useEffect, useMemo, useCallback } from "react";
+import { useEffect, useMemo } from "react";
 import { nanoid } from "nanoid";
 
 // Utils
@@ -37,7 +37,7 @@ const createNewOption = async (newOptionLabel) => {
 	return newOption;
 };
 
-const prepopulateValues = {
+const prepopData = {
 	textField: "Text field from getFormValues",
 	check: [
 		{
@@ -117,8 +117,7 @@ const prepopulateValues = {
 export const Playground = ({
 	showState,
 	onBack,
-	prepopulate,
-	prepopulateDuration,
+	prepop,
 	showSave,
 	showCancel,
 	required,
@@ -126,9 +125,8 @@ export const Playground = ({
 	showSections,
 	collapsed,
 	containerHeight,
-	skeleton,
 }: typeof Playground.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: prepop ? prepopData : {} });
 	const { state, methods, handleSubmit } = controller;
 
 	const { reset } = methods;
@@ -417,23 +415,6 @@ export const Playground = ({
 
 	const sectionsAmount = useMemo(() => sections.slice(0, showSections), [sections, showSections]);
 
-	/**
-	 * Function that prepopulates the form. Includes
-	 * an artificial delay just to show how the form
-	 * is disabled while fields values are being resolved.
-	 */
-	const getFormValues = useCallback(async () => {
-		if (!prepopulate) {
-			return;
-		}
-
-		await new Promise((res) => setTimeout(res, prepopulateDuration * 1000));
-
-		return {
-			...prepopulateValues,
-		};
-	}, [prepopulate, prepopulateDuration]);
-
 	const buttons = useMemo<ButtonProps[]>(() => [
 		{
 			name: "reset",
@@ -441,10 +422,9 @@ export const Playground = ({
 			onClick: () => reset(),
 			color: "gray",
 			variant: "outlined",
-			show: !state.loadingInitial,
 		},
 		...renderButtons(handleSubmit, { showCancel, showSave }),
-	], [handleSubmit, reset, showCancel, showSave, state.loadingInitial]);
+	], [handleSubmit, reset, showCancel, showSave]);
 
 	return (
 		<div style={{ boxShadow: "0 1px 2px 0 rgb(0 0 0 / 0.05)", height: containerHeight }}>
@@ -457,10 +437,8 @@ export const Playground = ({
 				onBack={onBack ? () => alert("Cancelling, going back to previous site") : undefined}
 				description="Suspendisse condimentum iaculis velit id vestibulum."
 				fields={fields}
-				getFormValues={getFormValues}
 				sections={showSections > 0 ? sectionsAmount : undefined}
 				buttons={buttons}
-				skeleton={skeleton}
 			/>
 		</div>
 	);
@@ -469,8 +447,7 @@ export const Playground = ({
 Playground.args = {
 	showState: false,
 	onBack: false,
-	prepopulate: false,
-	prepopulateDuration: 2,
+	prepop: false,
 	showSave: true,
 	showCancel: true,
 	required: true,
@@ -488,11 +465,8 @@ Playground.argTypes = {
 	onBack: {
 		name: "Show Back Button",
 	},
-	prepopulate: {
+	prepop: {
 		name: "Prepopulate",
-	},
-	prepopulateDuration: {
-		name: "Prepopulate Duration",
 	},
 	showSave: {
 		name: "Show Save Button",

--- a/containers/sb-8/stories/components/Form/Playground.stories.tsx
+++ b/containers/sb-8/stories/components/Form/Playground.stories.tsx
@@ -14,7 +14,7 @@ import Form from "@root/components/Form";
 // Types
 import type { FieldDef } from "@root/components/Field";
 import { getOptionsCountries, getOptionsStates } from "@root/mock/options";
-import { columns, numberTableDefaultValue, rows } from "@root/components/Field/FormFieldNumberTable/numberTableUtils";
+import { columns, rows, mockNumberTableData } from "@root/mock/numberTable";
 
 import { ORIGINAL_BODY_MARGIN } from "@root/components/Form/stories/utils";
 import type { ButtonProps } from "@root/components/Button";
@@ -111,7 +111,7 @@ const prepopData = {
 		},
 	],
 	textEditor: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet augue augue.",
-	numberTable: numberTableDefaultValue,
+	numberTable: mockNumberTableData,
 };
 
 export const Playground = ({

--- a/containers/sb-8/stories/components/Form/Profile.stories.tsx
+++ b/containers/sb-8/stories/components/Form/Profile.stories.tsx
@@ -40,12 +40,6 @@ const factors = (number: number) => Array
 	.from(Array(number + 1), (_, i) => i)
 	.filter(i => number % i === 0);
 
-const getFormValues = async () => ({
-	workDates: {
-		current: true,
-	},
-});
-
 export const Profile = ({
 	showState,
 	hideSectionNav,
@@ -54,13 +48,16 @@ export const Profile = ({
 	showFirstName,
 	showLastName,
 	showInitials,
-	skeleton,
 	showAboutYou,
 	showContactDetails,
 	showYourWork,
 	showPreferences,
 }: typeof Profile.args): ReactElement => {
-	const controller = useForm();
+	const controller = useForm({ data: {
+		workDates: {
+			current: true,
+		},
+	} });
 	const { state, methods: { setFieldValue }, handleSubmit } = controller;
 
 	useEffect(() => {
@@ -538,8 +535,6 @@ export const Profile = ({
 					description="Give us some information to understand a little more about you."
 					sections={sections}
 					fields={fields}
-					skeleton={skeleton}
-					getFormValues={getFormValues}
 					hideSectionNav={hideSectionNav}
 				/>
 			</div>

--- a/containers/sb-8/stories/components/Form/SetFormValues.stories.tsx
+++ b/containers/sb-8/stories/components/Form/SetFormValues.stories.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import type { ReactElement } from "react";
+import { useEffect, useMemo } from "react";
+
+// Utils
+import { useForm } from "@root/components/Form";
+import { renderButtons } from "../../../utils";
+
+// Components
+import Form from "@root/components/Form";
+
+// Types
+import type { FieldDef } from "@root/components/Field";
+
+export default {
+	title: "Components/Form",
+};
+
+export const SetFormValues = (): ReactElement => {
+	const controller = useForm({
+		disabled: true,
+		skeleton: true,
+	});
+
+	const { methods: { setFormValues }, handleSubmit } = controller;
+
+	const fields = useMemo(
+		() : FieldDef[] =>
+			[
+				{
+					name: "firstName",
+					label: "First Name",
+					type: "text",
+				},
+			],
+		[],
+	);
+
+	useEffect(() => {
+		(async () => {
+			await new Promise((resolve) => setTimeout(() => resolve(null), 2000));
+			setFormValues({
+				values: { firstName: "Fluffy" },
+				skeleton: false,
+				disabled: false,
+			});
+		})();
+	}, [setFormValues]);
+
+	return (
+		<Form
+			{...controller}
+			buttons={renderButtons(handleSubmit)}
+			title="Profile"
+			description="Give us some information to understand a little more about you."
+			fields={fields}
+		/>
+	);
+};
+
+SetFormValues.args = {};
+
+SetFormValues.argTypes = {};

--- a/containers/sb-8/utils/commonFieldControl.ts
+++ b/containers/sb-8/utils/commonFieldControl.ts
@@ -3,7 +3,6 @@ const args = {
 	hideLabel: false,
 	disabled: false,
 	required: false,
-	skeleton: false,
 	prepop: false,
 	instructionText: "Instruction text",
 	forceInstructionTooltip: false,
@@ -22,9 +21,6 @@ const argTypes = {
 	},
 	required: {
 		name: "Required",
-	},
-	skeleton: {
-		name: "Skeleton",
 	},
 	prepop: {
 		name: "Prepopulate",

--- a/containers/sb-8/utils/commonFieldControl.ts
+++ b/containers/sb-8/utils/commonFieldControl.ts
@@ -1,13 +1,14 @@
-const args = {
+const args = <T = unknown>({ prepopData }: { prepopData?: T } = {}) => ({
 	label: "Label",
 	hideLabel: false,
 	disabled: false,
 	required: false,
 	prepop: false,
+	prepopData,
 	instructionText: "Instruction text",
 	forceInstructionTooltip: false,
 	helperText: "Helper text",
-};
+});
 
 const argTypes = {
 	label: {

--- a/containers/sb-8/utils/index.ts
+++ b/containers/sb-8/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./renderButtons";
 export * from "./toggleOptions";
 export * from "./commonFieldControl";
+export * from "./parseDateControl";

--- a/containers/sb-8/utils/parseDateControl.ts
+++ b/containers/sb-8/utils/parseDateControl.ts
@@ -1,0 +1,24 @@
+import { isValidDate } from "@root/utils/date";
+
+export function parseDateControl(input: string): string | Date | undefined {
+	if (!input) {
+		return;
+	}
+
+	const match = input.match(/^(?:(\d{4})-(\d{2})-(\d{2})-)?(\d{2})-(\d{2})?$/);
+	if (!match) {
+		return;
+	}
+
+	const parts = match.slice(1).filter(Boolean).map(Number);
+	if (parts.length === 2) {
+		return `${parts[0]}:${parts[1]}`;
+	}
+
+	const date = new Date(parts[0], parts[1] - 1, parts[2], parts[3], parts[4]);
+	if (!isValidDate(date)) {
+		return;
+	}
+
+	return date;
+}


### PR DESCRIPTION
# [MOS-1588](https://simpleviewtools.atlassian.net/browse/MOS-1588)

## Description
- (Form) useForm hook now accepts `data`, `skeleton` and `disabled` as parameters that will be used for initial form state.
- (Form) The parameter for `useForm().methods.setFormValues` now accepts `skeleton` and `disabled` properties that will be used to update the corresponding state properties if provided.
- **(BREAKING CHANGE)** (Form) Drops support for the `getFormValues` property.
- **(BREAKING CHANGE)** (Form) `disabled` state property is `false` by default instead of `true`, unless otherwise specified.
- See [documentation](https://simpleviewinc.github.io/sv-mosaic/sb8/master/?path=/docs/components-form--form#prepopulated-values) for new usage.

## Checklist
- [ ] I have written new tests to cover the changes
- [x] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1588]: https://simpleviewtools.atlassian.net/browse/MOS-1588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ