### PR TITLE
MOS-1627

### DIFF
--- a/containers/mosaic/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/containers/mosaic/src/components/ThemeProvider/ThemeProvider.tsx
@@ -53,13 +53,13 @@ const muiTheme = createTheme({
 			},
 		},
 		MuiButton: {
-			defaultProps: {
-				disableRipple: true,
-			},
 			styleOverrides: {
 				root: {
 					textTransform: "none",
 					fontSize: "inherit",
+					":focus": {
+						outline: "none",
+					},
 				},
 			},
 		},

--- a/containers/mosaic/src/components/ThemeProvider/baselineCss.ts
+++ b/containers/mosaic/src/components/ThemeProvider/baselineCss.ts
@@ -12,7 +12,6 @@ const baselineCss = `
  */
 
 html {
-  line-height: 1.15; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }
 
@@ -364,6 +363,7 @@ template {
 	font-variation-settings:
 		"wdth" 100;
 	color: ${theme.color.black};
+  line-height: ${theme.line["3xloose"]}
 }
 
 b, strong {


### PR DESCRIPTION
# [MOS-1627](https://simpleviewtools.atlassian.net/browse/MOS-1627)

## Description
- (Typography) Set root line height to 1.5.
- (Theme) Re-enable ripple until we address button styling.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1627]: https://simpleviewtools.atlassian.net/browse/MOS-1627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ