### PR TITLE
MOS-1665

### DIFF
--- a/containers/mosaic/eslint.config.mjs
+++ b/containers/mosaic/eslint.config.mjs
@@ -8,7 +8,7 @@ export default [
 				"error",
 				{
 					patterns: [{
-						regex: "@mui\\/material$",
+						regex: "@mui\\/(?:icons-)?material$",
 						message: "Do not import from the root of material UI. For example, instead of `import { InputAdornment } from \"@mui/material\"`, do `import InputAdornment from \"@mui/material/InputAdornment\"`",
 					}],
 				},

--- a/containers/mosaic/src/components/ChipList/ChipList.tsx
+++ b/containers/mosaic/src/components/ChipList/ChipList.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement } from "react";
 
 import React, { memo, useState, forwardRef, useMemo } from "react";
-import { ExpandLess, ExpandMore } from "@mui/icons-material";
+import ExpandLess from "@mui/icons-material/ExpandLess";
+import ExpandMore from "@mui/icons-material/ExpandMore";
 
 import type { ChipListProps } from "./ChipListTypes";
 


### PR DESCRIPTION
# [MOS-1665](https://simpleviewtools.atlassian.net/browse/MOS-1665)

## Description
- (chore) Add icons-material to eslint rule to prevent loose importing of all icons.
- (ChipList) Fix loose icon import.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [ ] I have verified these changes in all major browsers
- [ ] This contains breaking changes