### PR TITLE
MOS-1667

### DIFF
--- a/containers/mosaic/src/components/Field/FormFieldRadio/FormFieldRadio.styled.ts
+++ b/containers/mosaic/src/components/Field/FormFieldRadio/FormFieldRadio.styled.ts
@@ -6,6 +6,7 @@ export const StyledRadioGroup = styled(MUIRadioGroup)`
 	& {
 		margin-left: ${theme.spacing(-1.5)};
 		gap: ${theme.spacing(1)};
+		align-items: start;
 	}
 `;
 


### PR DESCRIPTION
# [MOS-1667](https://simpleviewtools.atlassian.net/browse/MOS-1667)

## Description
- (RadioField) Fix flex alignment to prevent clickable area extending far beyond the corresponding radio label.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1667]: https://simpleviewtools.atlassian.net/browse/MOS-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ