### PR TITLE
MOS-1582

### DIFF
--- a/containers/mosaic/src/__tests__/components/Field/FormFieldAddress/utils/getAddressFields.test.ts
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldAddress/utils/getAddressFields.test.ts
@@ -106,7 +106,7 @@ describe(__dirname, () => {
 					type: "string",
 				},
 				required: undefined,
-				size: "sm",
+				size: "full",
 				type: "text",
 				validators:  [
 					{
@@ -132,7 +132,7 @@ describe(__dirname, () => {
 				label: "Address",
 				name: "address1",
 				required: undefined,
-				size: "lg",
+				size: "full",
 				type: AddressAutocompleteField,
 				inputSettings: {
 					getOptionsCountries: getOptionsCountries,
@@ -148,7 +148,7 @@ describe(__dirname, () => {
 				label: "Country",
 				name: "country",
 				required: undefined,
-				size: "sm",
+				size: "full",
 				type: "dropdown",
 				validates: [
 					{
@@ -164,7 +164,7 @@ describe(__dirname, () => {
 				label: "City",
 				name: "city",
 				required: undefined,
-				size: "sm",
+				size: "full",
 				type: "text",
 			},
 			{
@@ -174,7 +174,7 @@ describe(__dirname, () => {
 				},
 				label: "State",
 				name: "state",
-				size: "sm",
+				size: "full",
 				type: AddressStateField,
 			},
 			{
@@ -185,7 +185,7 @@ describe(__dirname, () => {
 				label: "Postal Code",
 				name: "postalCode",
 				required: undefined,
-				size: "sm",
+				size: "full",
 				type: "text",
 				validators: [
 					{
@@ -209,7 +209,7 @@ describe(__dirname, () => {
 				label: "Address",
 				name: "address1",
 				required: undefined,
-				size: "lg",
+				size: "full",
 				type: "text",
 			},
 			{
@@ -217,7 +217,7 @@ describe(__dirname, () => {
 				label: "Address Line 2",
 				hideLabel: true,
 				name: "address2",
-				size: "lg",
+				size: "full",
 				type: "text",
 			},
 			{
@@ -225,7 +225,7 @@ describe(__dirname, () => {
 				label: "Address Line 3",
 				hideLabel: true,
 				name: "address3",
-				size: "lg",
+				size: "full",
 				type: "text",
 			},
 			{
@@ -236,7 +236,7 @@ describe(__dirname, () => {
 				label: "Country",
 				name: "country",
 				required: undefined,
-				size: "sm",
+				size: "full",
 				type: "dropdown",
 				validates: [
 					{
@@ -252,7 +252,7 @@ describe(__dirname, () => {
 				label: "City",
 				name: "city",
 				required: undefined,
-				size: "sm",
+				size: "full",
 				type: "text",
 			},
 			{
@@ -262,7 +262,7 @@ describe(__dirname, () => {
 				},
 				label: "State",
 				name: "state",
-				size: "sm",
+				size: "full",
 				type: AddressStateField,
 			},
 			{
@@ -273,7 +273,7 @@ describe(__dirname, () => {
 				label: "Postal Code",
 				name: "postalCode",
 				required: undefined,
-				size: "sm",
+				size: "full",
 				type: "text",
 				validators: [
 					{

--- a/containers/mosaic/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocompleteField.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAddress/AddressAutocomplete/AddressAutocompleteField.tsx
@@ -8,7 +8,6 @@ import type { MosaicLabelValue } from "@root/types";
 import type { MosaicFieldProps } from "../../FieldTypes";
 import type { AddressAutocompleteInputSettings } from "./AddressAutocompleteTypes";
 
-import { Sizes } from "@root/theme";
 import FieldWrapper from "@root/components/FieldWrapper";
 import AddressAutocomplete from "./AddressAutocomplete";
 import { geocodeByAddress } from "react-places-autocomplete";
@@ -169,7 +168,7 @@ function AddressAutocompleteField(props: MosaicFieldProps<"text", AddressAutocom
 					label,
 					hideLabel: fieldDef.hideLabel,
 					required: fieldDef.required,
-					size: Sizes.lg,
+					size: fieldDef.size,
 				}}
 				path={path}
 				methods={props.methods}

--- a/containers/mosaic/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldAddress/AddressDrawer/AddressDrawer.tsx
@@ -87,10 +87,10 @@ const AddressDrawer = (props: AddressDrawerProps): ReactElement => {
 	const sections = useMemo<SectionDef[]>(() => [
 		{
 			fields: [
-				[["address1"]],
-				[["address2"]],
-				[["address3"]],
-				[["country"]],
+				[{ names: ["address1"], span: 4 }],
+				[{ names: ["address2"], span: 4 }],
+				[{ names: ["address3"], span: 4 }],
+				[{ names: ["country"], span: 2 }],
 				[["city"], ["state"], ["postalCode"]],
 				...(addressTypes ? [[["types"]]] : []),
 			],

--- a/containers/mosaic/src/components/Field/FormFieldAddress/utils/getAddressFields.ts
+++ b/containers/mosaic/src/components/Field/FormFieldAddress/utils/getAddressFields.ts
@@ -74,7 +74,7 @@ function getAddressFields({
 			required,
 			disabled,
 			label: "Address",
-			size: "lg",
+			size: "full",
 			// If a google maps API key has been provided,
 			// use an autocomplete field. Otherwise, just a
 			// standard text field will do.
@@ -94,7 +94,7 @@ function getAddressFields({
 			label: "Address Line 2",
 			hideLabel: true,
 			type: "text",
-			size: "lg",
+			size: "full",
 			disabled,
 		},
 		address3: {
@@ -102,14 +102,14 @@ function getAddressFields({
 			label: "Address Line 3",
 			hideLabel: true,
 			type: "text",
-			size: "lg",
+			size: "full",
 			disabled,
 		},
 		country: {
 			name: "country",
 			type: "dropdown",
 			label: "Country",
-			size: "sm",
+			size: "full",
 			required,
 			disabled,
 			inputSettings: {
@@ -124,7 +124,7 @@ function getAddressFields({
 			name: "city",
 			type: "text",
 			label: "City",
-			size: "sm",
+			size: "full",
 			required,
 			disabled,
 		},
@@ -132,7 +132,7 @@ function getAddressFields({
 			name: "state",
 			type: AddressStateField,
 			label: "State",
-			size: "sm",
+			size: "full",
 			disabled,
 			inputSettings: {
 				getOptionsStates,
@@ -142,7 +142,7 @@ function getAddressFields({
 			name: "postalCode",
 			type: "text",
 			label: "Postal Code",
-			size: "sm",
+			size: "full",
 			required,
 			disabled,
 			inputSettings: {

--- a/containers/mosaic/src/components/Field/FormFieldGroup/FormFieldGroup.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldGroup/FormFieldGroup.tsx
@@ -2,7 +2,6 @@ import React, { memo, useMemo } from "react";
 
 import type { MosaicFieldProps } from "@root/components/Field";
 import type { GroupData, GroupInputSettings } from "./FormFieldGroupTypes";
-import type { MosaicGridConfig } from "@root/types";
 
 import { StyledRows } from "@root/components/Form/Section/SectionStyled";
 import Row from "@root/components/Form/Row/Row";
@@ -20,7 +19,7 @@ const FormFieldGroup = ({
 	} = fieldDef;
 	const { fields } = inputSettings;
 
-	const layout = useMemo<MosaicGridConfig>(
+	const layout = useMemo<string[][][]>(
 		() => inputSettings.layout || fields.map(field => [[field.name]]),
 		[fields, inputSettings.layout],
 	);

--- a/containers/mosaic/src/components/Field/FormFieldGroup/FormFieldGroup.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldGroup/FormFieldGroup.tsx
@@ -19,7 +19,7 @@ const FormFieldGroup = ({
 	} = fieldDef;
 	const { fields } = inputSettings;
 
-	const layout = useMemo<string[][][]>(
+	const layout = useMemo<GroupInputSettings["layout"]>(
 		() => inputSettings.layout || fields.map(field => [[field.name]]),
 		[fields, inputSettings.layout],
 	);

--- a/containers/mosaic/src/components/Field/FormFieldGroup/FormFieldGroupTypes.ts
+++ b/containers/mosaic/src/components/Field/FormFieldGroup/FormFieldGroupTypes.ts
@@ -1,9 +1,8 @@
-import type { MosaicGridConfig } from "@root/types";
 import type { FieldDef, FieldDefBase } from "../FieldTypes";
 
 export interface GroupInputSettings {
 	fields: FieldDef[];
-	layout?: MosaicGridConfig;
+	layout?: string[][][];
 }
 
 export type GroupData = Record<string, any>;

--- a/containers/mosaic/src/components/Field/FormFieldGroup/FormFieldGroupTypes.ts
+++ b/containers/mosaic/src/components/Field/FormFieldGroup/FormFieldGroupTypes.ts
@@ -1,8 +1,9 @@
+import type { SectionPropTypes } from "@root/components/Form/Section";
 import type { FieldDef, FieldDefBase } from "../FieldTypes";
 
 export interface GroupInputSettings {
 	fields: FieldDef[];
-	layout?: string[][][];
+	layout?: SectionPropTypes["rows"];
 }
 
 export type GroupData = Record<string, any>;

--- a/containers/mosaic/src/components/Form/Col/Col.tsx
+++ b/containers/mosaic/src/components/Form/Col/Col.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import type { ColPropsTypes } from "./ColTypes";
 import { StyledCol } from "./ColStyled";
 import Field from "../Field/Field";
+import { FORM_GRID_SEGMENTS } from "@root/constants/form";
 
 const Col = (props: ColPropsTypes) => {
 	const {
@@ -19,8 +20,11 @@ const Col = (props: ColPropsTypes) => {
 		path,
 	} = props;
 
+	const gridStart = ((FORM_GRID_SEGMENTS / colsInRow) * colIdx) + 1;
+	const gridEnd = gridStart + (FORM_GRID_SEGMENTS / colsInRow);
+
 	return (
-		<StyledCol data-layout="column" $colsInRow={colsInRow}>
+		<StyledCol data-layout="column" $gridColumn={`${gridStart} / ${gridEnd}`}>
 			{col.map((field) => (
 				<Field
 					key={field}

--- a/containers/mosaic/src/components/Form/Col/Col.tsx
+++ b/containers/mosaic/src/components/Form/Col/Col.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { memo } from "react";
 
-import type { ColPropsTypes } from "./ColTypes";
+import type { ColLayout, ColPropsTypes } from "./ColTypes";
 import { StyledCol } from "./ColStyled";
 import Field from "../Field/Field";
 import { FORM_GRID_SEGMENTS } from "@root/constants/form";
@@ -20,12 +20,17 @@ const Col = (props: ColPropsTypes) => {
 		path,
 	} = props;
 
+	const { span = "auto", names }: ColLayout = Array.isArray(col) ? {
+		span: "auto",
+		names: col,
+	} : col;
+
 	const gridStart = ((FORM_GRID_SEGMENTS / colsInRow) * colIdx) + 1;
-	const gridEnd = gridStart + (FORM_GRID_SEGMENTS / colsInRow);
+	const gridEnd = gridStart + (span === "auto" ? FORM_GRID_SEGMENTS / colsInRow : span);
 
 	return (
 		<StyledCol data-layout="column" $gridColumn={`${gridStart} / ${gridEnd}`}>
-			{col.map((field) => (
+			{names.map((field) => (
 				<Field
 					key={field}
 					fieldName={field}

--- a/containers/mosaic/src/components/Form/Col/Col.tsx
+++ b/containers/mosaic/src/components/Form/Col/Col.tsx
@@ -14,6 +14,7 @@ const Col = (props: ColPropsTypes) => {
 		colIdx,
 		rowIdx,
 		sectionIdx,
+		gridMinWidth,
 		spacing,
 		methods,
 		skeleton,
@@ -29,7 +30,11 @@ const Col = (props: ColPropsTypes) => {
 	const gridEnd = gridStart + (span === "auto" ? FORM_GRID_SEGMENTS / colsInRow : span);
 
 	return (
-		<StyledCol data-layout="column" $gridColumn={`${gridStart} / ${gridEnd}`}>
+		<StyledCol
+			data-layout="column"
+			$gridColumn={`${gridStart} / ${gridEnd}`}
+			$gridMinWidth={gridMinWidth}
+		>
 			{names.map((field) => (
 				<Field
 					key={field}

--- a/containers/mosaic/src/components/Form/Col/ColStyled.tsx
+++ b/containers/mosaic/src/components/Form/Col/ColStyled.tsx
@@ -1,17 +1,22 @@
 import styled from "styled-components";
 import { CONTAINERS } from "@root/theme/theme";
+import { containerQuery } from "@root/utils/css";
 
-export const StyledCol = styled.div<{ $gridColumn?: string }>`
+export const StyledCol = styled.div<{ $gridMinWidth?: string; $gridColumn?: string }>`
 	display: flex;
 	flex-direction: column;
 	position: relative;
 	gap: 24px;
-
-	${({ $gridColumn }) => `
-		grid-column: ${$gridColumn};
-	`}
-
-
 	container-type: inline-size;
 	container-name: ${CONTAINERS.FORM_COL};
+
+	${({ $gridMinWidth, $gridColumn }) => $gridMinWidth ? `
+		@container form (min-width: ${$gridMinWidth}) {
+			grid-column: ${$gridColumn};
+		}
+	` : `
+		${containerQuery("md", "FORM")} {
+			grid-column: ${$gridColumn};
+		}
+	`}
 `;

--- a/containers/mosaic/src/components/Form/Col/ColStyled.tsx
+++ b/containers/mosaic/src/components/Form/Col/ColStyled.tsx
@@ -1,13 +1,16 @@
 import styled from "styled-components";
-import type { TransientProps } from "@root/types";
 import { CONTAINERS } from "@root/theme/theme";
-import type { ColPropsTypes } from "./ColTypes";
 
-export const StyledCol = styled.div<TransientProps<ColPropsTypes, "colsInRow">>`
+export const StyledCol = styled.div<{ $gridColumn?: string }>`
 	display: flex;
 	flex-direction: column;
 	position: relative;
 	gap: 24px;
+
+	${({ $gridColumn }) => `
+		grid-column: ${$gridColumn};
+	`}
+
 
 	container-type: inline-size;
 	container-name: ${CONTAINERS.FORM_COL};

--- a/containers/mosaic/src/components/Form/Col/ColTypes.ts
+++ b/containers/mosaic/src/components/Form/Col/ColTypes.ts
@@ -13,6 +13,7 @@ export interface ColPropsTypes {
 	colIdx?: number;
 	rowIdx?: number;
 	sectionIdx?: number;
+	gridMinWidth?: string;
 	spacing?: FormSpacing;
 	methods: FormMethods;
 	skeleton?: boolean;

--- a/containers/mosaic/src/components/Form/Col/ColTypes.ts
+++ b/containers/mosaic/src/components/Form/Col/ColTypes.ts
@@ -1,8 +1,13 @@
 import type { FieldDef } from "@root/components/Field";
 import type { FormSpacing, FormMethods, FieldPath } from "@root/components/Form";
 
+export interface ColLayout {
+	span?: "auto" | number;
+	names: string[];
+}
+
 export interface ColPropsTypes {
-	col: string[];
+	col: ColLayout | string[];
 	fieldsDef: FieldDef[];
 	colsInRow?: number;
 	colIdx?: number;

--- a/containers/mosaic/src/components/Form/FormTypes.tsx
+++ b/containers/mosaic/src/components/Form/FormTypes.tsx
@@ -1,21 +1,17 @@
 import type { ButtonProps } from "@root/components/Button";
 import type { FieldDef } from "@root/components/Field";
 import type { TitleWrapperProps } from "@root/components/Title";
-import type { MosaicGridConfig, MosaicToggle } from "@root/types";
+import type { MosaicToggle } from "@root/types";
 import type { FormMethods, FormStable, FormState } from "./useForm/types";
 import type { ReactNode } from "react";
+import type { SectionPropTypes } from "./Section";
 
 export type FormSpacing = "normal" | "compact";
-
-export interface Section {
+export interface SectionDef {
 	title?: string;
 	id?: string;
-}
-
-export interface SectionDef extends Section {
-	title?: string;
 	description?: string | JSX.Element;
-	fields: MosaicGridConfig;
+	fields: SectionPropTypes["rows"];
 	collapsed?: boolean;
 	show?: MosaicToggle<FormState>;
 	gridMinWidth?: string;

--- a/containers/mosaic/src/components/Form/Layout/layoutUtils.ts
+++ b/containers/mosaic/src/components/Form/Layout/layoutUtils.ts
@@ -11,7 +11,7 @@ export const generateLayout = ({ sections, fields }: { sections?: SectionDef[]; 
 		 * Filters out rows that have all-empty columns
 		 */
 		const rows = section.fields.filter(row => {
-			const columnsWithFields = row.filter(column => column.length);
+			const columnsWithFields = row.filter(column => Array.isArray(column) ? column.length : column.names.length);
 			return columnsWithFields.length;
 		});
 

--- a/containers/mosaic/src/components/Form/Row/Row.tsx
+++ b/containers/mosaic/src/components/Form/Row/Row.tsx
@@ -29,7 +29,11 @@ const Row = (props: RowPropTypes) => {
 	 * passing the field defs down
 	 */
 	const fieldDefsFlattened = useMemo(
-		() => row.flat().flat().map(fieldName => fieldsDef.find((fieldDef) => fieldName === fieldDef.name)),
+		() => row
+			.flat()
+			.map(column => typeof column === "string" ? column : column.names)
+			.flat()
+			.map(fieldName => fieldsDef.find((fieldDef) => fieldName === fieldDef.name)),
 		[fieldsDef, row],
 	);
 	const shownFields = useWrappedToggle(fieldDefsFlattened, state, "show", true);

--- a/containers/mosaic/src/components/Form/Row/Row.tsx
+++ b/containers/mosaic/src/components/Form/Row/Row.tsx
@@ -54,6 +54,7 @@ const Row = (props: RowPropTypes) => {
 						col={col}
 						fieldsDef={fieldsDef}
 						colsInRow={row.length}
+						gridMinWidth={gridMinWidth}
 						spacing={spacing}
 						methods={methods}
 						skeleton={skeleton}

--- a/containers/mosaic/src/components/Form/Row/RowStyled.tsx
+++ b/containers/mosaic/src/components/Form/Row/RowStyled.tsx
@@ -3,24 +3,25 @@ import styled from "styled-components";
 // Components
 import { containerQuery } from "@root/utils/css";
 import type { FormSpacing } from "../FormTypes";
+import { FORM_GRID_SEGMENTS } from "@root/constants/form";
 
 export const StyledRow = styled.div<{ $columns?: number; $gridMinWidth?: string; $spacing?: FormSpacing }>`
 	${({ $columns, $gridMinWidth, $spacing }) => $columns && `
 		display: grid;
-		grid-template-columns: repeat(1,minmax(0,1fr));
+		grid-template-columns: repeat(${FORM_GRID_SEGMENTS},minmax(0,1fr));
 		gap: ${$spacing === "compact" ? "16px" : "24px"};
 
-		${$gridMinWidth ? `
-			@container form (min-width: ${$gridMinWidth}) {
-				grid-template-columns: repeat(${$columns},minmax(0,1fr));
-			}
-		` : `
-			${containerQuery("md", "FORM")} {
-				grid-template-columns: repeat(${$columns > 1 ? 2 : 1},minmax(0,1fr));
-			}
-			${containerQuery("lg", "FORM")} {
-				grid-template-columns: repeat(${$columns},minmax(0,1fr));
-			}
-		`}
+		// ${$gridMinWidth ? `
+		// 	@container form (min-width: ${$gridMinWidth}) {
+		// 		grid-template-columns: repeat(${$columns},minmax(0,1fr));
+		// 	}
+		// ` : `
+		// 	${containerQuery("md", "FORM")} {
+		// 		grid-template-columns: repeat(${$columns > 1 ? 2 : 1},minmax(0,1fr));
+		// 	}
+		// 	${containerQuery("lg", "FORM")} {
+		// 		grid-template-columns: repeat(${$columns},minmax(0,1fr));
+		// 	}
+		// `}
 	`}
 `;

--- a/containers/mosaic/src/components/Form/Row/RowStyled.tsx
+++ b/containers/mosaic/src/components/Form/Row/RowStyled.tsx
@@ -8,20 +8,17 @@ import { FORM_GRID_SEGMENTS } from "@root/constants/form";
 export const StyledRow = styled.div<{ $columns?: number; $gridMinWidth?: string; $spacing?: FormSpacing }>`
 	${({ $columns, $gridMinWidth, $spacing }) => $columns && `
 		display: grid;
-		grid-template-columns: repeat(${FORM_GRID_SEGMENTS},minmax(0,1fr));
+		grid-template-columns: repeat(1,minmax(0,1fr));
 		gap: ${$spacing === "compact" ? "16px" : "24px"};
 
-		// ${$gridMinWidth ? `
-		// 	@container form (min-width: ${$gridMinWidth}) {
-		// 		grid-template-columns: repeat(${$columns},minmax(0,1fr));
-		// 	}
-		// ` : `
-		// 	${containerQuery("md", "FORM")} {
-		// 		grid-template-columns: repeat(${$columns > 1 ? 2 : 1},minmax(0,1fr));
-		// 	}
-		// 	${containerQuery("lg", "FORM")} {
-		// 		grid-template-columns: repeat(${$columns},minmax(0,1fr));
-		// 	}
-		// `}
+		${$gridMinWidth ? `
+			@container form (min-width: ${$gridMinWidth}) {
+				grid-template-columns: repeat(${FORM_GRID_SEGMENTS},minmax(0,1fr));
+			}
+		` : `
+			${containerQuery("md", "FORM")} {
+				grid-template-columns: repeat(${FORM_GRID_SEGMENTS},minmax(0,1fr));
+			}
+		`}
 	`}
 `;

--- a/containers/mosaic/src/components/Form/Row/RowTypes.ts
+++ b/containers/mosaic/src/components/Form/Row/RowTypes.ts
@@ -1,9 +1,10 @@
 import type { FieldPath, FormSpacing } from "@root/components/Form";
 import type { FieldDef } from "@root/components/Field";
 import type { FormMethods } from "../useForm/types";
+import type { ColPropsTypes } from "../Col";
 
 export interface RowPropTypes {
-	row: string[][];
+	row: ColPropsTypes["col"][];
 	fieldsDef: FieldDef[];
 	rowIdx?: number;
 	sectionIdx?: number;

--- a/containers/mosaic/src/components/Form/Section/Section.tsx
+++ b/containers/mosaic/src/components/Form/Section/Section.tsx
@@ -34,7 +34,10 @@ const Section = (props: SectionPropTypes) => {
 	const { state } = useContext(FormContext);
 
 	const fieldsHaveErrors = useCallback(() => {
-		const fieldNames = rows.flat(2);
+		const fieldNames = rows
+			.flat(2)
+			.map(column => typeof column === "string" ? column : column.names)
+			.flat();
 
 		if (fieldNames.some(name => state.errors[name])) {
 			return true;

--- a/containers/mosaic/src/components/Form/Section/SectionTypes.ts
+++ b/containers/mosaic/src/components/Form/Section/SectionTypes.ts
@@ -1,4 +1,4 @@
-import type { MosaicGridConfig, MosaicToggle } from "@root/types";
+import type { MosaicToggle } from "@root/types";
 import type { FormSpacing } from "@root/components/Form";
 import type { FieldDef } from "@root/components/Field";
 import type { FormMethods } from "../useForm/types";
@@ -8,7 +8,7 @@ export interface SectionPropTypes {
 	sectionIdx: number;
 	description: string | JSX.Element;
 	fieldsDef: FieldDef[];
-	rows: MosaicGridConfig;
+	rows: string[][][];
 	collapsed?: boolean;
 	show?: MosaicToggle;
 	registerRef?: (ref: HTMLElement) => () => void;

--- a/containers/mosaic/src/components/Form/Section/SectionTypes.ts
+++ b/containers/mosaic/src/components/Form/Section/SectionTypes.ts
@@ -2,13 +2,14 @@ import type { MosaicToggle } from "@root/types";
 import type { FormSpacing } from "@root/components/Form";
 import type { FieldDef } from "@root/components/Field";
 import type { FormMethods } from "../useForm/types";
+import type { RowPropTypes } from "../Row";
 
 export interface SectionPropTypes {
 	title: string;
 	sectionIdx: number;
 	description: string | JSX.Element;
 	fieldsDef: FieldDef[];
-	rows: string[][][];
+	rows: RowPropTypes["row"][];
 	collapsed?: boolean;
 	show?: MosaicToggle;
 	registerRef?: (ref: HTMLElement) => () => void;

--- a/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
@@ -45,24 +45,38 @@ function sanitizeFieldDefs(fields: FieldDef[], sections?: SectionDef[]): FieldDe
 						required,
 						disabled,
 						include: (subFields || defaultAddressFields).map(subField => {
-							// Labels "Address Line 1" field and hides it by default
-							if (typeof subField === "string" && subField === "address1") {
-								return {
-									name: "address1",
-									label: "Address Line 1",
-									hideLabel: true,
-								};
+
+							if (typeof subField === "string") {
+								if (subField === "address1") {
+									return {
+										name: "address1",
+										label: "Street Address",
+									};
+								}
+								if (subField === "state") {
+									return {
+										name: "state",
+										label: "State/Province/Region",
+									};
+								}
+								if (subField === "postalCode") {
+									return {
+										name: "postalCode",
+										label: "ZIP/Postal Code",
+									};
+								}
 							}
 
 							return subField;
 						}),
 					}),
 					layout: [
+						[{ names: ["country"], span: 2 }],
 						[{ names: ["address1"], span: 4 }],
 						[{ names: ["address2"], span: 4 }],
-						[{ names: ["address3"], span: 4 }],
-						[["country"], ["city"], []],
-						[["state"], ["postalCode"], []],
+						[{ names: ["city"], span: 2 }],
+						[{ names: ["state"], span: 2 }],
+						[{ names: ["postalCode"], span: 2 }],
 					],
 				},
 			};

--- a/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
@@ -9,7 +9,11 @@ import dateToTimeString from "@root/utils/date/dateToTimeString";
 function sanitizeFieldDefs(fields: FieldDef[], sections?: SectionDef[]): FieldDefSanitized[] {
 	if (sections) {
 		const fieldNames = fields.map(({ name }) => name);
-		const sectionFieldNames = sections.map(({ fields }) => fields).flat(3);
+		const sectionFieldNames = sections.map(({ fields }) => fields)
+			.flat(3)
+			.map(column => typeof column === "string" ? column : column.names)
+			.flat();
+
 		for (const sectionFieldName of sectionFieldNames ) {
 			if (!fieldNames.includes(sectionFieldName)) {
 				throw new Error(`Section references field \`${sectionFieldName}\`, which does not exist in list of field definitions.`);
@@ -54,9 +58,9 @@ function sanitizeFieldDefs(fields: FieldDef[], sections?: SectionDef[]): FieldDe
 						}),
 					}),
 					layout: [
-						[["address1"]],
-						[["address2"]],
-						[["address3"]],
+						[{ names: ["address1"], span: 4 }],
+						[{ names: ["address2"], span: 4 }],
+						[{ names: ["address3"], span: 4 }],
 						[["country"], ["city"], []],
 						[["state"], ["postalCode"], []],
 					],

--- a/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
@@ -53,6 +53,13 @@ function sanitizeFieldDefs(fields: FieldDef[], sections?: SectionDef[]): FieldDe
 							return subField;
 						}),
 					}),
+					layout: [
+						[["address1"]],
+						[["address2"]],
+						[["address3"]],
+						[["country"], ["city"], []],
+						[["state"], ["postalCode"], []],
+					],
 				},
 			};
 		}

--- a/containers/mosaic/src/constants/form.ts
+++ b/containers/mosaic/src/constants/form.ts
@@ -1,0 +1,1 @@
+export const FORM_GRID_SEGMENTS = 6;


### PR DESCRIPTION
# [MOS-1582](https://simpleviewtools.atlassian.net/browse/MOS-1582)

## Description
- (chore) Begin to retire MosaicGridConfig type.
- (Form) Adds support for explicitly defining a number of grid segments a column should span, falling back to an automatic span if none is provided.
- (AddressSingle) Update sub field layout and labels.
- (Form) Adjust responsive breakpoints at which form layout will fall back to normal stacking.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1582]: https://simpleviewtools.atlassian.net/browse/MOS-1582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ