### PR TITLE
MOS-1636

### DIFF
--- a/containers/mosaic/src/components/DataViewFilterText/DataViewFilterTextDropdownContent.tsx
+++ b/containers/mosaic/src/components/DataViewFilterText/DataViewFilterTextDropdownContent.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import React, { useState } from "react";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import DataViewFilterDropdownButtons from "@root/components/DataViewFilterDropdownButtons";
@@ -18,7 +19,8 @@ function DataViewFilterTextDropdownContent(props: DataViewFilterTextDropdownCont
 
 	const { t } = useMosaicTranslation();
 
-	const activeComparison = props.comparisons ? props.comparisons.find(val => val.value === state.comparison) : undefined;
+	const hasComparisons = props.comparisons?.length > 0;
+	const activeComparison = hasComparisons ? props.comparisons.find(val => val.value === state.comparison) : undefined;
 
 	const onApply = function() {
 		const cleanValue = state.value.trim();
@@ -65,8 +67,8 @@ function DataViewFilterTextDropdownContent(props: DataViewFilterTextDropdownCont
 
 	const disabled = existsComparisons.includes(state.comparison);
 
-	let comparisonButton;
-	if (props.comparisons) {
+	let comparisonButton: ReactNode;
+	if (hasComparisons) {
 		const menuItems = props.comparisons.map(comparison => {
 			return {
 				label : comparison.label,
@@ -117,7 +119,7 @@ function DataViewFilterTextDropdownContent(props: DataViewFilterTextDropdownCont
 						onChange={onInputChange}
 						onKeyPress={onKeyPress}
 						disabled={disabled}
-						$bluntLeft
+						$bluntLeft={hasComparisons}
 					/>
 				)}
 			</div>


### PR DESCRIPTION
# [MOS-1636](https://simpleviewtools.atlassian.net/browse/MOS-1636)

## Description
- (DataViewFilterText) Blunt the left side of the keyword input only if there's an adjacent comparison dropdown.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes

[MOS-1636]: https://simpleviewtools.atlassian.net/browse/MOS-1636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ