### PR TITLE
MOS-1670

### DIFF
--- a/containers/mosaic/src/__tests__/utils/string/classnames.test.ts
+++ b/containers/mosaic/src/__tests__/utils/string/classnames.test.ts
@@ -1,0 +1,45 @@
+import { classnames } from "@root/utils/string";
+import type { TestDef } from "@simpleview/mochalib";
+import { testArray } from "@simpleview/mochalib";
+
+describe(__filename, function () {
+	interface Test {
+		input: Parameters<typeof classnames>;
+		result: string;
+	}
+
+	const tests: TestDef<Test>[] = [
+		{
+			name: "should return a single classname",
+			args: {
+				input: ["foo"],
+				result: "foo",
+			},
+		},
+		{
+			name: "should return multiple classnames separated by a string",
+			args: {
+				input: ["foo", "bar", "baz"],
+				result: "foo bar baz",
+			},
+		},
+		{
+			name: "should omit a classname if the parameter is false",
+			args: {
+				input: ["foo", false, "baz"],
+				result: "foo baz",
+			},
+		},
+		{
+			name: "should omit a classname if the parameter is undefined",
+			args: {
+				input: ["foo", undefined, "baz"],
+				result: "foo baz",
+			},
+		},
+	];
+
+	testArray(tests, ({ input, result }) => {
+		expect(classnames(...input)).toBe(result);
+	});
+});

--- a/containers/mosaic/src/components/Field/FormFieldGroup/FormFieldGroupTypes.ts
+++ b/containers/mosaic/src/components/Field/FormFieldGroup/FormFieldGroupTypes.ts
@@ -4,6 +4,7 @@ import type { FieldDef, FieldDefBase } from "../FieldTypes";
 export interface GroupInputSettings {
 	fields: FieldDef[];
 	layout?: SectionPropTypes["rows"];
+	useHeaderLabel?: boolean;
 }
 
 export type GroupData = Record<string, any>;

--- a/containers/mosaic/src/components/FieldWrapper/FieldWrapper.tsx
+++ b/containers/mosaic/src/components/FieldWrapper/FieldWrapper.tsx
@@ -8,7 +8,7 @@ import { default as HelperText } from "./HelperText";
 import { default as InstructionText } from "./InstructionText";
 import { type FieldDef, type MosaicFieldProps } from "../Field";
 import Skeleton from "@mui/material/Skeleton";
-import { getTextLength } from "@root/utils/string";
+import { classnames, getTextLength } from "@root/utils/string";
 import useRegisterField from "@root/utils/hooks/useRegisterField";
 import { getHtmlCharacterCount } from "@root/utils/dom/getHtmlCharacterCount";
 
@@ -107,7 +107,7 @@ const FieldWrapper = (props: MosaicFieldProps<any>): ReactElement => {
 	return (
 		<StyledFieldContainer
 			id={id}
-			className={fieldDef?.className}
+			className={classnames(fieldDef?.className, "Mos-Field", `Mos-Field--${fieldDef.type}`)}
 			style={fieldDef?.style}
 			data-testid="field-test-id"
 			ref={fieldRef}
@@ -133,12 +133,16 @@ const FieldWrapper = (props: MosaicFieldProps<any>): ReactElement => {
 								name={fieldDef.name}
 								as={hasRealLabel ? "label" : "div"}
 								hideLabel={fieldDef.hideLabel}
+								isGroup={fieldDef.type === "group"}
 							>
 								{fieldDef?.label}
 							</Label>
 						)
 					)}
-					<StyledControlWrapper $size={fieldDef?.size}>
+					<StyledControlWrapper
+						className="Mos-FieldControl"
+						$size={fieldDef?.size}
+					>
 						{children}
 					</StyledControlWrapper>
 				</StyledLabelControlWrapper>

--- a/containers/mosaic/src/components/FieldWrapper/FieldWrapper.tsx
+++ b/containers/mosaic/src/components/FieldWrapper/FieldWrapper.tsx
@@ -134,6 +134,7 @@ const FieldWrapper = (props: MosaicFieldProps<any>): ReactElement => {
 								as={hasRealLabel ? "label" : "div"}
 								hideLabel={fieldDef.hideLabel}
 								isGroup={fieldDef.type === "group"}
+								useHeaderLabel={fieldDef.type === "group" && fieldDef?.inputSettings.useHeaderLabel}
 							>
 								{fieldDef?.label}
 							</Label>

--- a/containers/mosaic/src/components/FieldWrapper/HelperText.tsx
+++ b/containers/mosaic/src/components/FieldWrapper/HelperText.tsx
@@ -16,12 +16,12 @@ const HelperText = ({
 	error = false,
 }: HelperTextProps): ReactElement => {
 	return error ? (
-		<ErrorTextWrapper>
+		<ErrorTextWrapper className="Mos-FieldErrorText">
 			<StyledErrorIcon $error={!!children} data-testid="error-icon-test-id" />
 			<StyledText error={error}>{children}</StyledText>
 		</ErrorTextWrapper>
 	) : (
-		<StyledText error={error}>{children}</StyledText>
+		<StyledText className="Mos-FieldHelperText" error={error}>{children}</StyledText>
 	);
 };
 

--- a/containers/mosaic/src/components/FieldWrapper/InstructionText.tsx
+++ b/containers/mosaic/src/components/FieldWrapper/InstructionText.tsx
@@ -13,7 +13,7 @@ interface InstructionTextProps {
 const InstructionText = (props: InstructionTextProps): ReactElement => {
 	const { children, colsInRow } = props;
 	return (
-		<InstructionTextWrapper $colsInRow={colsInRow}>
+		<InstructionTextWrapper className="Mos-FieldInstructionText" $colsInRow={colsInRow}>
 			<StyledInstructionText>{children}</StyledInstructionText>
 		</InstructionTextWrapper>
 	);

--- a/containers/mosaic/src/components/FieldWrapper/Label.tsx
+++ b/containers/mosaic/src/components/FieldWrapper/Label.tsx
@@ -10,6 +10,7 @@ import { containerQuery } from "@root/utils/css";
 import Tooltip, { useTooltip } from "../Tooltip";
 import testIds from "@root/utils/testIds";
 import { TooltipIcon } from "../common";
+import { classnames } from "@root/utils/string";
 
 const LabelWrapper = styled.div<TransientProps<LabelProps, "required">>`
 	display: flex;
@@ -76,6 +77,7 @@ interface LabelProps {
 	forceInstructionTooltip?: boolean;
 	colsInRow?: number;
 	as?: "label" | "div";
+	isGroup?: boolean;
 }
 
 const Label = (props: LabelProps): ReactElement => {
@@ -90,6 +92,7 @@ const Label = (props: LabelProps): ReactElement => {
 		forceInstructionTooltip,
 		colsInRow,
 		as = "label",
+		isGroup,
 	} = props;
 
 	const { anchorProps, tooltipProps } = useTooltip();
@@ -106,6 +109,7 @@ const Label = (props: LabelProps): ReactElement => {
 					as={as === "label" ? InputLabel : InputLabelDiv}
 					data-testid={name && `${testIds.FORM_FIELD_LABEL}:${name}`}
 					title={typeof children === "string" ? children : undefined}
+					className={classnames("Mos-FieldLabel", isGroup && "Mos-GroupLabel")}
 				>
 					{children}
 					{required && <StyledRequiredIndicator>*</StyledRequiredIndicator>}
@@ -115,6 +119,7 @@ const Label = (props: LabelProps): ReactElement => {
 				<StyledTooltipWrapper
 					$colsInRow={colsInRow}
 					$alwaysShow={forceInstructionTooltip}
+					className="Mos-FieldTooltip"
 				>
 					<TooltipIcon {...anchorProps} />
 					<Tooltip {...tooltipProps}>
@@ -123,7 +128,10 @@ const Label = (props: LabelProps): ReactElement => {
 				</StyledTooltipWrapper>
 			)}
 			{limit && (
-				<CharCounterWrapper $invalid={limit[0] > limit[1]}>
+				<CharCounterWrapper
+					className="Mos-CharacterCount"
+					$invalid={limit[0] > limit[1]}
+				>
 					{limit[0]}
 					/
 					{limit[1]}

--- a/containers/mosaic/src/components/FieldWrapper/Label.tsx
+++ b/containers/mosaic/src/components/FieldWrapper/Label.tsx
@@ -45,9 +45,10 @@ const CharCounterWrapper = styled.div<{ $invalid?: boolean }>`
 const StyledInputLabel = styled(InputLabel)<{ $isHeader?: boolean }>`
 	font-weight: ${theme.weight.medium};
   	align-self: center;
+	color: ${theme.newColors.grey4["100"]} !important;
 
 	${({ $isHeader }) => $isHeader ? `
-		font-weight: ${theme.weight.semi};
+		font-weight: ${theme.weight.bold};
 		font-size: ${theme.fontSize.text["2xl"]};
 		margin-bottom: ${theme.spacing(1)};
 	` : `

--- a/containers/mosaic/src/components/FieldWrapper/Label.tsx
+++ b/containers/mosaic/src/components/FieldWrapper/Label.tsx
@@ -33,7 +33,6 @@ const InputLabelDiv = styled.div`
 	font-size: ${theme.fontSize.text.lg};
 	line-height: ${theme.line.tight};
 	font-weight: ${theme.weight.medium};
-	color:  ${theme.newColors.almostBlack["100"]};
 	word-wrap: break-word;
 `;
 
@@ -43,10 +42,17 @@ const CharCounterWrapper = styled.div<{ $invalid?: boolean }>`
 	margin-left: auto;
 `;
 
-const StyledInputLabel = styled(InputLabel)`
+const StyledInputLabel = styled(InputLabel)<{ $isHeader?: boolean }>`
 	font-weight: ${theme.weight.medium};
   	align-self: center;
-	color: ${theme.newColors.grey4["100"]} !important;
+
+	${({ $isHeader }) => $isHeader ? `
+		font-weight: ${theme.weight.semi};
+		font-size: ${theme.fontSize.text["2xl"]};
+		margin-bottom: ${theme.spacing(1)};
+	` : `
+		font-weight: ${theme.weight.medium};
+	`}
 `;
 
 const StyledRequiredIndicator = styled.span`
@@ -78,6 +84,7 @@ interface LabelProps {
 	colsInRow?: number;
 	as?: "label" | "div";
 	isGroup?: boolean;
+	useHeaderLabel?: boolean;
 }
 
 const Label = (props: LabelProps): ReactElement => {
@@ -93,6 +100,7 @@ const Label = (props: LabelProps): ReactElement => {
 		colsInRow,
 		as = "label",
 		isGroup,
+		useHeaderLabel,
 	} = props;
 
 	const { anchorProps, tooltipProps } = useTooltip();
@@ -110,6 +118,7 @@ const Label = (props: LabelProps): ReactElement => {
 					data-testid={name && `${testIds.FORM_FIELD_LABEL}:${name}`}
 					title={typeof children === "string" ? children : undefined}
 					className={classnames("Mos-FieldLabel", isGroup && "Mos-GroupLabel")}
+					$isHeader={useHeaderLabel}
 				>
 					{children}
 					{required && <StyledRequiredIndicator>*</StyledRequiredIndicator>}

--- a/containers/mosaic/src/components/Form/Col/Col.tsx
+++ b/containers/mosaic/src/components/Form/Col/Col.tsx
@@ -31,6 +31,7 @@ const Col = (props: ColPropsTypes) => {
 
 	return (
 		<StyledCol
+			className="Mos-FormColumn"
 			data-layout="column"
 			$gridColumn={`${gridStart} / ${gridEnd}`}
 			$gridMinWidth={gridMinWidth}

--- a/containers/mosaic/src/components/Form/Form.tsx
+++ b/containers/mosaic/src/components/Form/Form.tsx
@@ -286,6 +286,7 @@ const Form = (props: FormProps) => {
 				role="form"
 				aria-label={title}
 				$fullHeight={fullHeight}
+				className="Mos-Form"
 			>
 				<StyledForm
 					autoComplete="off"

--- a/containers/mosaic/src/components/Form/Row/Row.tsx
+++ b/containers/mosaic/src/components/Form/Row/Row.tsx
@@ -43,7 +43,12 @@ const Row = (props: RowPropTypes) => {
 	}
 
 	return (
-		<StyledRow data-layout="row" $columns={row.length} $gridMinWidth={gridMinWidth} $spacing={spacing}>
+		<StyledRow
+			className="Mos-FormRow"
+			data-layout="row"
+			$columns={row.length}
+			$gridMinWidth={gridMinWidth} $spacing={spacing}
+		>
 			{row.map((col, i) => {
 				return (
 					<Col

--- a/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
@@ -38,6 +38,7 @@ function sanitizeFieldDefs(fields: FieldDef[], sections?: SectionDef[]): FieldDe
 				...field,
 				type: "group",
 				inputSettings: {
+					useHeaderLabel: true,
 					fields: getAddressFields({
 						getOptionsCountries,
 						getOptionsStates,

--- a/containers/mosaic/src/utils/string/classnames.ts
+++ b/containers/mosaic/src/utils/string/classnames.ts
@@ -1,0 +1,3 @@
+export function classnames(...items: (boolean | string | undefined)[]): string {
+	return items.filter(Boolean).join(" ");
+}

--- a/containers/mosaic/src/utils/string/index.ts
+++ b/containers/mosaic/src/utils/string/index.ts
@@ -1,3 +1,4 @@
 export { default as joinAnd } from "./joinAnd";
 export { default as getTextLength } from "./getTextLength";
 export * from "./sanitizeUrl";
+export * from "./classnames";


### PR DESCRIPTION
# [MOS-1670](https://simpleviewtools.atlassian.net/browse/MOS-1670)

## Description
- (Form) Adds class names to form and field elements for easy CSS targeting:
  - `Mos-Form`
  - `Mos-FormRow`
  - `Mos-FormColumn`
  - `Mos-Field` and `Mos-Field--{type}`
  - `Mos-FieldErrorText`
  - `Mos-FieldHelperText`
  - `Mos-FieldInstructionText`
  - `Mos-FieldLabel` and `Mos-FieldGroupLabel`
  - `Mos-FieldTooltip`
  - `Mos-CharacterCount`

## Checklist
- [x] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1670]: https://simpleviewtools.atlassian.net/browse/MOS-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ