### PR TITLE
MOS-1550

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldCheckbox/FormFieldCheckbox.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldCheckbox/FormFieldCheckbox.tsx
@@ -8,7 +8,6 @@ import type { FormFieldCheckboxInputSettings, CheckboxData } from "./FormFieldCh
 
 import { StyledCheckboxList } from "./FormFieldCheckbox.styled";
 import { FormFieldCheckboxSkeleton } from "./FormFieldCheckboxSkeleton";
-import useMountWarning from "@root/utils/hooks/useMountWarning/useMountWarning";
 import useOptions from "@root/utils/hooks/useOptions/useOptions";
 
 const FormFieldCheckbox = (
@@ -26,16 +25,10 @@ const FormFieldCheckbox = (
 
 	const {
 		inputSettings: {
-			getOptions: optionsAsync,
-			options: providedOptions = optionsAsync,
+			options: providedOptions,
 			itemsPerColumn,
 		} = {},
 	} = fieldDef;
-
-	useMountWarning(
-		`The \`getOptions\` input setting (provided to the \`${fieldDef.name}\` field) is deprecated and will be removed in future versions. Use the \`options\` input setting instead.`,
-		Boolean(optionsAsync),
-	);
 
 	const { options, loading } = useOptions({
 		from: providedOptions,

--- a/containers/mosaic/src/components/Field/FormFieldCheckbox/FormFieldCheckboxTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldCheckbox/FormFieldCheckboxTypes.tsx
@@ -2,30 +2,12 @@ import type { CheckboxListProps } from "@root/components/CheckboxList";
 import type { FieldDefBase } from "@root/components/Field";
 import type { MosaicLabelValue } from "@root/types";
 
-interface FormFieldCheckboxLocalOptions extends Pick<CheckboxListProps, "itemsPerColumn"> {
+export interface FormFieldCheckboxInputSettings extends Pick<CheckboxListProps, "itemsPerColumn"> {
 	/**
 	* List of options
 	*/
 	options: MosaicLabelValue[] | (() => Promise<MosaicLabelValue[]>);
 }
-
-interface FormFieldCheckboxExternalOptions {
-	/**
-	 * Used to get options from db.
-	 *
-	 * @deprecated Use the `options` input setting instead.
-	 */
-	getOptions: () => Promise<MosaicLabelValue[]>;
-}
-
-type UnionKeys<T> = T extends T ? keyof T : never;
-
-type StrictUnionHelper<T, TAll> =
-	T extends any ? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>> : never;
-
-export type StrictUnion<T> = StrictUnionHelper<T, T>;
-
-export type FormFieldCheckboxInputSettings = StrictUnion<FormFieldCheckboxLocalOptions | FormFieldCheckboxExternalOptions>;
 
 export type CheckboxData = MosaicLabelValue[];
 

--- a/containers/mosaic/src/components/Field/FormFieldChips/FormFieldChips.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldChips/FormFieldChips.tsx
@@ -7,7 +7,6 @@ import type { MosaicFieldProps } from "@root/components/Field";
 import type { ChipData, FormFieldChipsInputSettings } from "./FormFieldChipsTypes";
 
 import useOptions from "@root/utils/hooks/useOptions/useOptions";
-import useMountWarning from "@root/utils/hooks/useMountWarning/useMountWarning";
 import Chip from "../../Chip";
 import { StyledChipGroup } from "./FormFieldChips.styled";
 import { FormFieldChipsSkeleton } from "./FormFieldChipsSkeleton";
@@ -25,15 +24,9 @@ const FormFieldChips = (props: MosaicFieldProps<"chip", FormFieldChipsInputSetti
 
 	const {
 		inputSettings: {
-			getOptions: optionsAsync,
-			options: providedOptions = optionsAsync,
+			options: providedOptions,
 		} = {},
 	} = fieldDef;
-
-	useMountWarning(
-		`The \`getOptions\` input setting (provided to the \`${fieldDef.name}\` field) is deprecated and will be removed in future versions. Use the \`options\` input setting instead.`,
-		Boolean(optionsAsync),
-	);
 
 	const { options, loading } = useOptions({
 		from: providedOptions,

--- a/containers/mosaic/src/components/Field/FormFieldChips/FormFieldChipsTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldChips/FormFieldChipsTypes.tsx
@@ -1,36 +1,12 @@
 import type { FieldDefBase } from "@root/components/Field";
 import type { MosaicLabelValue } from "@root/types";
-import type { StrictUnion } from "../FormFieldCheckbox";
 
-interface FormFieldChipsLocalOptions {
+export interface FormFieldChipsInputSettings {
 	/**
 	* List of options
 	*/
 	options: MosaicLabelValue[] | (() => Promise<MosaicLabelValue[]>);
-	/**
-	* Function to be executed as callback when an option is selected
-	 *
-	 * @deprecated Use the `onChange` prop on the field instead.
-	*/
-	onSelect?: (...args) => void;
 }
-
-interface FormFieldChipsExternalOptions {
-	/**
-	 * Used to get options from db.
-	 *
-	 * @deprecated Use the `options` input setting instead.
-	 */
-	getOptions: () => Promise<MosaicLabelValue[]>;
-	/**
-	* Function to be executed as callback when an option is selected
-	 *
-	 * @deprecated Use the `onChange` prop on the field instead.
-	*/
-	onSelect?: (...args) => void;
-}
-
-export type FormFieldChipsInputSettings = StrictUnion<FormFieldChipsLocalOptions | FormFieldChipsExternalOptions>;
 
 export type ChipData = MosaicLabelValue;
 

--- a/containers/mosaic/src/components/Field/FormFieldDropdown/FormFieldDropdown.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDropdown/FormFieldDropdown.tsx
@@ -8,7 +8,6 @@ import type { MosaicLabelValue } from "@root/types";
 import type { CustomPopperProps, DropdownData, DropdownInputSettings } from "./FormFieldDropdownTypes";
 
 import useOptions from "@root/utils/hooks/useOptions/useOptions";
-import useMountWarning from "@root/utils/hooks/useMountWarning/useMountWarning";
 import InputWrapper from "../../InputWrapper";
 import { StyledAutocomplete, StyledPopper, SingleDropdownWrapper } from "./FormFieldDropdown.styled";
 import testIds from "@root/utils/testIds";
@@ -28,15 +27,9 @@ const FormFieldDropdown = (props: MosaicFieldProps<"dropdown", DropdownInputSett
 
 	const {
 		inputSettings: {
-			getOptions: optionsAsync,
-			options: providedOptions = optionsAsync,
+			options: providedOptions,
 		} = {},
 	} = fieldDef;
-
-	useMountWarning(
-		`The \`getOptions\` input setting (provided to the \`${fieldDef.name}\` field) is deprecated and will be removed in future versions. Use the \`options\` input setting instead.`,
-		Boolean(optionsAsync),
-	);
 
 	const { options, loading } = useOptions({
 		from: providedOptions,

--- a/containers/mosaic/src/components/Field/FormFieldDropdown/FormFieldDropdownTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDropdown/FormFieldDropdownTypes.tsx
@@ -1,11 +1,8 @@
 import type { MosaicLabelValue } from "@root/types";
 import type { PopperProps } from "@mui/material/Popper";
-import type { StrictUnion } from "../FormFieldCheckbox";
 import type { FieldDefBase } from "@root/components/Field";
 
-export type DropdownInputSettings = StrictUnion<DropdownLocalOptions | DropdownExternalOptions>;
-
-interface DropdownLocalOptions {
+export interface DropdownInputSettings {
 	/**
 	 * Example text shown inside of the text field
 	 * portion of the dropdown.
@@ -16,20 +13,6 @@ interface DropdownLocalOptions {
 	 * dropdown.
 	 */
 	options: MosaicLabelValue[] | (() => Promise<MosaicLabelValue[]>);
-}
-
-interface DropdownExternalOptions {
-	/**
-	 * Example text shown inside of the text field
-	 * portion of the dropdown.
-	 */
-	placeholder?: string;
-	/**
-	 * Used to get options from db.
-	 *
-	 * @deprecated Use the `options` input setting instead.
-	 */
-	getOptions?: () => Promise<MosaicLabelValue[]>;
 }
 
 export type CustomPopperProps = {

--- a/containers/mosaic/src/components/Field/FormFieldRadio/FormFieldRadio.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldRadio/FormFieldRadio.tsx
@@ -7,7 +7,6 @@ import type { MosaicFieldProps } from "@root/components/Field";
 import type { RadioInputSettings, RadioData } from "./FormFieldRadioTypes";
 import type { MosaicLabelValue } from "@root/types";
 
-import useMountWarning from "@root/utils/hooks/useMountWarning/useMountWarning";
 import useOptions from "@root/utils/hooks/useOptions/useOptions";
 import RadioButton from "@root/components/RadioButton";
 import { StyledRadioGroup } from "./FormFieldRadio.styled";
@@ -25,15 +24,9 @@ const FormFieldRadio = (props: MosaicFieldProps<"radio", RadioInputSettings, Rad
 
 	const {
 		inputSettings: {
-			getOptions: optionsAsync,
-			options: providedOptions = optionsAsync,
+			options: providedOptions,
 		} = {},
 	} = fieldDef;
-
-	useMountWarning(
-		`The \`getOptions\` input setting (provided to the \`${fieldDef.name}\` field) is deprecated and will be removed in future versions. Use the \`options\` input setting instead.`,
-		Boolean(optionsAsync),
-	);
 
 	const { options, loading } = useOptions({
 		from: providedOptions,

--- a/containers/mosaic/src/components/Field/FormFieldRadio/FormFieldRadioTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldRadio/FormFieldRadioTypes.tsx
@@ -1,24 +1,12 @@
 import type { MosaicLabelValue } from "@root/types";
-import type { StrictUnion } from "../FormFieldCheckbox";
 import type { FieldDefBase } from "@root/components/Field";
 
-interface FormFieldRadioLocalOptions {
+export interface RadioInputSettings {
 	/**
 	* List of options
 	*/
 	options: MosaicLabelValue[] | (() => Promise<MosaicLabelValue[]>);
 }
-
-interface FormFieldRadioExternalOptions {
-	/**
-	 * Used to get options from db.
-	 *
-	 * @deprecated Use the `options` input setting instead.
-	 */
-	getOptions: () => Promise<MosaicLabelValue[]>;
-}
-
-export type RadioInputSettings = StrictUnion<FormFieldRadioLocalOptions | FormFieldRadioExternalOptions>;
 
 export type RadioData = MosaicLabelValue;
 


### PR DESCRIPTION
# [MOS-1550](https://simpleviewtools.atlassian.net/browse/MOS-1550)

## Description
- **(BREAKING CHANGE)** (chore) Removes deprecated getOptions input setting for applicable (optionable) field types.
- **(BREAKING CHANGE)** (ChipField) Removes the deprecated `onSelect` input setting.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes