### PR TITLE
MOS-1628

### DIFF
--- a/containers/e2e-tests/pages/BasePage.ts
+++ b/containers/e2e-tests/pages/BasePage.ts
@@ -5,6 +5,7 @@ import { generateRandomId, rgbToHex } from "../utils/helpers/helper";
 import { getDateFormatted } from "../utils/helpers/dateHelper";
 import theme from "@simpleview/sv-mosaic/theme";
 import { testIds } from "@simpleview/sv-mosaic";
+import { ensureRgbCss } from "utils/helpers/color";
 export class BasePage {
 
 	readonly page: Page;
@@ -331,9 +332,9 @@ export class BasePage {
 
 	async validateTitleStylingOfLocator(titleLocator: Locator): Promise<void> {
 		expect(await this.getFontFamilyFromElement(titleLocator), "Checking Font Family of the Title").toContain("Roboto, sans-serif");
-		expect(await this.getFontSizeFromElement(titleLocator), "Checking Font Size of the Title").toBe("28px");
+		expect(await this.getFontSizeFromElement(titleLocator), "Checking Font Size of the Title").toBe("30px");
 		expect(await this.getFontWeightFromElement(titleLocator), "Checking Font Weight of the Title").toBe((theme.weight.medium).toString());
-		expect(await this.getColorFromElement(titleLocator), "Checking Font Color of the Title").toBe(theme.newColors.almostBlack["100"]);
+		expect(await this.getColorFromElement(titleLocator), "Checking Font Color of the Title").toBe(ensureRgbCss(theme.color.black));
 	}
 
 	async getZIndexFromElement(element: Locator): Promise<string> {

--- a/containers/e2e-tests/pages/Components/Dialog/DialogPage.ts
+++ b/containers/e2e-tests/pages/Components/Dialog/DialogPage.ts
@@ -16,7 +16,7 @@ export class DialogPage extends BasePage {
 		this.page = page;
 		this.openDialogButton = page.locator("button", { hasText: "Open Dialog" });
 		this.dialog = page.locator("div[role='dialog']");
-		this.dialogTitle = this.dialog.locator("div").first();
+		this.dialogTitle = this.dialog.getByRole("heading");
 		this.dialogText = this.dialog.locator("div").nth(1);
 	}
 }

--- a/containers/e2e-tests/playwright.config.ts
+++ b/containers/e2e-tests/playwright.config.ts
@@ -7,7 +7,7 @@ import { env } from "./utils/urls/environments";
 export default defineConfig({
 	testDir: "./tests",
 	forbidOnly: !!process.env.CI,
-	retries: 2,
+	retries: 0,
 	timeout: 30000,
 	reporter: [["html", { open: "never", outputFolder: "./playwright-report" }]],
 	workers: process.env.CI ? 2 : 4,

--- a/containers/e2e-tests/tests/Components/Button/buttonPlayground.spec.ts
+++ b/containers/e2e-tests/tests/Components/Button/buttonPlayground.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test";
 import { test, expect } from "@playwright/test";
 import { ButtonPage } from "../../../pages/Components/Button/ButtonPlaygroundPage";
-import theme from "@simpleview/sv-mosaic/theme";;
+import theme from "@simpleview/sv-mosaic/theme";
 import { buttonKnobs as knob, commonKnobs } from "../../../utils/data/knobs";
 import { hexToRgb } from "../../../utils/helpers/helper";
 

--- a/containers/e2e-tests/tests/Components/Card/cardPlayground.spec.ts
+++ b/containers/e2e-tests/tests/Components/Card/cardPlayground.spec.ts
@@ -2,7 +2,7 @@ import type { Page } from "@playwright/test";
 import { test, expect } from "@playwright/test";
 import { CardPage } from "../../../pages/Components/Card/CardPlaygroundPage";
 import { cardKnobs } from "../../../utils/data/knobs";
-import theme from "@simpleview/sv-mosaic/theme";;
+import theme from "@simpleview/sv-mosaic/theme";
 
 test.describe("Components - Card - Playground", () => {
 	let page: Page;
@@ -31,11 +31,11 @@ test.describe("Components - Card - Playground", () => {
 		await validateNumberOfButtons(cardKnobs.knobTopActions);
 	});
 
-	test("Validate font weight of the Content Title.", async () => {
-		expect(await cardPage.getFontWeightFromElement(cardPage.cardTitle)).toBe((theme.fontWeight.medium).toString());
+	test("Validate font weight of the Card Title.", async () => {
+		expect(await cardPage.getFontWeightFromElement(cardPage.cardTitle)).toBe((theme.weight.medium).toString());
 	});
 
-	test("Validate font size of the Content Title.", async () => {
+	test("Validate font size of the Card Title.", async () => {
 		expect(await cardPage.getFontSizeFromElement(cardPage.cardTitle)).toBe("16px");
 	});
 });

--- a/containers/e2e-tests/tests/Components/Content/Content.spec.ts
+++ b/containers/e2e-tests/tests/Components/Content/Content.spec.ts
@@ -1,8 +1,9 @@
 import type { Page } from "@playwright/test";
 import { test, expect } from "@playwright/test";
 import { ContentPage } from "../../../pages/Components/Content/ContentPage";
-import theme from "@simpleview/sv-mosaic/theme";;
+import theme from "@simpleview/sv-mosaic/theme";
 import { cardKnobs as knob, pageHeaderKnobs } from "../../../utils/data/knobs";
+import { ensureRgbCss } from "utils/helpers/color";
 
 test.describe("Components - Content - Playground", () => {
 	let page: Page;
@@ -15,7 +16,7 @@ test.describe("Components - Content - Playground", () => {
 	});
 
 	test("Validate Content title has almostBlack color.", async () => {
-		const expectedColor = theme.newColors.almostBlack["100"];
+		const expectedColor = ensureRgbCss(theme.color.black);
 		expect(await contentPage.getColorFromElement(contentPage.mainContentTitle)).toBe(expectedColor);
 	});
 
@@ -40,7 +41,7 @@ test.describe("Components - Content - Playground", () => {
 	});
 
 	test("Validate font weight of the Content Title.", async () => {
-		expect(await contentPage.getFontWeightFromElement(contentPage.mainContentTitle)).toBe((theme.fontWeight.medium).toString());
+		expect(await contentPage.getFontWeightFromElement(contentPage.mainContentTitle)).toBe((theme.weight.medium).toString());
 	});
 
 	test("Validate font size of the Content Title.", async () => {

--- a/containers/e2e-tests/tests/Components/Dialog/dialog.spec.ts
+++ b/containers/e2e-tests/tests/Components/Dialog/dialog.spec.ts
@@ -1,7 +1,8 @@
 import type { Page } from "@playwright/test";
 import { test, expect } from "@playwright/test";
 import { DialogPage } from "../../../pages/Components/Dialog/DialogPage";
-import theme from "@simpleview/sv-mosaic/theme";;
+import theme from "@simpleview/sv-mosaic/theme";
+import { ensureRgbCss } from "../../../utils/helpers/color";
 
 test.describe("Components - Dialog - Example", () => {
 	let page: Page;
@@ -14,18 +15,12 @@ test.describe("Components - Dialog - Example", () => {
 	});
 
 	test("Validate Dialog title has almostBlack color.", async () => {
-		const expectedColor = theme.newColors.almostBlack["100"];
+		const expectedColor = ensureRgbCss(theme.color.black);
+		const dialogTitle = dialogPage.page.getByRole("heading", { name: "Dialog title" });
 		if (!await dialogPage.dialog.isVisible()) {
 			await dialogPage.openDialogButton.click();
 		}
+		await expect(dialogTitle).toBeVisible();
 		expect(await dialogPage.getColorFromElement(dialogPage.dialogTitle)).toBe(expectedColor);
-	});
-
-	test("Validate Dialog text has grey2 in border bottom.", async () => {
-		const expectedColor = theme.newColors.grey2["100"];
-		if (!await dialogPage.dialog.isVisible()) {
-			await dialogPage.openDialogButton.click();
-		}
-		expect(await dialogPage.getSpecificBorderFromElement(dialogPage.dialogText, "bottom")).toContain(expectedColor);
 	});
 });

--- a/containers/e2e-tests/utils/helpers/color.ts
+++ b/containers/e2e-tests/utils/helpers/color.ts
@@ -1,0 +1,7 @@
+export function ensureRgbCss(maybeHex: string) {
+	const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(maybeHex);
+
+	return result
+		? `rgb(${parseInt(result[1], 16)}, ${parseInt(result[2], 16)}, ${parseInt(result[3], 16)})`
+		: maybeHex;
+}

--- a/containers/mosaic/src/components/Card/Card.styled.tsx
+++ b/containers/mosaic/src/components/Card/Card.styled.tsx
@@ -26,10 +26,6 @@ export const Title = styled.div`
 	}
 `;
 
-export const Count = styled.span`
-	font-size: ${theme.fontSize.text.md};
-`;
-
 export const CardButtonRow = styled(ButtonRow)`
 	margin-left: auto;
 `;

--- a/containers/mosaic/src/components/Card/Card.tsx
+++ b/containers/mosaic/src/components/Card/Card.tsx
@@ -31,7 +31,7 @@ const Card = (props: CardProps): ReactElement => {
 			<Heading data-testid={testIds.CARD_HEADING}>
 				<Title>
 					{TitleIcon && <TitleIcon data-testid={testIds.CARD_TITLE_ICON} />}
-					<Text maxLines={1} tag="h3" size="lg">{title}</Text>
+					<Text maxLines={1} tag="h3" size="lg" weight="medium">{title}</Text>
 				</Title>
 				{count !== undefined && (count !== 0 || showZeroCount) && (
 					<Text attrs={{ "data-testid": testIds.CARD_COUNT }} size="sm">

--- a/containers/mosaic/src/components/Card/Card.tsx
+++ b/containers/mosaic/src/components/Card/Card.tsx
@@ -10,11 +10,10 @@ import {
 	StyledHr,
 	Title,
 	Heading,
-	Count,
 	CardButtonRow,
 } from "./Card.styled";
 import ButtonRow from "../ButtonRow/ButtonRow";
-import { SubtitleText } from "../Typography";
+import { Text } from "../Typography";
 
 const Card = (props: CardProps): ReactElement => {
 	const {
@@ -32,14 +31,14 @@ const Card = (props: CardProps): ReactElement => {
 			<Heading data-testid={testIds.CARD_HEADING}>
 				<Title>
 					{TitleIcon && <TitleIcon data-testid={testIds.CARD_TITLE_ICON} />}
-					<SubtitleText maxLines={1}>{title}</SubtitleText>
+					<Text maxLines={1} tag="h3" size="lg">{title}</Text>
 				</Title>
 				{count !== undefined && (count !== 0 || showZeroCount) && (
-					<Count data-testid={testIds.CARD_COUNT}>
+					<Text attrs={{ "data-testid": testIds.CARD_COUNT }} size="sm">
 						(
 						{count}
 						)
-					</Count>
+					</Text>
 				)}
 				{topActions?.length > 0 && (
 					<CardButtonRow className="Foo" buttons={topActions} />

--- a/containers/mosaic/src/components/Content/Content.tsx
+++ b/containers/mosaic/src/components/Content/Content.tsx
@@ -53,7 +53,7 @@ const Content = (props: ContentProps): ReactElement => {
 			data-testid={testIds.CONTENT}
 		>
 			<TitleWrapper className={cardVariant ? "title-bar" : ""}>
-				<Text maxLines={1} tag="h3">{title}</Text>
+				<Text maxLines={1} tag="h3" size="lg" weight="medium">{title}</Text>
 				{buttons.length > 0 && (
 					<ButtonRow
 						buttons={buttons}

--- a/containers/mosaic/src/components/Content/Content.tsx
+++ b/containers/mosaic/src/components/Content/Content.tsx
@@ -14,7 +14,7 @@ import {
 } from "./Content.styled";
 import ButtonRow from "../ButtonRow/ButtonRow";
 import ContentField from "./ContentField";
-import { SubtitleText } from "../Typography";
+import { Text } from "../Typography";
 import { getToggle } from "@root/utils";
 import testIds from "@root/utils/testIds";
 
@@ -53,7 +53,7 @@ const Content = (props: ContentProps): ReactElement => {
 			data-testid={testIds.CONTENT}
 		>
 			<TitleWrapper className={cardVariant ? "title-bar" : ""}>
-				<SubtitleText maxLines={1}>{title}</SubtitleText>
+				<Text maxLines={1} tag="h3">{title}</Text>
 				{buttons.length > 0 && (
 					<ButtonRow
 						buttons={buttons}

--- a/containers/mosaic/src/components/DataView/DataViewColumDrawer/DataViewColumnDrawer.styled.ts
+++ b/containers/mosaic/src/components/DataView/DataViewColumDrawer/DataViewColumnDrawer.styled.ts
@@ -10,14 +10,6 @@ export const MutedText = styled.span`
 	font-style: italic;
 `;
 
-export const ColumnTitle = styled.h2`
-	color: ${theme.newColors.almostBlack["100"]};
-	font-size: ${theme.fontSize.text.xl};
-	font-weight: ${theme.weight.medium};
-	line-height: ${theme.line.xtight};
-	margin: 0px;
-`;
-
 export const StyledWrapper = styled.div`
 	display: flex;
 	margin-top: 30px;

--- a/containers/mosaic/src/components/DataView/DataViewColumDrawer/DataViewColumnDrawerContent.tsx
+++ b/containers/mosaic/src/components/DataView/DataViewColumDrawer/DataViewColumnDrawerContent.tsx
@@ -7,7 +7,6 @@ import type { ButtonProps } from "../../Button";
 import type { DataViewColumnDrawerContentProps } from "./DataViewColumnDrawerTypes";
 import {
 	StyledWrapper,
-	ColumnTitle,
 	MutedText,
 	NoColumns,
 } from "./DataViewColumnDrawer.styled";
@@ -17,6 +16,7 @@ import { StyledTextField } from "@root/components/Field/FormFieldText/FormFieldT
 import InputAdornment from "@mui/material/InputAdornment";
 import SearchIcon from "@mui/icons-material/Search";
 import { escapeRegexp } from "@root/utils/string/escapeRegexp";
+import { Text } from "@root/components/Typography";
 
 function DataViewColumnDrawerContent(props: DataViewColumnDrawerContentProps) {
 	const [activeColumns, setActiveColumns] = useState<string[]>(props.columns.map((val) => val.name));
@@ -128,7 +128,9 @@ function DataViewColumnDrawerContent(props: DataViewColumnDrawerContentProps) {
 					)}
 				</div>
 				<div className="right">
-					<ColumnTitle>{t("mosaic:DataView.column_order")}</ColumnTitle>
+					<Text size="xl" tag="h3" weight="medium">
+						{t("mosaic:DataView.column_order")}
+					</Text>
 					<DataViewColumnDrawerColumns
 						activeColumns={activeColumns}
 						allColumns={props.allColumns}

--- a/containers/mosaic/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectDropdownContent.tsx
+++ b/containers/mosaic/src/components/DataViewFilterMultiselect/DataViewFilterMultiselectDropdownContent.tsx
@@ -16,7 +16,7 @@ import DataViewFilterDropdownButtons from "@root/components/DataViewFilterDropdo
 import Button from "../Button";
 import ButtonRow from "../ButtonRow";
 import Spinner from "../Spinner";
-import { SubtitleText } from "../Typography";
+import { Text } from "../Typography";
 import { StyledWrapper, StyledComparisonHeader, StyledComparisonHelp } from "./DataViewFilterMultiselect.styled";
 import { StyledTextField } from "@root/components/Field/FormFieldText/FormFieldText.styled";
 import CheckboxList from "../CheckboxList";
@@ -185,9 +185,9 @@ function DataViewFilterMultiselectDropdownContent(props: DataViewFilterMultisele
 		comparisonDropdown = (
 			<div className="comparisonDropdown">
 				<StyledComparisonHeader>
-					<SubtitleText tag="h3">
+					<Text tag="h3">
 						{t("mosaic:DataView.comparison")}
-					</SubtitleText>
+					</Text>
 				</StyledComparisonHeader>
 				<ButtonRow>
 					<Button

--- a/containers/mosaic/src/components/Dialog/Dialog.styled.tsx
+++ b/containers/mosaic/src/components/Dialog/Dialog.styled.tsx
@@ -5,6 +5,7 @@ import Dialog from "@mui/material/Dialog";
 
 // Utils
 import theme from "@root/theme";
+import { Text } from "../Typography";
 
 export const StyledDialog = styled(Dialog)`
   z-index: 99999 !important;
@@ -30,10 +31,8 @@ export const StyledDialog = styled(Dialog)`
   }
 `;
 
-export const StyledDialogTitle = styled.div`
-  color: ${theme.newColors.almostBlack["100"]};
-  font-size: ${theme.fontSize.text.xl};
-  line-height: ${theme.line.xtight};
-  font-weight: ${theme.weight.medium};
-  padding: 40px 30px 24px 30px;
+export const StyledDialogTitle = styled(Text).attrs({ size: "xl", weight: "medium" })`
+  && {
+    padding: 40px 30px 24px 30px;
+  }
 `;

--- a/containers/mosaic/src/components/Dialog/Dialog.styled.tsx
+++ b/containers/mosaic/src/components/Dialog/Dialog.styled.tsx
@@ -31,7 +31,7 @@ export const StyledDialog = styled(Dialog)`
   }
 `;
 
-export const StyledDialogTitle = styled(Text).attrs({ size: "xl", weight: "medium" })`
+export const StyledDialogTitle = styled(Text).attrs({ tag: "h3", size: "xl", weight: "medium" })`
   && {
     padding: 40px 30px 24px 30px;
   }

--- a/containers/mosaic/src/components/Form/Top/Top.tsx
+++ b/containers/mosaic/src/components/Form/Top/Top.tsx
@@ -52,7 +52,7 @@ const Top = (props: TopProps): ReactElement => {
 								label={backLabel}
 							/>
 						)}
-						<DisplayText attrs={{ title }}>{title}</DisplayText>
+						<DisplayText attrs={{ title }} tag="h1">{title}</DisplayText>
 					</Title>
 				</Heading>
 				{description && <SmallDescription>{description}</SmallDescription>}

--- a/containers/mosaic/src/components/Form/Top/Top.tsx
+++ b/containers/mosaic/src/components/Form/Top/Top.tsx
@@ -22,7 +22,7 @@ import {
 import ButtonRow from "@root/components/ButtonRow/ButtonRow";
 import { Title } from "@root/components/Title/TitleWrapper.styled";
 import { TitleBackButton } from "@root/components/Title";
-import { TitleText } from "@root/components/Typography";
+import { DisplayText } from "@root/components/Typography";
 
 const Top = (props: TopProps): ReactElement => {
 	const {
@@ -52,7 +52,7 @@ const Top = (props: TopProps): ReactElement => {
 								label={backLabel}
 							/>
 						)}
-						<TitleText attrs={{ title }} >{title}</TitleText>
+						<DisplayText attrs={{ title }}>{title}</DisplayText>
 					</Title>
 				</Heading>
 				{description && <SmallDescription>{description}</SmallDescription>}

--- a/containers/mosaic/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/containers/mosaic/src/components/ThemeProvider/ThemeProvider.tsx
@@ -44,6 +44,7 @@ const elemDefs: ElemDef[] = [
 				font-size: 14px;
 				font-variation-settings:
 					"wdth" 100;
+				color: ${theme.color.black};
 			}
 		`.trim(),
 	},
@@ -69,6 +70,13 @@ const muiTheme = createTheme({
 				root: {
 					textTransform: "none",
 					fontSize: "inherit",
+				},
+			},
+		},
+		MuiPaper: {
+			styleOverrides: {
+				root: {
+					color: "inherit",
 				},
 			},
 		},

--- a/containers/mosaic/src/components/Title/TitleWrapper.tsx
+++ b/containers/mosaic/src/components/Title/TitleWrapper.tsx
@@ -6,7 +6,7 @@ import { memo } from "react";
 import { Description, Title } from "./TitleWrapper.styled";
 import type { TitleWrapperProps } from "./TitleWrapperTypes";
 import TitleBackButton from "./TitleBackButton";
-import { TitleText } from "../Typography";
+import { DisplayText } from "../Typography";
 
 const TitleWrapper = (props: TitleWrapperProps): ReactElement => {
 	const {
@@ -26,7 +26,7 @@ const TitleWrapper = (props: TitleWrapperProps): ReactElement => {
 						label={backLabel}
 					/>
 				)}
-				<TitleText attrs={{ title }} >{title}</TitleText>
+				<DisplayText attrs={{ title }} tag="h1">{title}</DisplayText>
 			</Title>
 			{description && <Description>{description}</Description>}
 		</>

--- a/containers/mosaic/src/components/TopSummary/TopSummary.styled.tsx
+++ b/containers/mosaic/src/components/TopSummary/TopSummary.styled.tsx
@@ -4,7 +4,6 @@ import theme from "../../theme";
 export const StyledTopSummary = styled.div`
   background: white;
   border-bottom: 2px solid ${theme.newColors.grey2["100"]};
-  color: ${theme.newColors.almostBlack["100"]};
   padding: 24px 24px 16px 24px;
   display: flex;
   gap: 24px;

--- a/containers/mosaic/src/components/Typography/BodyText.tsx
+++ b/containers/mosaic/src/components/Typography/BodyText.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import Typography from "./Typography";
 import type { TypographyProps } from "./TypographyTypes";
 
-const BodyText = (props: Omit<TypographyProps, "variant">): ReactElement => {
+const BodyText = (props: Omit<TypographyProps<"body">, "variant">): ReactElement => {
 	return <Typography {...props} variant="body" />;
 };
 

--- a/containers/mosaic/src/components/Typography/DisplayText.tsx
+++ b/containers/mosaic/src/components/Typography/DisplayText.tsx
@@ -4,8 +4,8 @@ import React from "react";
 import Typography from "./Typography";
 import type { TypographyProps } from "./TypographyTypes";
 
-const SubtitleText = (props: Omit<TypographyProps, "variant">): ReactElement => {
-	return <Typography {...props} variant="subtitle" />;
+const DisplayText = (props: Omit<TypographyProps<"display">, "variant">): ReactElement => {
+	return <Typography {...props} variant="display" />;
 };
 
-export default SubtitleText;
+export default DisplayText;

--- a/containers/mosaic/src/components/Typography/Text.tsx
+++ b/containers/mosaic/src/components/Typography/Text.tsx
@@ -4,8 +4,8 @@ import React from "react";
 import Typography from "./Typography";
 import type { TypographyProps } from "./TypographyTypes";
 
-const TitleText = (props: Omit<TypographyProps, "variant">): ReactElement => {
-	return <Typography {...props} variant="title" />;
+const Text = (props: Omit<TypographyProps<"text">, "variant">): ReactElement => {
+	return <Typography {...props} variant="text" />;
 };
 
-export default TitleText;
+export default Text;

--- a/containers/mosaic/src/components/Typography/Typography.styled.ts
+++ b/containers/mosaic/src/components/Typography/Typography.styled.ts
@@ -1,26 +1,124 @@
-import type { RuleSet } from "styled-components";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import theme from "@root/theme";
 
-import type { TypographyVariant } from "./TypographyTypes";
-import type { ColorTypes } from "../Button";
+import type { Theme } from "@root/theme/theme";
+import type { TypographyVariantSize, TypographyVariant, TypographyVariantSizeMap } from "./TypographyTypes";
 import type { Properties } from "csstype";
-
-interface BaseProps {
+interface BaseProps<T extends TypographyVariant> {
 	$maxLines?: number;
-	$color?: ColorTypes;
+	$color?: string;
 	$breakAll?: boolean;
 	$whiteSpace?: Properties["whiteSpace"];
+	$size?: TypographyVariantSize<T>;
+	$weight?: keyof Theme["weight"];
 }
 
-export const base = css<BaseProps>`
-	margin: 0;
-	padding: 0;
-	font-size: inherit;
-    line-height: 1.5em;
+/**
+ * It seems counter intuitive to remap the font sizes like this, but
+ * my gut is telling me not to tightly couple the size of the Typograhpy
+ * component with the font sizes in the theme object.
+ */
+const variantStyleMap: TypographyVariantSizeMap = {
+	body: {
+		xs: {
+			fontSize: theme.fontSize.body["xs"],
+			lineHeight: theme.line["8xloose"],
+		},
+		sm: {
+			fontSize: theme.fontSize.body["sm"],
+			lineHeight: theme.line["3xloose"],
+		},
+		md: {
+			fontSize: theme.fontSize.body["md"],
+			lineHeight: theme.line["2xloose"],
+		},
+		lg: {
+			fontSize: theme.fontSize.body["lg"],
+			lineHeight: theme.line["3xloose"],
+		},
+		xl: {
+			fontSize: theme.fontSize.body["xl"],
+			lineHeight: theme.line["4xloose"],
+		},
+		"2xl": {
+			fontSize: theme.fontSize.body["2xl"],
+			lineHeight: theme.line["3xloose"],
+		},
+	},
+	display: {
+		xs: {
+			fontSize: theme.fontSize.display["xs"],
+			lineHeight: theme.line.loose,
+		},
+		sm: {
+			fontSize: theme.fontSize.display["sm"],
+			lineHeight: theme.line.snug,
+		},
+		md: {
+			fontSize: theme.fontSize.display["md"],
+			lineHeight: theme.line.xtight,
+		},
+		lg: {
+			fontSize: theme.fontSize.display["lg"],
+			lineHeight: theme.line.tight,
+		},
+		xl: {
+			fontSize: theme.fontSize.display["xl"],
+			lineHeight: theme.line["2xtight"],
+		},
+		"2xl": {
+			fontSize: theme.fontSize.display["2xl"],
+			lineHeight: theme.line.tight,
+		},
+	},
+	text: {
+		xs: {
+			fontSize: theme.fontSize.text["xs"],
+			lineHeight: theme.line.xloose,
+		},
+		sm: {
+			fontSize: theme.fontSize.text["sm"],
+			lineHeight: theme.line.loose,
+		},
+		md: {
+			fontSize: theme.fontSize.text["md"],
+			lineHeight: theme.line.normal,
+		},
+		lg: {
+			fontSize: theme.fontSize.text["lg"],
+			lineHeight: theme.line.tight,
+		},
+		xl: {
+			fontSize: theme.fontSize.text["xl"],
+			lineHeight: theme.line.xtight,
+		},
+		"2xl": {
+			fontSize: theme.fontSize.text["2xl"],
+			lineHeight: theme.line.relaxed,
+		},
+	},
+};
 
-    ${({ $maxLines, $breakAll, $color, $whiteSpace }) => {
-		const parts = [
+export function getComponent<T extends TypographyVariant>() {
+	return styled.div<BaseProps<T> & { $variant: T }>(({
+		$variant,
+		$size,
+		$maxLines,
+		$breakAll,
+		$color,
+		$whiteSpace,
+		$weight,
+	}) => {
+		const { fontSize, lineHeight } = variantStyleMap[$variant][$size];
+
+		const parts: string[] = [
+			`
+				margin: 0;
+				padding: 0;
+				font-size: ${fontSize};
+				font-weight: ${theme.weight[$weight]};
+				line-height: ${lineHeight};
+			`,
 			$maxLines && `
 				display: -webkit-box;
 				-webkit-line-clamp: ${$maxLines};
@@ -31,35 +129,13 @@ export const base = css<BaseProps>`
 				word-break: break-all;
 			`,
 			$color && `
-				color: ${theme.colors[$color]};
+				color: ${$color};
 			`,
 			$whiteSpace && `
 				white-space: ${$whiteSpace};
 			`,
 		];
 
-		return parts.filter(Boolean).join("\n");
-	}}
-`;
-export const variants: Record<TypographyVariant, RuleSet> = {
-	title: css`
-        font-size: 28px;
-        font-weight: ${theme.weight.medium};
-		color: ${theme.newColors.almostBlack["100"]};
-        line-height: 1.2em;
-	`,
-	subtitle: css`
-        font-size: 16px;
-        font-weight: ${theme.weight.medium};
-		color: ${theme.newColors.almostBlack["100"]};
-	`,
-	body: css`
-        font-size: 16px;
-	`,
-	none: css``,
-};
-
-export const Component = styled.div<BaseProps & { $variant: TypographyVariant }>`
-	${base}
-	${({ $variant }) => $variant ? variants[$variant] : ""}
-`;
+		return parts.filter(Boolean).map(str => str.trim()).join("\n");
+	});
+}

--- a/containers/mosaic/src/components/Typography/Typography.styled.ts
+++ b/containers/mosaic/src/components/Typography/Typography.styled.ts
@@ -99,43 +99,41 @@ const variantStyleMap: TypographyVariantSizeMap = {
 	},
 };
 
-export function getComponent<T extends TypographyVariant>() {
-	return styled.div<BaseProps<T> & { $variant: T }>(({
-		$variant,
-		$size,
-		$maxLines,
-		$breakAll,
-		$color,
-		$whiteSpace,
-		$weight,
-	}) => {
-		const { fontSize, lineHeight } = variantStyleMap[$variant][$size];
+export const StyledTypography = styled.div<BaseProps<TypographyVariant> & { $variant: TypographyVariant }>(({
+	$variant,
+	$size,
+	$maxLines,
+	$breakAll,
+	$color,
+	$whiteSpace,
+	$weight,
+}) => {
+	const { fontSize, lineHeight } = variantStyleMap[$variant][$size];
 
-		const parts: string[] = [
-			`
-				margin: 0;
-				padding: 0;
-				font-size: ${fontSize};
-				font-weight: ${theme.weight[$weight]};
-				line-height: ${lineHeight};
-			`,
-			$maxLines && `
-				display: -webkit-box;
-				-webkit-line-clamp: ${$maxLines};
-				-webkit-box-orient: vertical;
-				overflow: hidden;
-			`,
-			$breakAll && `
-				word-break: break-all;
-			`,
-			$color && `
-				color: ${$color};
-			`,
-			$whiteSpace && `
-				white-space: ${$whiteSpace};
-			`,
-		];
+	const parts: string[] = [
+		`
+			margin: 0;
+			padding: 0;
+			font-size: ${fontSize};
+			font-weight: ${theme.weight[$weight]};
+			line-height: ${lineHeight};
+		`,
+		$maxLines && `
+			display: -webkit-box;
+			-webkit-line-clamp: ${$maxLines};
+			-webkit-box-orient: vertical;
+			overflow: hidden;
+		`,
+		$breakAll && `
+			word-break: break-all;
+		`,
+		$color && `
+			color: ${$color};
+		`,
+		$whiteSpace && `
+			white-space: ${$whiteSpace};
+		`,
+	];
 
-		return parts.filter(Boolean).map(str => str.trim()).join("\n");
-	});
-}
+	return parts.filter(Boolean).map(str => str.trim()).join("\n");
+});

--- a/containers/mosaic/src/components/Typography/Typography.tsx
+++ b/containers/mosaic/src/components/Typography/Typography.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import type { ReactElement } from "react";
 
 import type { TypographyProps, TypographyVariantSize, TypographyTag, TypographyVariant } from "./TypographyTypes";
-import { getComponent } from "./Typography.styled";
+import { StyledTypography } from "./Typography.styled";
 import type { Theme } from "@root/theme/theme";
 
 const defaultTagMap: Record<TypographyVariant, TypographyTag> = {
@@ -37,22 +37,21 @@ export default function Typography<T extends TypographyVariant>({
 	weight = defaultWeightMap[variant],
 }: TypographyProps<T>): ReactElement {
 	const tag = providedTag || defaultTagMap[variant];
-	const Component = getComponent<T>();
 
 	return (
-		<Component
+		<StyledTypography
 			{...attrs}
 			className={className}
 			$variant={variant}
 			$maxLines={maxLines}
 			$color={color}
 			$breakAll={breakAll}
-			$size={size}
+			$size={size as any}
 			$weight={weight}
 			title={title !== undefined ? title : typeof children === "string" ? children : undefined}
 			as={tag}
 		>
 			{children}
-		</Component>
+		</StyledTypography>
 	);
 }

--- a/containers/mosaic/src/components/Typography/Typography.tsx
+++ b/containers/mosaic/src/components/Typography/Typography.tsx
@@ -1,28 +1,43 @@
 import * as React from "react";
 import type { ReactElement } from "react";
 
-import type { TypographyProps, TypographyTag, TypographyVariant } from "./TypographyTypes";
-import { Component } from "./Typography.styled";
+import type { TypographyProps, TypographyVariantSize, TypographyTag, TypographyVariant } from "./TypographyTypes";
+import { getComponent } from "./Typography.styled";
+import type { Theme } from "@root/theme/theme";
 
 const defaultTagMap: Record<TypographyVariant, TypographyTag> = {
-	title: "h1",
-	subtitle: "h3",
 	body: "div",
-	none: "span",
+	display: "div",
+	text: "span",
 };
 
-export default function Typography({
+const defaultSizeMap: {[T in TypographyVariant]: TypographyVariantSize<T>} = {
+	body: "md",
+	display: "sm",
+	text: "md",
+};
+
+const defaultWeightMap: Record<TypographyVariant, keyof Theme["weight"]> = {
+	body: "regular",
+	display: "medium",
+	text: "inherit",
+};
+
+export default function Typography<T extends TypographyVariant>({
 	children,
 	attrs = {},
 	tag: providedTag,
-	variant = "none",
+	variant = "text" as T,
 	maxLines,
 	color,
 	breakAll,
 	className,
 	title,
-}: TypographyProps): ReactElement {
+	size = defaultSizeMap[variant],
+	weight = defaultWeightMap[variant],
+}: TypographyProps<T>): ReactElement {
 	const tag = providedTag || defaultTagMap[variant];
+	const Component = getComponent<T>();
 
 	return (
 		<Component
@@ -32,6 +47,8 @@ export default function Typography({
 			$maxLines={maxLines}
 			$color={color}
 			$breakAll={breakAll}
+			$size={size}
+			$weight={weight}
 			title={title !== undefined ? title : typeof children === "string" ? children : undefined}
 			as={tag}
 		>

--- a/containers/mosaic/src/components/Typography/TypographyTypes.ts
+++ b/containers/mosaic/src/components/Typography/TypographyTypes.ts
@@ -1,17 +1,27 @@
 import type { ReactNode } from "react";
 import type { MosaicObject } from "../../types";
-import type { ColorTypes } from "../Button";
 import type { Properties } from "csstype";
+import type { Theme } from "@root/theme/theme";
 
-export type TypographyVariant = "title" | "subtitle" | "body" | "none";
+export type TypographyVariant = keyof Theme["fontSize"];
 
 export type TypographyTag = string;
 
-export interface TypographyProps {
+export type TypographyVariantSize<T extends TypographyVariant> = keyof Theme["fontSize"][T]
+
+export type TypographyVariantSizeMap = {
+	[V in TypographyVariant]: {
+		[S in keyof Theme["fontSize"][V]]: {
+			fontSize: Theme["fontSize"][V][S];
+			lineHeight: Theme["line"][keyof Theme["line"]];
+		}
+	};
+};
+export interface TypographyProps<T extends TypographyVariant> {
 	/**
 	 * Controls the look of the typography
 	 */
-	variant?: TypographyVariant;
+	variant?: T;
 	/**
 	 * The HTML element to use.
 	 */
@@ -47,5 +57,14 @@ export interface TypographyProps {
 	/**
 	 * The text colour of the typography
 	 */
-	color?: ColorTypes;
+	color?: string;
+	/**
+	 * The size of the text, which is determined by the variant
+	 */
+	size?: TypographyVariantSize<T>;
+	/**
+	 * The weight of the font. Defaults to different weights depending
+	 * on the Typography variant.
+	 */
+	weight?: keyof Theme["weight"];
 }

--- a/containers/mosaic/src/components/Typography/index.ts
+++ b/containers/mosaic/src/components/Typography/index.ts
@@ -1,6 +1,6 @@
 export { default } from "./Typography";
 export * from "./TypographyTypes";
 
-export { default as TitleText } from "./TitleText";
-export { default as SubtitleText } from "./SubtitleText";
+export { default as DisplayText } from "./DisplayText";
+export { default as Text } from "./Text";
 export { default as BodyText } from "./BodyText";

--- a/containers/mosaic/src/theme/index.ts
+++ b/containers/mosaic/src/theme/index.ts
@@ -1,3 +1,3 @@
-export { default, BREAKPOINTS } from "./theme";
+export { default, BREAKPOINTS, Theme } from "./theme";
 export { default as Sizes } from "./sizes";
 export { default as TridentIcon } from "./TridentIcon";

--- a/containers/mosaic/src/theme/theme.ts
+++ b/containers/mosaic/src/theme/theme.ts
@@ -323,6 +323,7 @@ const line = {
 };
 
 const weight = {
+	inherit: "inherit",
 	/**
 	 * Font weight 400
 	 */
@@ -430,7 +431,7 @@ const rounded = {
 	full: "9999px",
 };
 
-export default {
+const theme = {
 	...legacyThemeProps,
 	fontSize,
 	line,
@@ -441,4 +442,8 @@ export default {
 	spacing,
 	color,
 	rounded,
-};
+} as const;
+
+export type Theme = typeof theme;
+
+export default theme;

--- a/containers/sb-8/stories/components/Spinner/Spinner.stories.tsx
+++ b/containers/sb-8/stories/components/Spinner/Spinner.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import type { ReactElement } from "react";
 import Spinner from "#mosaic/components/Spinner";
-import { SubtitleText } from "#mosaic/components/Typography";
+import { Text } from "#mosaic/components/Typography";
 
 export default {
 	title: "Components/Spinner",
@@ -30,9 +30,9 @@ Playground.argTypes = {
 export const KitchenSink = (): ReactElement => {
 	return (
 		<>
-			<SubtitleText tag="h3">Spinner that spins indifinitely</SubtitleText>
+			<Text tag="h3">Spinner that spins indifinitely</Text>
 			<Spinner />
-			<SubtitleText tag="h3">Spinner that spins indifinitely</SubtitleText>
+			<Text tag="h3">Spinner that reaches 60%</Text>
 			<Spinner progress={60} />
 		</>
 	);

--- a/containers/sb-8/stories/components/Typography/Typography.mdx
+++ b/containers/sb-8/stories/components/Typography/Typography.mdx
@@ -5,7 +5,25 @@ import * as stories from './Typography.stories';
 
 # Typography
 
-The `Typography` and its helper components offer a way to consistently style text. This ensures that text throughout your application matches the Mosaic system. The `Typography` component currently offers 3 variations. There are helper components for each variation, enabling you to invoke, for example `<Prose />` instead of `<Typography variant="prose" />`.
+The `Typography` and its helper components offer a way to consistently style text. This ensures that text throughout your application matches the Mosaic system. The `Typography` component currently offers 3 variations. There are helper components for each variation, enabling you to invoke, for example `<BodyText />` instead of `<Typography variant="body" />`.
+
+## Props
+Both the base `Typography` component *and* the helper components have the below properties, with the exception of `variant`. `variant` is a required property when using the `Typography` component and an invalid property when using the variation helper components.
+
+| Prop name | Type | Description |
+| ------ | ------ | ------ |
+| <code>variant</code> | <code>"text" &#124; "body" &#124; "display"</code>  | **Base <code>Typography</code> component only**. Controls the look of the typography. See table below for more information on variants. |
+| <code>tag</code> | Any valid HTML tag | The HTML element to use. Each variant defaults to its own, specifically picked HTML tag (see above) |
+| <code>maxLines</code> | <code>number</code> | If provided, text will be truncated at the given number of lines |
+| <code>whiteSpace</code> | Any valid CSS white-space value | The "white-space" CSS style |
+| <code>breakAll</code> | <code>boolean</code> | Utilises <code>word-break: break-all</code> - useful for displaying long strings with no breaking characters like URLs |
+| <code>children</code> | <code>ReactNode</code> | The content, usually text, of the Typography component |
+| <code>className</code> | <code>string</code> | Pass custom classes to the wrapping element |
+| <code>title</code> | <code>string</code> | Provides a title attribute to the Typography element |
+| <code>attrs</code> | Any valid HTML attribute | Additional attributes to be provided to the Typography element |
+| <code>color</code> | <code>string</code> | A CSS color in which to render the typography text. |
+
+## Variants
 
 <table width="100%">
 	<tr>
@@ -81,7 +99,7 @@ The `Typography` and its helper components offer a way to consistently style tex
 			`Text`
 		</td>
 		<td rowspan="6">
-			`div`
+			`span`
 		</td>
 		<td>
 			`xs`
@@ -193,21 +211,3 @@ The `Typography` and its helper components offer a way to consistently style tex
 		</td>
 	</tr>
 </table>
-
-## Props
-Both the base `Typography` component *and* the helper components have the below properties, with the exception of `variant`. `variant` is a required property when using the `Typography` component and an invalid property when using the variation helper components.
-
-| Prop name | Type | Description |
-| ------ | ------ | ------ |
-| <code>variant</code> | <code>"title" &#124; "subtitle" &#124; "body"</code>  | **Base <code>Typography</code> component only**. Controls the look of the typography |
-| <code>as</code> | Any valid HTML tag | **DEPRECATED** Use "tag" prop instead |
-| <code>tag</code> | Any valid HTML tag | The HTML element to use. Each variant defaults to its own, specifically picked HTML tag (see above) |
-| <code>maxLines</code> | <code>number</code> | If provided, text will be truncated at the given number of lines |
-| <code>whiteSpace</code> | Any valid CSS white-space value | The "white-space" CSS style |
-| <code>breakAll</code> | <code>boolean</code> | Utilises <code>word-break: break-all</code> - useful for displaying long strings with no breaking characters like URLs |
-| <code>style</code> | <code>MosaicObject</code> | **DEPRECATED** Use a style property on an object provided to <code>attrs</code> instead |
-| <code>children</code> | <code>ReactNode</code> | The content, usually text, of the Typography component |
-| <code>className</code> | <code>string</code> | Pass custom classes to the wrapping element |
-| <code>title</code> | <code>string</code> | Provides a title attribute to the Typography element |
-| <code>attrs</code> | Any valid HTML attribute | Additional attributes to be provided to the Typography element |
-| <code>color</code> | <code>ColorTypes</code> | The text colour of the typography |

--- a/containers/sb-8/stories/components/Typography/Typography.mdx
+++ b/containers/sb-8/stories/components/Typography/Typography.mdx
@@ -5,72 +5,193 @@ import * as stories from './Typography.stories';
 
 # Typography
 
-The `Typography` and its helper components offer a way to consistently style text. This ensures that text throughout your application matches the Mosaic system. The `Typography` component currently offers 3 variations. There are helper components for each variation, enabling you to invoke `<TitleText />` instead of `<Typography variant="title" />`.
+The `Typography` and its helper components offer a way to consistently style text. This ensures that text throughout your application matches the Mosaic system. The `Typography` component currently offers 3 variations. There are helper components for each variation, enabling you to invoke, for example `<Prose />` instead of `<Typography variant="prose" />`.
 
 <table width="100%">
-<tr>
-<td>Variant</td>
-<td>Component Name</td>
-<td>Default Tag</td>
-<td>Default Styles</td>
-</tr>
-<tr>
-<td>title</td>
-<td>
-
-`TitleText`
-</td>
-<td>
-
-`h1`
-</td>
-<td>
-
-```css
-font-family: ${theme.museoFont};
-font-size: 28px;
-font-weight: ${theme.fontWeight.light};
-line-height: 1.2em;
-```
-</td>
-</tr>
-<tr>
-<td>subtitle</td>
-<td>
-
-`SubtitleText`
-</td>
-<td>
-
-`h3`
-</td>
-<td>
-
-```css
-font-family: ${theme.fontFamily};
-font-size: 18px;
-font-weight: 600;
-```
-</td>
-</tr>
-<tr>
-<td>body</td>
-<td>
-
-`BodyText`
-</td>
-<td>
-
-`div`
-</td>
-<td>
-
-```css
-font-family: ${theme.fontFamily};
-font-size: 16px;
-```
-</td>
-</tr>
+	<tr>
+		<th>Variant</th>
+		<th>Component Name</th>
+		<th>Default Tag</th>
+		<th colspan="2">Sizes (Font Size / Line Height)</th>
+		<th>Default Weight</th>
+	</tr>
+	{/** Display */}
+	<tr>
+		<td rowspan="6">display</td>
+		<td rowspan="6">
+			`DisplayText`
+		</td>
+		<td rowspan="6">
+			`div`
+		</td>
+		<td>
+			`xs`
+		</td>
+		<td>
+			24px / 32px
+		</td>
+		<td rowspan="6">
+			`medium`
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`sm` (default)
+		</td>
+		<td>
+			30px / 38px
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`md`
+		</td>
+		<td>
+			36px / 44px
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`lg`
+		</td>
+		<td>
+			48px / 60px
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`xl`
+		</td>
+		<td>
+			60px / 72px
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`2xl`
+		</td>
+		<td>
+			72px / 90px
+		</td>
+	</tr>
+	{/** Text */}
+	<tr>
+		<td rowspan="6">text</td>
+		<td rowspan="6">
+			`Text`
+		</td>
+		<td rowspan="6">
+			`div`
+		</td>
+		<td>
+			`xs`
+		</td>
+		<td>
+			10px / 14px
+		</td>
+		<td rowspan="6">
+			`normal`
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`sm`
+		</td>
+		<td>
+			12px / 16px
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`md` (default)
+		</td>
+		<td>
+			14px / 18px
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`lg`
+		</td>
+		<td>
+			16px / 20px
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`xl`
+		</td>
+		<td>
+			18px / 22px
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`2xl`
+		</td>
+		<td>
+			20px / 26px
+		</td>
+	</tr>
+	{/** Body */}
+	<tr>
+		<td rowspan="6">body</td>
+		<td rowspan="6">
+			`BodyText`
+		</td>
+		<td rowspan="6">
+			`div`
+		</td>
+		<td>
+			`xs`
+		</td>
+		<td>
+			10px / 18px
+		</td>
+		<td rowspan="6">
+			`normal`
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`sm`
+		</td>
+		<td>
+			12px / 18px
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`md` (default)
+		</td>
+		<td>
+			14px / 20px
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`lg`
+		</td>
+		<td>
+			16px / 24px
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`xl`
+		</td>
+		<td>
+			18px / 28px
+		</td>
+	</tr>
+	<tr>
+		<td>
+			`2xl`
+		</td>
+		<td>
+			20px / 30px
+		</td>
+	</tr>
 </table>
 
 ## Props

--- a/containers/sb-8/stories/components/Typography/Typography.stories.tsx
+++ b/containers/sb-8/stories/components/Typography/Typography.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import type { ReactElement } from "react";
 import type { Properties } from "csstype";
+import type { Theme } from "#mosaic/theme";
 import theme from "#mosaic/theme";
 import type { TypographyVariant } from "#mosaic/components/Typography";
-import Typography, { BodyText, SubtitleText, TitleText } from "#mosaic/components/Typography";
+import Typography, { BodyText, Text, DisplayText } from "#mosaic/components/Typography";
 import styled from "styled-components";
-import type { ColorTypes } from "#mosaic/components/Button";
 import { tags } from "./storyUtils";
 
 export default {
@@ -16,18 +16,7 @@ const content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In lob
 const contentShort = content.substring(0, 93);
 const contentUrl = "https://www.google.com/?q=46503807498226023045874012183575071093022671901587285495525521941359381308429902926377654197863336467166861936857990937433143015269066983394795324415786553093224671668619368579909374331430152690669833947";
 
-const variants: TypographyVariant[] = ["title", "subtitle", "body"];
-
-const colors: ColorTypes[] = [
-	"black",
-	"blue",
-	"lightBlue",
-	"red",
-	"yellow",
-	"teal",
-	"gray",
-	"white",
-];
+const variants: TypographyVariant[] = ["display", "text", "body"];
 
 const whiteSpaceOptions: Properties["whiteSpace"][] = [
 	"-moz-initial",
@@ -42,6 +31,15 @@ const whiteSpaceOptions: Properties["whiteSpace"][] = [
 	"pre-wrap",
 	"revert",
 	"revert-layer",
+];
+
+const sizes: (keyof Theme["fontSize"][keyof Theme["fontSize"]])[] = [
+	"2xl",
+	"xl",
+	"lg",
+	"md",
+	"sm",
+	"xs",
 ];
 
 const BackDrop = styled.div`
@@ -94,7 +92,17 @@ const MyBodyText = styled(BodyText)`
 	}
 `;
 
-export function Playground({ variant, tag, maxLines, whiteSpace, breakAll, title, children, color }: typeof Playground.args): ReactElement {
+export function Playground({
+	variant,
+	tag,
+	maxLines,
+	whiteSpace,
+	breakAll,
+	title,
+	children,
+	color,
+	size,
+}: typeof Playground.args): ReactElement {
 	return (
 		<Typography
 			variant={variant}
@@ -105,12 +113,13 @@ export function Playground({ variant, tag, maxLines, whiteSpace, breakAll, title
 			title={title}
 			children={children}
 			color={color}
+			size={size}
 		/>
 	);
 }
 
 Playground.args = {
-	variant: "title",
+	variant: "display",
 	tag: "div",
 	maxLines: 0,
 	whiteSpace: "normal",
@@ -118,6 +127,8 @@ Playground.args = {
 	title: "",
 	children: "Lorem ipsum",
 	color: "black",
+	provideSize: false,
+	size: "md",
 } as const;
 
 Playground.argTypes = {
@@ -149,9 +160,16 @@ Playground.argTypes = {
 		name: "Children",
 	},
 	color: {
-		name: "Colour",
+		name: "Color",
+	},
+	provideSize: {
+		name: "Provide Size",
+	},
+	size: {
+		name: "Size",
 		control: { type: "select" },
-		options: colors,
+		options: sizes,
+		if: { arg: "provideSize" },
 	},
 };
 
@@ -163,24 +181,24 @@ export function KitchenSink(): ReactElement {
 				<Wrapper>
 
 					<Heading>Standard Title</Heading>
-					<TitleText
+					<DisplayText
 						children={contentShort}
 					/>
 
 					<Heading>Title rendered as a h2 element</Heading>
-					<TitleText
+					<DisplayText
 						tag="h2"
 						children={contentShort}
 					/>
 
 					<Heading>Title with a maximum number of lines</Heading>
-					<TitleText
+					<DisplayText
 						children={content}
 						maxLines={1}
 					/>
 
 					<Heading>Subtitle</Heading>
-					<SubtitleText
+					<Text
 						children={contentShort}
 					/>
 


### PR DESCRIPTION
# [MOS-1628](https://simpleviewtools.atlassian.net/browse/MOS-1628)

## Description
- (Typography) Swaps out variants. Adds support for the size and weight props.
- **(BREAKING CHANGE)** the `variant` prop now accepts `text`, `body` or `display`. Similarly, the helper components are now `Text`, `BodyText` and `DisplayText`. The typography [documentation](https://simpleviewinc.github.io/sv-mosaic/sb8/master/?path=/docs/components-typography--docs) has been updated to list the variants and their default tag, available sizes and default weight.
- **(BREAKING CHANGE)** `as` is no longer an accepted property - use `tag` instead..
- **(BREAKING CHANGE)** `style` is not longer an accepted property - use `attrs` instead.

## Checklist
- [ ] I have written new tests to cover the changes
- [x] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [x] This contains breaking changes

[MOS-1628]: https://simpleviewtools.atlassian.net/browse/MOS-1628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ