### PR TITLE
MOS-1616

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldPhone/FormFieldPhone.styled.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldPhone/FormFieldPhone.styled.tsx
@@ -1,10 +1,9 @@
 import styled from "styled-components";
-
-// Theme
-import theme from "@root/theme";
 import Autocomplete from "@mui/material/Autocomplete";
-import { StyledTextField } from "../FormFieldText/FormFieldText.styled";
 import Popper from "@mui/material/Popper";
+
+import theme from "@root/theme";
+import { StyledTextField } from "../FormFieldText/FormFieldText.styled";
 
 export const StyledPhoneContainer = styled.div`
 	display: flex;
@@ -111,4 +110,20 @@ export const StyledFlagIcon = styled.img<{ $disabled?: boolean }>`
 	${({ $disabled }) => $disabled && `
 		opacity: .25;
 	`}
+`;
+
+export const StyledUnknownFlag = styled.div`
+	background: white;
+	box-shadow: 0 0 2px 0 rgba(0,0,0,.5);
+	height: 1rem;
+	width: 1.5rem;
+	color: ${theme.colors.gray600};
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	svg {
+		height: 0.8rem;
+		width: auto;
+	}
 `;

--- a/containers/mosaic/src/components/Field/FormFieldPhone/FormFieldPhoneTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldPhone/FormFieldPhoneTypes.tsx
@@ -12,8 +12,8 @@ export type PhoneCodeSelectProps = Omit<ComponentProps<"button">, "onChange"> & 
 }
 
 export interface PhoneCountryFlagProps {
-	country: string;
-	label: string;
+	country?: string;
+	label?: string;
 	disabled?: boolean;
 }
 export interface PhoneCodeAutocompleteProps {

--- a/containers/mosaic/src/components/Field/FormFieldPhone/PhoneCodeSelect.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldPhone/PhoneCodeSelect.tsx
@@ -49,9 +49,11 @@ function PhoneCodeSelect({
 					label={selectedOption?.label}
 					disabled={disabled}
 				/>
-				<span>
-					{`+${countryCallingCode}`}
-				</span>
+				{countryCallingCode && (
+					<span>
+						{`+${countryCallingCode}`}
+					</span>
+				)}
 				{autocompleteOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
 			</StyledFlagSelectButton>
 			<StyledPopper

--- a/containers/mosaic/src/components/Field/FormFieldPhone/PhoneCountryFlag.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldPhone/PhoneCountryFlag.tsx
@@ -1,16 +1,25 @@
 import React, { memo } from "react";
+import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
 
 import type { PhoneCountryFlagProps } from "./FormFieldPhoneTypes";
 
-import { StyledFlagIcon } from "./FormFieldPhone.styled";
+import { StyledFlagIcon, StyledUnknownFlag } from "./FormFieldPhone.styled";
 
 const flagUrl = "https://purecatamphetamine.github.io/country-flag-icons/3x2/{XX}.svg";
 
 function PhoneCountryFlag({
-	label,
+	label = "Unknown",
 	country,
 	disabled,
 }: PhoneCountryFlagProps) {
+	if (!country) {
+		return (
+			<StyledUnknownFlag>
+				<QuestionMarkIcon />
+			</StyledUnknownFlag>
+		);
+	}
+
 	return (
 		<StyledFlagIcon
 			src={flagUrl.replace("{XX}", country).replace("{xx}", country.toLowerCase())}


### PR DESCRIPTION
# [MOS-1616](https://simpleviewtools.atlassian.net/browse/MOS-1616)

## Description
- (PhoneField) Prevent throwing errors for numbers with unknown country codes, gracefully falling back to a question mark and no country code displayed.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1616]: https://simpleviewtools.atlassian.net/browse/MOS-1616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ