### PR TITLE
MOS-1854

### DIFF
--- a/containers/mosaic/src/components/RadioButton/index.ts
+++ b/containers/mosaic/src/components/RadioButton/index.ts
@@ -1,3 +1,4 @@
 export { default } from "./RadioButton";
 export * from "./RadioButton";
 export * from "./RadioButtonTypes";
+export { default as RadioGroup } from "@mui/material/RadioGroup";

--- a/containers/sb-8/stories/components/RadioButton/RadioButton.stories.tsx
+++ b/containers/sb-8/stories/components/RadioButton/RadioButton.stories.tsx
@@ -1,10 +1,9 @@
 import * as React from "react";
 import type { ReactElement, ChangeEvent } from "react";
 import { useState } from "react";
-import RadioGroup from "@mui/material/RadioGroup";
 
 // Components
-import RadioButton from "#mosaic/components/RadioButton";
+import RadioButton, { RadioGroup } from "#mosaic/components/RadioButton";
 
 export default {
 	title: "Components/RadioButton",


### PR DESCRIPTION
# [MOS-1854](https://simpleviewtools.atlassian.net/browse/MOS-1854)

## Description
- Export MUI’s RadioGroup from Mosaic to avoid context mismatches caused by duplicate React instances.

## Checklist
- [ ] I have written new tests to cover the changes
- [ ] I have written/updated documentation to cover the changes
- [x] I have verified these changes in all major browsers
- [ ] This contains breaking changes