### PR TITLE
MOS-1937 Rework

### DIFF
--- a/containers/e2e-tests/pages/Components/DataView/AdvancedFiltersComponent.ts
+++ b/containers/e2e-tests/pages/Components/DataView/AdvancedFiltersComponent.ts
@@ -72,12 +72,13 @@ export class AdvancedFiltersComponent extends FilterComponent {
 		this.searchTitleMenuDropdownItem = page.locator("ul[role='menu']");
 		this.errorMessageDates = page.locator("#rangeStart p");
 
-		this.fromCalendarButton = page.locator("[data-testid='date-picker-test-id'] button").nth(0);
-		// The accessible field DOM structure uses a hidden <input> (not type="tel") to hold
-		// the formatted date value. Use container-scoped locators for stability.
-		this.fromCalendarInput = page.locator("[data-testid='date-picker-test-id']").nth(0).locator("input");
-		this.toCalendarButton = page.locator("[data-testid='date-picker-test-id'] button").nth(1);
-		this.toCalendarInput = page.locator("[data-testid='date-picker-test-id']").nth(1).locator("input");
+		// Open by accessible name — clearable fields insert a Clear control when valued,
+		// which breaks global button nth indexes.
+		const datePickers = page.locator("[data-testid='date-picker-test-id']");
+		this.fromCalendarButton = datePickers.nth(0).getByRole("button", { name: "Choose date" });
+		this.fromCalendarInput = datePickers.nth(0).locator("input");
+		this.toCalendarButton = datePickers.nth(1).getByRole("button", { name: "Choose date" });
+		this.toCalendarInput = datePickers.nth(1).locator("input");
 	}
 
 	async getNumberOfSingleSelectCategoryOptions(): Promise<number> {

--- a/containers/e2e-tests/pages/FormFields/FormFieldDateField/FormFieldDateFieldPage.ts
+++ b/containers/e2e-tests/pages/FormFields/FormFieldDateField/FormFieldDateFieldPage.ts
@@ -10,7 +10,6 @@ export class FormFieldDateFieldPage extends BasePage {
 	readonly page: Page;
 	readonly singleDateCalendarInput: Locator;
 	readonly singleDateCalendarButton: Locator;
-	readonly calendarCell: Locator;
 	readonly disabledSingleDateCalendarText: Locator;
 	readonly dateTimeInput: Locator;
 	readonly dateHourInput: Locator;
@@ -31,23 +30,25 @@ export class FormFieldDateFieldPage extends BasePage {
 		// In the accessible field DOM structure, date/time pickers render a hidden <input>
 		// (aria-hidden, tabindex=-1) that holds the formatted value. That hidden input is
 		// not directly typeable, so use fillDatePicker() to enter values via section paste.
-		this.singleDateCalendarInput = page.locator("[data-testid='date-picker-test-id']").nth(0).locator("input");
-		this.singleDateCalendarButton = page.locator("[data-testid='date-picker-test-id'] button").nth(0);
-		this.calendarCell = page.locator("[role='row'] button");
+		// Open buttons must be resolved by accessible name (not button nth): clearable fields
+		// insert a Clear control when a value is present, which shifts nth indexes.
+		const datePickers = page.locator("[data-testid='date-picker-test-id']");
+		this.singleDateCalendarInput = datePickers.nth(0).locator("input");
+		this.singleDateCalendarButton = datePickers.nth(0).getByRole("button", { name: "Choose date" });
 		this.disabledSingleDateCalendarText = page.locator("#disableSingleDate");
 
-		this.dateTimeInput = page.locator("[data-testid='date-picker-test-id']").nth(1).locator("input");
+		this.dateTimeInput = datePickers.nth(1).locator("input");
 		this.dateHourInput = page.locator("#dateTime-time-input");
-		this.dateTimeInputCalendarButton = page.locator("[data-testid='date-picker-test-id'] button").nth(1);
-		this.dateHourInputCalendarButton = this.getTimeFieldContainer("dateTime").locator("button");
+		this.dateTimeInputCalendarButton = datePickers.nth(1).getByRole("button", { name: "Choose date" });
+		this.dateHourInputCalendarButton = this.getTimeFieldContainer("dateTime").getByRole("button", { name: "Choose time" });
 		this.hourMinutesOption = this.roleOptionLocator;
 		this.hourAMButton = page.locator("[role='dialog'] .MuiTimeClock-root button").nth(0);
 		this.hourPMButton = page.locator("[role='dialog'] .MuiTimeClock-root button").nth(1);
 
-		this.requiredDateTimeInput = page.locator("[data-testid='date-picker-test-id']").nth(3).locator("input");
+		this.requiredDateTimeInput = datePickers.nth(3).locator("input");
 		this.requiredDateHourInput = page.locator("#requiredDateTime-time-input");
-		this.requiredDateTimeInputCalendarButton = page.locator("[data-testid='date-picker-test-id'] button").nth(3);
-		this.requiredDateHourInputCalendarButton = this.getTimeFieldContainer("requiredDateTime").locator("button");
+		this.requiredDateTimeInputCalendarButton = datePickers.nth(3).getByRole("button", { name: "Choose date" });
+		this.requiredDateHourInputCalendarButton = this.getTimeFieldContainer("requiredDateTime").getByRole("button", { name: "Choose time" });
 		this.dateFieldText = page.locator("#date p").first();
 	}
 
@@ -73,8 +74,13 @@ export class FormFieldDateFieldPage extends BasePage {
 		}, value);
 	}
 
-	async selectDayFromDatePicker(day:number): Promise<void> {
-		await this.calendarCell.nth(day - 1).click();
+	async selectDayFromDatePicker(day: number): Promise<void> {
+		// MUI X uses MuiPickerPopper-root (singular "Picker"); the older
+		// MuiPickersPopper-root class name no longer appears in the DOM.
+		await this.page
+			.locator(".MuiPickerPopper-root")
+			.getByRole("gridcell", { name: String(day), exact: true })
+			.click();
 	}
 
 	async selectHourAndMinutesInHourPicker(timeOfDay:string): Promise<string> {

--- a/containers/mosaic/src/__tests__/components/DataViewFilterDate/DataViewFilterDateDropdownContent.test.tsx
+++ b/containers/mosaic/src/__tests__/components/DataViewFilterDate/DataViewFilterDateDropdownContent.test.tsx
@@ -160,7 +160,10 @@ describe(__dirname, () => {
 		const from = screen.queryByLabelText("From");
 		const to = screen.queryByLabelText("To");
 		const option = screen.queryByRole("menuitem", { name: "Today" });
-		const clear = screen.queryByRole("button", { name: "Clear" });
+		// Date fields also expose clear icon buttons (title "Clear") when valued —
+		// exclude those MUI field clear controls (class "clearButton").
+		const clear = screen.getAllByRole("button", { name: "Clear" })
+			.find((button) => !button.classList.contains("clearButton"));
 
 		expect(from).toBeInTheDocument();
 		expect(to).toBeInTheDocument();
@@ -173,8 +176,9 @@ describe(__dirname, () => {
 
 		await user.click(clear);
 
-		expect(from).toHaveValue("");
-		expect(to).toHaveValue("");
+		// Date fields remount on inputRevision reset — re-query after clear.
+		expect(screen.getByLabelText("From")).toHaveValue("");
+		expect(screen.getByLabelText("To")).toHaveValue("");
 		expect(option).toHaveAttribute("aria-selected", "false");
 	});
 });

--- a/containers/mosaic/src/__tests__/components/Field/FormFieldDate/DatePicker/DatePicker.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldDate/DatePicker/DatePicker.test.tsx
@@ -63,4 +63,23 @@ describe(__dirname, () => {
 		await user.keyboard("{Escape}");
 		expect(onBlurMock).toBeCalled();
 	});
+
+	it("should keep the selected date after choosing from the calendar", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => null);
+
+		const onChangeMock = vi.fn();
+		const { user } = await setup({ onChange: onChangeMock });
+
+		await user.click(screen.getByRole("button", { name: "Choose date" }));
+		await user.click(screen.getByRole("gridcell", { name: "15" }));
+
+		const selectedCalls = onChangeMock.mock.calls.filter(([date]) => (
+			date instanceof Date && date.getDate() === 15
+		));
+		expect(selectedCalls.length).toBeGreaterThan(0);
+
+		const lastCall = onChangeMock.mock.calls.at(-1);
+		expect(lastCall?.[0]).toBeInstanceOf(Date);
+		expect((lastCall?.[0] as Date).getDate()).toBe(15);
+	});
 });

--- a/containers/mosaic/src/__tests__/components/Field/FormFieldDate/FormFieldDate.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldDate/FormFieldDate.test.tsx
@@ -75,6 +75,7 @@ describe(__dirname, () => {
 		expect(onChangeMock).toHaveBeenCalledWith({
 			date: new Date("2024/01/01"),
 			keyboardInputValue: "01/01/2024",
+			isPartiallyFilled: false,
 		});
 	});
 
@@ -96,7 +97,34 @@ describe(__dirname, () => {
 		expect(onChangeMock).toBeCalledWith({
 			date: new Date(`${now.getFullYear()}/${now.getMonth() + 1}/01`),
 			keyboardInputValue: undefined,
+			isPartiallyFilled: false,
 		});
+	});
+
+	it("should mark the field as partially filled on blur after incomplete manual entry", async () => {
+		const onChangeMock = vi.fn();
+		const onBlurMock = vi.fn();
+
+		const { user } = await setup({ onChange: onChangeMock, onBlur: onBlurMock });
+
+		const monthSection = screen.getByRole("spinbutton", { name: /month/i });
+		await user.click(monthSection);
+		await user.keyboard("1");
+
+		// Move focus outside the picker. Blur is deferred with requestAnimationFrame.
+		await user.click(document.body);
+		await act(async () => {
+			await new Promise<void>((resolve) => {
+				requestAnimationFrame(() => resolve());
+			});
+		});
+
+		expect(onBlurMock).toHaveBeenCalled();
+		expect(onChangeMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				isPartiallyFilled: true,
+			}),
+		);
 	});
 
 	it("should render the skeleton components if skeleton is truthy", async () => {

--- a/containers/mosaic/src/__tests__/components/Field/FormFieldDate/FormFieldDate.validation.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldDate/FormFieldDate.validation.test.tsx
@@ -18,21 +18,28 @@ function FormFieldDateWithBlur({ onBlur }: { onBlur: () => void }) {
 	);
 }
 
+const requiredDateFields: FieldDef[] = [{
+	name: "date",
+	type: "date",
+	label: "Date",
+	required: true,
+}];
+
 function RequiredDateForm() {
 	const controller = useForm();
-	const fields: FieldDef[] = [{
-		name: "date",
-		type: "date",
-		label: "Date",
-		required: true,
-	}];
 
 	return (
 		<>
 			<pre data-testid="errors">{JSON.stringify(controller.state.errors)}</pre>
-			<Form {...controller} fields={fields} title="Test" />
+			<Form {...controller} fields={requiredDateFields} title="Test" />
 		</>
 	);
+}
+
+async function tabOutOfDatePicker(user: ReturnType<typeof userEvent.setup>) {
+	// Empty fields have no clear button: sections → open calendar → next control.
+	await user.tab();
+	await user.tab();
 }
 
 describe("FormFieldDate validation timing", () => {
@@ -89,6 +96,26 @@ describe("FormFieldDate validation timing", () => {
 		expect(onBlurMock).not.toHaveBeenCalled();
 	});
 
+	it("should fire onBlur when tabbing out through the open button", async () => {
+		const onBlurMock = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<>
+				<FormFieldDateWithBlur onBlur={onBlurMock} />
+				<input data-testid="after" />
+			</>,
+		);
+
+		await user.click(screen.getAllByRole("spinbutton")[0]);
+		await tabOutOfDatePicker(user);
+
+		await waitFor(() => {
+			expect(onBlurMock).toHaveBeenCalled();
+		});
+		expect(screen.getByTestId("after")).toHaveFocus();
+	});
+
 	it("should validate required date field on blur", async () => {
 		const user = userEvent.setup();
 		render(
@@ -105,5 +132,99 @@ describe("FormFieldDate validation timing", () => {
 		await waitFor(() => {
 			expect(screen.getByTestId("errors").textContent).not.toBe("{}");
 		});
+	});
+
+	it("should validate required date field when tabbing out through the open button", async () => {
+		const user = userEvent.setup();
+		render(
+			<>
+				<RequiredDateForm />
+				<input data-testid="after" />
+			</>,
+		);
+
+		await user.click(screen.getAllByRole("spinbutton")[0]);
+		await tabOutOfDatePicker(user);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("errors").textContent).not.toBe("{}");
+		});
+		expect(screen.getByTestId("after")).toHaveFocus();
+	});
+});
+
+const requiredDateTimeFields: FieldDef[] = [{
+	name: "requiredDateTime",
+	type: "date",
+	label: "Required Single Date Calendar",
+	required: true,
+	inputSettings: {
+		showTime: true,
+	},
+}];
+
+function RequiredDateTimeForm() {
+	const controller = useForm();
+
+	return (
+		<>
+			<pre data-testid="errors">{JSON.stringify(controller.state.errors)}</pre>
+			<Form {...controller} fields={requiredDateTimeFields} title="Test" />
+		</>
+	);
+}
+
+describe("FormFieldDate showTime required validation timing", () => {
+	it("should validate only the date subfield when tabbing from date to time", async () => {
+		const user = userEvent.setup();
+		render(<RequiredDateTimeForm />);
+
+		await user.click(screen.getAllByRole("spinbutton")[0]);
+		await user.tab(); // date open
+		await user.tab(); // time sections
+
+		await waitFor(() => {
+			const errors = screen.getByTestId("errors").textContent;
+			expect(errors).toContain("requiredDateTime.date");
+			expect(errors).not.toContain("requiredDateTime.time");
+		});
+	});
+
+	it("should validate only the time subfield when tabbing from time to date", async () => {
+		const user = userEvent.setup();
+		render(<RequiredDateTimeForm />);
+
+		await user.click(screen.getByRole("spinbutton", { name: "Hours" }));
+		await user.tab({ shift: true }); // back to date open
+		await user.tab({ shift: true }); // into date sections
+
+		await waitFor(() => {
+			const errors = screen.getByTestId("errors").textContent;
+			expect(errors).toContain("requiredDateTime.time");
+			expect(errors).not.toContain("requiredDateTime.date");
+		});
+	});
+
+	it("should validate each subfield after tabbing forward through both", async () => {
+		const user = userEvent.setup();
+		render(
+			<>
+				<RequiredDateTimeForm />
+				<input data-testid="after" />
+			</>,
+		);
+
+		await user.click(screen.getAllByRole("spinbutton")[0]);
+		await user.tab(); // date open
+		await user.tab(); // time sections
+		await user.tab(); // time open
+		await user.tab(); // leave
+
+		await waitFor(() => {
+			const errors = screen.getByTestId("errors").textContent;
+			expect(errors).toContain("requiredDateTime.date");
+			expect(errors).toContain("requiredDateTime.time");
+		});
+		expect(screen.getByTestId("after")).toHaveFocus();
 	});
 });

--- a/containers/mosaic/src/__tests__/components/Field/FormFieldTime/TimeField/TimeField.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldTime/TimeField/TimeField.test.tsx
@@ -51,6 +51,7 @@ describe("TimeField component", () => {
 			time: new Date(new Date().setHours(6, 30, 0, 0)),
 			keyboardInputValue: "06:30 am",
 			usingDefaultTime: false,
+			isPartiallyFilled: false,
 		});
 	});
 
@@ -82,6 +83,7 @@ describe("TimeField component", () => {
 			time: null,
 			keyboardInputValue: undefined,
 			usingDefaultTime: true,
+			isPartiallyFilled: false,
 		});
 	});
 });

--- a/containers/mosaic/src/__tests__/components/Field/FormFieldTime/TimeField/TimeField.validation.test.tsx
+++ b/containers/mosaic/src/__tests__/components/Field/FormFieldTime/TimeField/TimeField.validation.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import FormFieldTime from "@root/components/Field/FormFieldTime/TimeField";
+
+function FormFieldTimeWithBlur({ onBlur }: { onBlur: () => void }) {
+	return (
+		<FormFieldTime
+			fieldDef={{ name: "time", label: "Time", type: "time", required: true }}
+			onChange={vi.fn()}
+			onBlur={onBlur}
+			id="time-input"
+		/>
+	);
+}
+
+describe("FormFieldTime validation timing", () => {
+	it("should not fire onBlur when clicking clock button", async () => {
+		const onBlurMock = vi.fn();
+		const user = userEvent.setup();
+
+		render(<FormFieldTimeWithBlur onBlur={onBlurMock} />);
+
+		await user.click(screen.getByRole("button", { name: "Choose time" }));
+
+		expect(onBlurMock).not.toHaveBeenCalled();
+	});
+
+	it("should fire onBlur when tabbing out through the open button", async () => {
+		const onBlurMock = vi.fn();
+		const user = userEvent.setup();
+
+		render(
+			<>
+				<FormFieldTimeWithBlur onBlur={onBlurMock} />
+				<input data-testid="after" />
+			</>,
+		);
+
+		await user.click(screen.getAllByRole("spinbutton")[0]);
+		// Empty fields have no clear button: sections → open → next control.
+		await user.tab();
+		await user.tab();
+
+		await waitFor(() => {
+			expect(onBlurMock).toHaveBeenCalled();
+		});
+		expect(screen.getByTestId("after")).toHaveFocus();
+	});
+});

--- a/containers/mosaic/src/__tests__/components/Field/utils/createContainedBlurHandler.test.ts
+++ b/containers/mosaic/src/__tests__/components/Field/utils/createContainedBlurHandler.test.ts
@@ -1,0 +1,90 @@
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	createContainedBlurHandler,
+	isFocusInPickerOverlay,
+} from "@root/components/Field/utils/createContainedBlurHandler";
+
+describe("createContainedBlurHandler", () => {
+	it("does not call onBlur when relatedTarget is inside the container", () => {
+		const onBlur = vi.fn();
+		const container = document.createElement("div");
+		const inside = document.createElement("button");
+		container.appendChild(inside);
+		document.body.appendChild(container);
+
+		const containerRef = createRef<HTMLElement>();
+		(containerRef as { current: HTMLElement }).current = container;
+
+		const handleBlur = createContainedBlurHandler(containerRef, onBlur);
+		handleBlur({ relatedTarget: inside } as unknown as FocusEvent);
+
+		expect(onBlur).not.toHaveBeenCalled();
+		container.remove();
+	});
+
+	it("calls onBlur when focus leaves the container", async () => {
+		const onBlur = vi.fn();
+		const container = document.createElement("div");
+		const outside = document.createElement("button");
+		document.body.append(container, outside);
+
+		const containerRef = createRef<HTMLElement>();
+		(containerRef as { current: HTMLElement }).current = container;
+
+		const handleBlur = createContainedBlurHandler(containerRef, onBlur);
+		outside.focus();
+		handleBlur({ relatedTarget: outside } as unknown as FocusEvent);
+
+		await vi.waitFor(() => {
+			expect(onBlur).toHaveBeenCalledTimes(1);
+		});
+
+		container.remove();
+		outside.remove();
+	});
+
+	it("does not call onBlur when focus is still contained via options", async () => {
+		const onBlur = vi.fn();
+		const container = document.createElement("div");
+		const outside = document.createElement("button");
+		document.body.append(container, outside);
+
+		const containerRef = createRef<HTMLElement>();
+		(containerRef as { current: HTMLElement }).current = container;
+
+		const handleBlur = createContainedBlurHandler(containerRef, onBlur, {
+			isFocusStillContained: () => true,
+		});
+		outside.focus();
+		handleBlur({ relatedTarget: outside } as unknown as FocusEvent);
+
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+		expect(onBlur).not.toHaveBeenCalled();
+
+		container.remove();
+		outside.remove();
+	});
+});
+
+describe("isFocusInPickerOverlay", () => {
+	it("returns true when the active element is inside a pickers popper", () => {
+		const popper = document.createElement("div");
+		popper.className = "MuiPickersPopper-root";
+		const button = document.createElement("button");
+		popper.appendChild(button);
+		document.body.appendChild(popper);
+
+		expect(isFocusInPickerOverlay(button)).toBe(true);
+		popper.remove();
+	});
+
+	it("returns false when the active element is not in an overlay", () => {
+		const button = document.createElement("button");
+		document.body.appendChild(button);
+
+		expect(isFocusInPickerOverlay(button)).toBe(false);
+		button.remove();
+	});
+});

--- a/containers/mosaic/src/__tests__/components/Field/utils/createContainedBlurHandler.test.ts
+++ b/containers/mosaic/src/__tests__/components/Field/utils/createContainedBlurHandler.test.ts
@@ -66,6 +66,27 @@ describe("createContainedBlurHandler", () => {
 		container.remove();
 		outside.remove();
 	});
+
+	it("cancel prevents a scheduled onBlur from firing", async () => {
+		const onBlur = vi.fn();
+		const container = document.createElement("div");
+		const outside = document.createElement("button");
+		document.body.append(container, outside);
+
+		const containerRef = createRef<HTMLElement>();
+		(containerRef as { current: HTMLElement }).current = container;
+
+		const handleBlur = createContainedBlurHandler(containerRef, onBlur);
+		outside.focus();
+		handleBlur({ relatedTarget: outside } as unknown as FocusEvent);
+		handleBlur.cancel();
+
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+		expect(onBlur).not.toHaveBeenCalled();
+
+		container.remove();
+		outside.remove();
+	});
 });
 
 describe("isFocusInPickerOverlay", () => {

--- a/containers/mosaic/src/__tests__/components/Field/utils/createContainedBlurHandler.test.ts
+++ b/containers/mosaic/src/__tests__/components/Field/utils/createContainedBlurHandler.test.ts
@@ -90,9 +90,12 @@ describe("createContainedBlurHandler", () => {
 });
 
 describe("isFocusInPickerOverlay", () => {
-	it("returns true when the active element is inside a pickers popper", () => {
+	it.each([
+		"MuiPickerPopper-root",
+		"MuiPickersPopper-root",
+	])("returns true when the active element is inside %s", (className) => {
 		const popper = document.createElement("div");
-		popper.className = "MuiPickersPopper-root";
+		popper.className = className;
 		const button = document.createElement("button");
 		popper.appendChild(button);
 		document.body.appendChild(popper);

--- a/containers/mosaic/src/__tests__/components/Field/utils/getIsPartiallyFilled.test.ts
+++ b/containers/mosaic/src/__tests__/components/Field/utils/getIsPartiallyFilled.test.ts
@@ -1,0 +1,32 @@
+import { getIsPartiallyFilled } from "@root/components/Field/utils/getIsPartiallyFilled";
+import type { FieldSection } from "@mui/x-date-pickers/models";
+
+function section(value: string): FieldSection {
+	return {
+		value,
+		format: "MM",
+		maxLength: 2,
+		placeholder: "MM",
+		type: "month",
+		contentType: "digit",
+		hasLeadingZerosInFormat: true,
+		hasLeadingZerosInInput: true,
+		modified: false,
+		startSeparator: "",
+		endSeparator: "/",
+	};
+}
+
+describe(__dirname, () => {
+	it("should return false when all sections are empty", () => {
+		expect(getIsPartiallyFilled([section(""), section(""), section("")])).toBe(false);
+	});
+
+	it("should return false when all sections are filled", () => {
+		expect(getIsPartiallyFilled([section("01"), section("31"), section("2024")])).toBe(false);
+	});
+
+	it("should return true when some but not all sections are filled", () => {
+		expect(getIsPartiallyFilled([section("12"), section(""), section("")])).toBe(true);
+	});
+});

--- a/containers/mosaic/src/__tests__/components/Form/useForm/reducers.test.ts
+++ b/containers/mosaic/src/__tests__/components/Form/useForm/reducers.test.ts
@@ -1,0 +1,50 @@
+import { getInitialState } from "@root/components/Form/useForm/initial";
+import { reducer } from "@root/components/Form/useForm/reducers";
+
+describe(__dirname, () => {
+	it("should preserve inputRevision when set field values without a revision update", () => {
+		const state = {
+			...getInitialState(),
+			inputRevision: 2,
+			data: { date: new Date("2024-01-01") },
+			internalData: { date: { date: new Date("2024-01-01") } },
+		};
+
+		const nextState = reducer(state, {
+			type: "SET_FIELD_VALUES",
+			values: state.data,
+			internalValues: { date: { date: null } },
+		});
+
+		expect(nextState.inputRevision).toBe(2);
+	});
+
+	it("should update inputRevision when set field values includes a revision update", () => {
+		const state = getInitialState();
+
+		const nextState = reducer(state, {
+			type: "SET_FIELD_VALUES",
+			values: {},
+			internalValues: {},
+			inputRevision: 1,
+		});
+
+		expect(nextState.inputRevision).toBe(1);
+	});
+
+	it("should set inputRevision on reset", () => {
+		const state = {
+			...getInitialState(),
+			inputRevision: 4,
+		};
+
+		const nextState = reducer(state, {
+			type: "RESET",
+			data: {},
+			internalData: {},
+			inputRevision: 5,
+		});
+
+		expect(nextState.inputRevision).toBe(5);
+	});
+});

--- a/containers/mosaic/src/__tests__/utils/form/validators.dateTime.test.ts
+++ b/containers/mosaic/src/__tests__/utils/form/validators.dateTime.test.ts
@@ -1,0 +1,31 @@
+import { validateDate, validateTime } from "@root/utils/form/validators";
+
+describe(__dirname, () => {
+	it("should reject a partially filled date", async () => {
+		await expect(validateDate(undefined, {}, {}, {
+			date: null,
+			isPartiallyFilled: true,
+		})).resolves.toBe("Date is incomplete. Finish entering MM/DD/YYYY or clear the field");
+	});
+
+	it("should accept an empty date that is not partially filled", async () => {
+		await expect(validateDate(undefined, {}, {}, {
+			date: null,
+			isPartiallyFilled: false,
+		})).resolves.toBeUndefined();
+	});
+
+	it("should reject a partially filled time", async () => {
+		await expect(validateTime(undefined, {}, {}, {
+			time: null,
+			isPartiallyFilled: true,
+		})).resolves.toBe("Time is incomplete. Finish entering a 12hr time or clear the field");
+	});
+
+	it("should accept an empty time that is not partially filled", async () => {
+		await expect(validateTime(undefined, {}, {}, {
+			time: null,
+			isPartiallyFilled: false,
+		})).resolves.toBeUndefined();
+	});
+});

--- a/containers/mosaic/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
+++ b/containers/mosaic/src/components/DataViewFilterDate/DataViewFilterDateDropdownContent.tsx
@@ -103,6 +103,7 @@ export default function DataViewFilterDateDropdownContent(props: DataViewFilterD
 				rangeEnd : undefined,
 			},
 			validate: true,
+			resetInputs: true,
 		});
 
 		setSelectedOption(undefined);

--- a/containers/mosaic/src/components/Field/FieldTypes.tsx
+++ b/containers/mosaic/src/components/Field/FieldTypes.tsx
@@ -264,5 +264,11 @@ export interface FieldConfig {
 	externalToInternalValue: ExternalToInternalValue;
 	internalToExternalValue: InternalToExternalValue;
 	hasValue: FieldHasValue;
+	/**
+	 * When true, the field remounts when the form's `inputRevision` increments
+	 * (e.g. on reset or `setFormValues({ resetInputs: true })`). Used by
+	 * section-based MUI date/time pickers to clear partially filled input.
+	 */
+	needsInputReset?: boolean;
 }
 

--- a/containers/mosaic/src/components/Field/FieldTypes.tsx
+++ b/containers/mosaic/src/components/Field/FieldTypes.tsx
@@ -97,6 +97,11 @@ export interface MosaicFieldProps<T = any, U = any, V = any> {
 	 * root field.
 	 */
 	path?: FieldPath;
+	/**
+	 * Optional ref that section-based fields assign a flush callback to.
+	 * Invoked before submit validation to sync UI-only state into form data.
+	 */
+	flushRef?: MutableRefObject<(() => void) | null>;
 }
 
 // SHARED FIELD DEFINITION - DEVELOPER GENERIC CONTRACT

--- a/containers/mosaic/src/components/Field/FormFieldDate/DateFieldTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDate/DateFieldTypes.tsx
@@ -37,6 +37,11 @@ export interface DateFieldInputSettings {
 export interface DateData {
 	date: null | Date;
 	keyboardInputValue?: string;
+	/**
+	 * True when the section-based picker has some but not all sections filled.
+	 * Used to validate incomplete manual entry that never produces a Date.
+	 */
+	isPartiallyFilled?: boolean;
 }
 
 export type FieldDefDate = FieldDefBase<"date", DateFieldInputSettings>;

--- a/containers/mosaic/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
@@ -62,6 +62,10 @@ const DatePicker = (props: DatePickerProps): ReactElement => {
 		[notifyBlur],
 	);
 
+	useEffect(() => () => {
+		handleBlur.cancel();
+	}, [handleBlur]);
+
 	const handleOpen = useCallback(() => {
 		openRef.current = true;
 	}, []);

--- a/containers/mosaic/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
@@ -53,6 +53,10 @@ const DatePicker = (props: DatePickerProps): ReactElement => {
 		[onBlur, syncPartialFillState, value],
 	);
 
+	const handleClear = useCallback(() => {
+		onChange?.(null, undefined, { isPartiallyFilled: false });
+	}, [onChange]);
+
 	const handleChange = (newValue: Date | null, context: PickerChangeHandlerContext<DateValidationError>) => {
 		const keyboardInputValue = context.source !== "view" && isValid(newValue)
 			? format(newValue, DATE_FORMAT_FULL)
@@ -75,8 +79,13 @@ const DatePicker = (props: DatePickerProps): ReactElement => {
 					inputRef={inputRef as React.Ref<HTMLInputElement>}
 					slots={{ textField: DatePickerTextField }}
 					slotProps={{
-						// MUI accepts unstableFieldRef on the field, but omits it from PickerFieldSlotProps.
-						field: { unstableFieldRef: fieldRef } as object,
+						field: {
+							clearable: true,
+							onClear: handleClear,
+							// Supported by the field at runtime; omitted from PickerFieldSlotProps typing.
+							// @ts-expect-error unstableFieldRef is not in PickerFieldSlotProps
+							unstableFieldRef: fieldRef,
+						},
 						textField: {
 							id,
 							onBlur: handleBlur,

--- a/containers/mosaic/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
-import type { PickerChangeHandlerContext, DateValidationError } from "@mui/x-date-pickers/models";
+import type { FieldRef, PickerChangeHandlerContext, DateValidationError } from "@mui/x-date-pickers/models";
 
-import React, { useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import format from "date-fns/format";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFnsV2";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
@@ -12,15 +12,45 @@ import type { DatePickerProps } from ".";
 import { DatePickerTextField, popperSx } from "./DatePicker.styled";
 import { DATE_FORMAT_FULL } from "@root/constants";
 import { createContainedBlurHandler } from "../../utils/createContainedBlurHandler";
+import { getIsPartiallyFilled } from "../../utils/getIsPartiallyFilled";
 import { isValid } from "date-fns";
 
 const DatePicker = (props: DatePickerProps): ReactElement => {
-	const { fieldDef, onChange, value = null, onBlur, disabled, inputRef, id, error } = props;
+	const { fieldDef, onChange, value = null, onBlur, disabled, inputRef, id, error, flushRef } = props;
 
 	const containerRef = useRef<HTMLDivElement>(null);
+	const fieldRef = useRef<FieldRef<Date | null>>(null);
+
+	const syncPartialFillState = useCallback((
+		date: Date | null,
+		keyboardInputValue?: string,
+	) => {
+		const sections = fieldRef.current?.getSections() ?? [];
+		onChange?.(date, keyboardInputValue, {
+			isPartiallyFilled: getIsPartiallyFilled(sections),
+		});
+	}, [onChange]);
+
+	useEffect(() => {
+		if (!flushRef) {
+			return;
+		}
+
+		flushRef.current = () => {
+			syncPartialFillState(value);
+		};
+
+		return () => {
+			flushRef.current = null;
+		};
+	}, [flushRef, syncPartialFillState, value]);
+
 	const handleBlur = useMemo(
-		() => createContainedBlurHandler(containerRef, onBlur),
-		[onBlur],
+		() => createContainedBlurHandler(containerRef, () => {
+			syncPartialFillState(value);
+			onBlur?.();
+		}),
+		[onBlur, syncPartialFillState, value],
 	);
 
 	const handleChange = (newValue: Date | null, context: PickerChangeHandlerContext<DateValidationError>) => {
@@ -28,7 +58,7 @@ const DatePicker = (props: DatePickerProps): ReactElement => {
 			? format(newValue, DATE_FORMAT_FULL)
 			: undefined;
 
-		onChange(newValue, keyboardInputValue);
+		syncPartialFillState(newValue, keyboardInputValue);
 	};
 
 	return (
@@ -45,12 +75,14 @@ const DatePicker = (props: DatePickerProps): ReactElement => {
 					inputRef={inputRef as React.Ref<HTMLInputElement>}
 					slots={{ textField: DatePickerTextField }}
 					slotProps={{
+						// MUI accepts unstableFieldRef on the field, but omits it from PickerFieldSlotProps.
+						field: { unstableFieldRef: fieldRef } as object,
 						textField: {
 							id,
 							onBlur: handleBlur,
 							required: Boolean(fieldDef.required),
 							disabled,
-							error: Boolean(error),
+							error: error ? true : undefined,
 							inputProps: {
 								"aria-label": fieldDef.label,
 							},

--- a/containers/mosaic/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDate/DatePicker/DatePicker.tsx
@@ -20,6 +20,9 @@ const DatePicker = (props: DatePickerProps): ReactElement => {
 
 	const containerRef = useRef<HTMLDivElement>(null);
 	const fieldRef = useRef<FieldRef<Date | null>>(null);
+	const openRef = useRef(false);
+	const valueRef = useRef(value);
+	valueRef.current = value;
 
 	const syncPartialFillState = useCallback((
 		date: Date | null,
@@ -37,23 +40,39 @@ const DatePicker = (props: DatePickerProps): ReactElement => {
 		}
 
 		flushRef.current = () => {
-			syncPartialFillState(value);
+			syncPartialFillState(valueRef.current);
 		};
 
 		return () => {
 			flushRef.current = null;
 		};
-	}, [flushRef, syncPartialFillState, value]);
+	}, [flushRef, syncPartialFillState]);
+
+	const notifyBlur = useCallback(() => {
+		// Prefer valueRef: onClose runs in the same tick as onChange after a calendar
+		// selection, before React re-renders with the new `value` prop.
+		syncPartialFillState(valueRef.current);
+		onBlur?.();
+	}, [onBlur, syncPartialFillState]);
 
 	const handleBlur = useMemo(
-		() => createContainedBlurHandler(containerRef, () => {
-			syncPartialFillState(value);
-			onBlur?.();
+		() => createContainedBlurHandler(containerRef, notifyBlur, {
+			isFocusStillContained: () => openRef.current,
 		}),
-		[onBlur, syncPartialFillState, value],
+		[notifyBlur],
 	);
 
+	const handleOpen = useCallback(() => {
+		openRef.current = true;
+	}, []);
+
+	const handleClose = useCallback(() => {
+		openRef.current = false;
+		notifyBlur();
+	}, [notifyBlur]);
+
 	const handleClear = useCallback(() => {
+		valueRef.current = null;
 		onChange?.(null, undefined, { isPartiallyFilled: false });
 	}, [onChange]);
 
@@ -62,17 +81,19 @@ const DatePicker = (props: DatePickerProps): ReactElement => {
 			? format(newValue, DATE_FORMAT_FULL)
 			: undefined;
 
+		valueRef.current = newValue;
 		syncPartialFillState(newValue, keyboardInputValue);
 	};
 
 	return (
 		<LocalizationProvider dateAdapter={AdapterDateFns}>
-			<div ref={containerRef} data-testid="date-picker-test-id">
+			<div ref={containerRef} onBlur={handleBlur} data-testid="date-picker-test-id">
 				<DesktopDatePicker
 					format={DATE_FORMAT_FULL}
 					value={value}
 					onChange={handleChange}
-					onClose={handleBlur}
+					onOpen={handleOpen}
+					onClose={handleClose}
 					minDate={fieldDef?.inputSettings?.minDate}
 					maxDate={fieldDef?.inputSettings?.maxDate}
 					disabled={disabled}
@@ -88,7 +109,6 @@ const DatePicker = (props: DatePickerProps): ReactElement => {
 						},
 						textField: {
 							id,
-							onBlur: handleBlur,
 							required: Boolean(fieldDef.required),
 							disabled,
 							error: error ? true : undefined,

--- a/containers/mosaic/src/components/Field/FormFieldDate/DatePicker/DatePickerTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDate/DatePicker/DatePickerTypes.tsx
@@ -1,6 +1,10 @@
 import type { MosaicFieldProps } from "@root/components/Field/FieldTypes";
 
+export interface DatePickerChangeOptions {
+	isPartiallyFilled?: boolean;
+}
+
 export interface DatePickerProps extends Omit<MosaicFieldProps, "onChange"> {
-	onChange?: (date: Date | null, keyboardInputValue?: string) => void;
+	onChange?: (date: Date | null, keyboardInputValue?: string, options?: DatePickerChangeOptions) => void;
 	minDate?: Date;
 }

--- a/containers/mosaic/src/components/Field/FormFieldDate/FormFieldDate.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldDate/FormFieldDate.tsx
@@ -22,6 +22,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 		inputRef,
 		skeleton,
 		id,
+		flushRef,
 	} = props;
 	const {
 		inputSettings: {
@@ -33,9 +34,18 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 	const value = useMemo(() => providedValue || {
 		date: null,
 		keyboardInputValue: undefined,
+		isPartiallyFilled: false,
 	}, [providedValue]);
 
-	const handleDateChange = (date: Date | null, keyboardInputValue?: string) => onChange({ date, keyboardInputValue });
+	const handleDateChange = (
+		date: Date | null,
+		keyboardInputValue?: string,
+		options?: { isPartiallyFilled?: boolean },
+	) => onChange({
+		date,
+		keyboardInputValue,
+		isPartiallyFilled: options?.isPartiallyFilled ?? false,
+	});
 
 	if (skeleton) {
 		return (
@@ -69,6 +79,7 @@ const FormFieldDate = (props: MosaicFieldProps<"date", DateFieldInputSettings, D
 				onBlur={onBlur}
 				disabled={disabled}
 				inputRef={inputRef}
+				flushRef={flushRef}
 
 			/>
 		</DateTimePickerWrapper>

--- a/containers/mosaic/src/components/Field/FormFieldTime/TimeField/FormFieldTime.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTime/TimeField/FormFieldTime.tsx
@@ -27,6 +27,7 @@ const FormFieldTime = (props: MosaicFieldProps<"time", TimeFieldInputSettings, T
 		id,
 		skeleton,
 		path,
+		flushRef,
 	} = props;
 	const { name, inputSettings = {} } = fieldDef;
 	const { defaultTime } = inputSettings;
@@ -34,6 +35,7 @@ const FormFieldTime = (props: MosaicFieldProps<"time", TimeFieldInputSettings, T
 	const value = useMemo(() => providedValue || {
 		time: null,
 		keyboardInputValue: undefined,
+		isPartiallyFilled: false,
 	}, [providedValue]);
 
 	const { methods: { addHook } } = useContext(FormContext);
@@ -70,6 +72,7 @@ const FormFieldTime = (props: MosaicFieldProps<"time", TimeFieldInputSettings, T
 						time: null,
 						keyboardInputValue: undefined,
 						usingDefaultTime: true,
+						isPartiallyFilled: false,
 					}, internalData),
 				};
 			}
@@ -80,16 +83,22 @@ const FormFieldTime = (props: MosaicFieldProps<"time", TimeFieldInputSettings, T
 					time: matchTime(new Date(), defaultTime),
 					keyboardInputValue: undefined,
 					usingDefaultTime: true,
+					isPartiallyFilled: false,
 				}, internalData),
 			};
 		});
 	}, [addHook, defaultTime, path, name]);
 
-	const handleTimeChange = (time: Date | null, keyboardInputValue?: string) => {
+	const handleTimeChange = (
+		time: Date | null,
+		keyboardInputValue?: string,
+		options?: { isPartiallyFilled?: boolean },
+	) => {
 		return onChange({
 			time,
 			keyboardInputValue,
 			usingDefaultTime: !time || !isValidDate(time),
+			isPartiallyFilled: options?.isPartiallyFilled ?? false,
 		});
 	};
 
@@ -120,6 +129,7 @@ const FormFieldTime = (props: MosaicFieldProps<"time", TimeFieldInputSettings, T
 			onBlur={onBlur}
 			disabled={disabled}
 			inputRef={inputRef}
+			flushRef={flushRef}
 		/>
 	);
 };

--- a/containers/mosaic/src/components/Field/FormFieldTime/TimeField/TimeFieldTypes.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTime/TimeField/TimeFieldTypes.tsx
@@ -15,6 +15,11 @@ export interface TimeData {
 	time: null | Date;
 	keyboardInputValue?: string;
 	usingDefaultTime?: boolean;
+	/**
+	 * True when the section-based picker has some but not all sections filled.
+	 * Used to validate incomplete manual entry that never produces a Date.
+	 */
+	isPartiallyFilled?: boolean;
 }
 
 export type FieldDefTime = FieldDefBase<"time", TimeFieldInputSettings>;

--- a/containers/mosaic/src/components/Field/FormFieldTime/TimePicker/TimePicker.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTime/TimePicker/TimePicker.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import type { ReactElement } from "react";
-import type { PickerChangeHandlerContext, TimeValidationError } from "@mui/x-date-pickers/models";
-import { useCallback, useMemo, useRef } from "react";
+import type { FieldRef, PickerChangeHandlerContext, TimeValidationError } from "@mui/x-date-pickers/models";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import format from "date-fns/format";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
@@ -17,27 +17,66 @@ import { ThemeProvider } from "@mui/material/styles";
 import { MosaicPickersTextField } from "../../FormFieldText/FormFieldTextPickers.styled";
 import { TIME_FORMAT_FULL } from "@root/constants";
 import { createContainedBlurHandler } from "../../utils/createContainedBlurHandler";
+import { getIsPartiallyFilled } from "../../utils/getIsPartiallyFilled";
 import { isValid } from "date-fns";
 
-const TimeFieldPicker = (props: MosaicFieldProps<"timePicker", TimePickerDef, TimePickerData>): ReactElement => {
-	const { fieldDef, onChange, value = null, onBlur, disabled, inputRef, id, error } = props;
+export interface TimePickerChangeOptions {
+	isPartiallyFilled?: boolean;
+}
+
+type TimePickerProps = Omit<MosaicFieldProps<"timePicker", TimePickerDef, TimePickerData>, "onChange"> & {
+	onChange?: (time: Date | null, keyboardInputValue?: string, options?: TimePickerChangeOptions) => void;
+};
+
+const TimeFieldPicker = (props: TimePickerProps): ReactElement => {
+	const { fieldDef, onChange, value = null, onBlur, disabled, inputRef, id, error, flushRef } = props;
 
 	const containerRef = useRef<HTMLDivElement>(null);
+	const fieldRef = useRef<FieldRef<Date | null>>(null);
+
+	const syncPartialFillState = useCallback((
+		time: Date | null,
+		keyboardInputValue?: string,
+	) => {
+		const sections = fieldRef.current?.getSections() ?? [];
+		onChange?.(time, keyboardInputValue, {
+			isPartiallyFilled: getIsPartiallyFilled(sections),
+		});
+	}, [onChange]);
+
+	useEffect(() => {
+		if (!flushRef) {
+			return;
+		}
+
+		flushRef.current = () => {
+			syncPartialFillState(value);
+		};
+
+		return () => {
+			flushRef.current = null;
+		};
+	}, [flushRef, syncPartialFillState, value]);
+
 	const handleBlur = useMemo(
-		() => createContainedBlurHandler(containerRef, onBlur),
-		[onBlur],
+		() => createContainedBlurHandler(containerRef, () => {
+			syncPartialFillState(value);
+			onBlur?.();
+		}),
+		[onBlur, syncPartialFillState, value],
 	);
 
 	const handleClose = useCallback(async () => {
+		syncPartialFillState(value);
 		onBlur && onBlur();
-	}, [onBlur]);
+	}, [onBlur, syncPartialFillState, value]);
 
 	const handleChange = (newValue: Date | null, context: PickerChangeHandlerContext<TimeValidationError>) => {
 		const keyboardInputValue = context.source !== "view" && isValid(newValue)
 			? format(newValue, TIME_FORMAT_FULL)
 			: undefined;
 
-		onChange(newValue, keyboardInputValue);
+		syncPartialFillState(newValue, keyboardInputValue);
 	};
 
 	return (
@@ -55,12 +94,14 @@ const TimeFieldPicker = (props: MosaicFieldProps<"timePicker", TimePickerDef, Ti
 						inputRef={inputRef as React.Ref<HTMLInputElement>}
 						slots={{ textField: MosaicPickersTextField }}
 						slotProps={{
+							// MUI accepts unstableFieldRef on the field, but omits it from PickerFieldSlotProps.
+							field: { unstableFieldRef: fieldRef } as object,
 							textField: {
 								id,
 								onBlur: handleBlur,
 								required: Boolean(fieldDef.required),
 								disabled,
-								error: Boolean(error),
+								error: error ? true : undefined,
 								inputProps: {
 									"aria-label": fieldDef.label,
 								},

--- a/containers/mosaic/src/components/Field/FormFieldTime/TimePicker/TimePicker.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTime/TimePicker/TimePicker.tsx
@@ -75,6 +75,10 @@ const TimeFieldPicker = (props: TimePickerProps): ReactElement => {
 		[notifyBlur],
 	);
 
+	useEffect(() => () => {
+		handleBlur.cancel();
+	}, [handleBlur]);
+
 	const handleOpen = useCallback(() => {
 		openRef.current = true;
 	}, []);

--- a/containers/mosaic/src/components/Field/FormFieldTime/TimePicker/TimePicker.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTime/TimePicker/TimePicker.tsx
@@ -71,6 +71,10 @@ const TimeFieldPicker = (props: TimePickerProps): ReactElement => {
 		onBlur && onBlur();
 	}, [onBlur, syncPartialFillState, value]);
 
+	const handleClear = useCallback(() => {
+		onChange?.(null, undefined, { isPartiallyFilled: false });
+	}, [onChange]);
+
 	const handleChange = (newValue: Date | null, context: PickerChangeHandlerContext<TimeValidationError>) => {
 		const keyboardInputValue = context.source !== "view" && isValid(newValue)
 			? format(newValue, TIME_FORMAT_FULL)
@@ -94,8 +98,13 @@ const TimeFieldPicker = (props: TimePickerProps): ReactElement => {
 						inputRef={inputRef as React.Ref<HTMLInputElement>}
 						slots={{ textField: MosaicPickersTextField }}
 						slotProps={{
-							// MUI accepts unstableFieldRef on the field, but omits it from PickerFieldSlotProps.
-							field: { unstableFieldRef: fieldRef } as object,
+							field: {
+								clearable: true,
+								onClear: handleClear,
+								// Supported by the field at runtime; omitted from PickerFieldSlotProps typing.
+								// @ts-expect-error unstableFieldRef is not in PickerFieldSlotProps
+								unstableFieldRef: fieldRef,
+							},
 							textField: {
 								id,
 								onBlur: handleBlur,

--- a/containers/mosaic/src/components/Field/FormFieldTime/TimePicker/TimePicker.tsx
+++ b/containers/mosaic/src/components/Field/FormFieldTime/TimePicker/TimePicker.tsx
@@ -33,6 +33,9 @@ const TimeFieldPicker = (props: TimePickerProps): ReactElement => {
 
 	const containerRef = useRef<HTMLDivElement>(null);
 	const fieldRef = useRef<FieldRef<Date | null>>(null);
+	const openRef = useRef(false);
+	const valueRef = useRef(value);
+	valueRef.current = value;
 
 	const syncPartialFillState = useCallback((
 		time: Date | null,
@@ -50,28 +53,39 @@ const TimeFieldPicker = (props: TimePickerProps): ReactElement => {
 		}
 
 		flushRef.current = () => {
-			syncPartialFillState(value);
+			syncPartialFillState(valueRef.current);
 		};
 
 		return () => {
 			flushRef.current = null;
 		};
-	}, [flushRef, syncPartialFillState, value]);
+	}, [flushRef, syncPartialFillState]);
+
+	const notifyBlur = useCallback(() => {
+		// Prefer valueRef: onClose runs in the same tick as onChange after a picker
+		// selection, before React re-renders with the new `value` prop.
+		syncPartialFillState(valueRef.current);
+		onBlur?.();
+	}, [onBlur, syncPartialFillState]);
 
 	const handleBlur = useMemo(
-		() => createContainedBlurHandler(containerRef, () => {
-			syncPartialFillState(value);
-			onBlur?.();
+		() => createContainedBlurHandler(containerRef, notifyBlur, {
+			isFocusStillContained: () => openRef.current,
 		}),
-		[onBlur, syncPartialFillState, value],
+		[notifyBlur],
 	);
 
-	const handleClose = useCallback(async () => {
-		syncPartialFillState(value);
-		onBlur && onBlur();
-	}, [onBlur, syncPartialFillState, value]);
+	const handleOpen = useCallback(() => {
+		openRef.current = true;
+	}, []);
+
+	const handleClose = useCallback(() => {
+		openRef.current = false;
+		notifyBlur();
+	}, [notifyBlur]);
 
 	const handleClear = useCallback(() => {
+		valueRef.current = null;
 		onChange?.(null, undefined, { isPartiallyFilled: false });
 	}, [onChange]);
 
@@ -80,17 +94,19 @@ const TimeFieldPicker = (props: TimePickerProps): ReactElement => {
 			? format(newValue, TIME_FORMAT_FULL)
 			: undefined;
 
+		valueRef.current = newValue;
 		syncPartialFillState(newValue, keyboardInputValue);
 	};
 
 	return (
 		<LocalizationProvider dateAdapter={AdapterDateFns} localeText={{ fieldMeridiemPlaceholder: () => "AM/PM" }}>
 			<ThemeProvider theme={customTheme}>
-				<div ref={containerRef}>
+				<div ref={containerRef} onBlur={handleBlur}>
 					<TimePicker
 						format={TIME_FORMAT_FULL}
 						value={value}
 						onChange={handleChange}
+						onOpen={handleOpen}
 						onClose={handleClose}
 						disabled={disabled}
 						closeOnSelect
@@ -107,7 +123,6 @@ const TimeFieldPicker = (props: TimePickerProps): ReactElement => {
 							},
 							textField: {
 								id,
-								onBlur: handleBlur,
 								required: Boolean(fieldDef.required),
 								disabled,
 								error: error ? true : undefined,

--- a/containers/mosaic/src/components/Field/utils/createContainedBlurHandler.ts
+++ b/containers/mosaic/src/components/Field/utils/createContainedBlurHandler.ts
@@ -26,12 +26,18 @@ export interface ContainedBlurHandlerOptions {
 	isFocusStillContained?: () => boolean;
 }
 
+export type ContainedBlurHandler = ((event?: FocusEvent) => void) & {
+	cancel: () => void;
+};
+
 export function createContainedBlurHandler(
 	containerRef: RefObject<HTMLElement | null>,
 	onBlur?: () => void,
 	options?: ContainedBlurHandlerOptions,
-): (event?: FocusEvent) => void {
-	return (event?: FocusEvent) => {
+): ContainedBlurHandler {
+	let frameId: number | undefined;
+
+	const handler = ((event?: FocusEvent) => {
 		if (!onBlur) {
 			return;
 		}
@@ -41,7 +47,13 @@ export function createContainedBlurHandler(
 			return;
 		}
 
-		requestAnimationFrame(() => {
+		if (frameId !== undefined) {
+			cancelAnimationFrame(frameId);
+		}
+
+		frameId = requestAnimationFrame(() => {
+			frameId = undefined;
+
 			if (containerRef.current?.contains(document.activeElement)) {
 				return;
 			}
@@ -52,5 +64,14 @@ export function createContainedBlurHandler(
 
 			onBlur();
 		});
+	}) as ContainedBlurHandler;
+
+	handler.cancel = () => {
+		if (frameId !== undefined) {
+			cancelAnimationFrame(frameId);
+			frameId = undefined;
+		}
 	};
+
+	return handler;
 }

--- a/containers/mosaic/src/components/Field/utils/createContainedBlurHandler.ts
+++ b/containers/mosaic/src/components/Field/utils/createContainedBlurHandler.ts
@@ -19,7 +19,9 @@ export function isFocusInPickerOverlay(activeElement: Element | null = document.
 		return false;
 	}
 
-	return Boolean(activeElement.closest(".MuiPickersPopper-root, .MuiModal-root"));
+	// MUI X renamed the popper root from MuiPickersPopper-root to MuiPickerPopper-root;
+	// keep both so focus-in-overlay detection works across versions.
+	return Boolean(activeElement.closest(".MuiPickerPopper-root, .MuiPickersPopper-root, .MuiModal-root"));
 }
 
 export interface ContainedBlurHandlerOptions {

--- a/containers/mosaic/src/components/Field/utils/createContainedBlurHandler.ts
+++ b/containers/mosaic/src/components/Field/utils/createContainedBlurHandler.ts
@@ -4,10 +4,32 @@ import type { FocusEvent, RefObject } from "react";
  * MUI X accessible pickers fire blur on the section container when focus moves
  * between internal elements (e.g. tabbing into the field). Only call onBlur when
  * focus has actually left the picker container.
+ *
+ * Clear/open adornments sit inside the container but outside the text field, so
+ * callers should attach this handler to the container (React onBlur bubbles via
+ * focusout) rather than only the text field — otherwise tabbing out via those
+ * buttons never notifies the form.
+ *
+ * Open picker overlays are portaled outside the container; pass
+ * `isFocusStillContained` (e.g. open ref / overlay DOM check) to avoid treating
+ * that as a leave.
  */
+export function isFocusInPickerOverlay(activeElement: Element | null = document.activeElement): boolean {
+	if (!(activeElement instanceof Element)) {
+		return false;
+	}
+
+	return Boolean(activeElement.closest(".MuiPickersPopper-root, .MuiModal-root"));
+}
+
+export interface ContainedBlurHandlerOptions {
+	isFocusStillContained?: () => boolean;
+}
+
 export function createContainedBlurHandler(
 	containerRef: RefObject<HTMLElement | null>,
 	onBlur?: () => void,
+	options?: ContainedBlurHandlerOptions,
 ): (event?: FocusEvent) => void {
 	return (event?: FocusEvent) => {
 		if (!onBlur) {
@@ -20,9 +42,15 @@ export function createContainedBlurHandler(
 		}
 
 		requestAnimationFrame(() => {
-			if (!containerRef.current?.contains(document.activeElement)) {
-				onBlur();
+			if (containerRef.current?.contains(document.activeElement)) {
+				return;
 			}
+
+			if (options?.isFocusStillContained?.() || isFocusInPickerOverlay()) {
+				return;
+			}
+
+			onBlur();
 		});
 	};
 }

--- a/containers/mosaic/src/components/Field/utils/getIsPartiallyFilled.ts
+++ b/containers/mosaic/src/components/Field/utils/getIsPartiallyFilled.ts
@@ -1,0 +1,11 @@
+import type { FieldSection } from "@mui/x-date-pickers/models";
+
+/**
+ * Returns true when some but not all field sections have a value.
+ * Matches MUI X's internal partial-fill check used on blur.
+ */
+export function getIsPartiallyFilled(sections: FieldSection[]): boolean {
+	const filledCount = sections.filter((section) => section.value !== "").length;
+
+	return filledCount > 0 && filledCount < sections.length;
+}

--- a/containers/mosaic/src/components/Form/Field/Field.tsx
+++ b/containers/mosaic/src/components/Form/Field/Field.tsx
@@ -39,6 +39,7 @@ const Field = ({
 
 	const disabled = useWrappedToggle(field, state, "disabled", false);
 	const inputRef = useRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | undefined>(undefined);
+	const flushRef = useRef<(() => void) | null>(null);
 
 	const onChange = useCallback((value: any, options: any = {}) => {
 		field.onChangeCb && field.onChangeCb();
@@ -92,6 +93,7 @@ const Field = ({
 			id={`${(field.id ?? field.name)}-input`}
 			skeleton={skeleton}
 			path={path}
+			flushRef={needsInputReset ? flushRef : undefined}
 		/>
 	), [
 		Component,
@@ -107,6 +109,7 @@ const Field = ({
 		field.name,
 		skeleton,
 		path,
+		needsInputReset,
 	]);
 
 	if (!shouldShow) {
@@ -125,6 +128,7 @@ const Field = ({
 		inputRef: inputRef,
 		disabled: disabled,
 		skeleton: skeleton,
+		flushRef: needsInputReset ? flushRef : undefined,
 	};
 
 	return isCustomField ? (

--- a/containers/mosaic/src/components/Form/Field/Field.tsx
+++ b/containers/mosaic/src/components/Form/Field/Field.tsx
@@ -30,7 +30,7 @@ const Field = ({
 	}
 
 	const isCustomField = typeof field.type !== "string";
-	const { Component }: FieldConfig = getFieldConfig(field.type);
+	const { Component, needsInputReset = false }: FieldConfig = getFieldConfig(field.type);
 	const { setFieldValue, setFieldBlur } = methods;
 
 	if (!Component) {
@@ -73,8 +73,12 @@ const Field = ({
 
 	const sanitizedFieldDef = useMemo(() => ({ ...field, size }), [field, size]);
 
+	const fieldPathKey = [...(path || []), field.name].join(".");
+	const componentKey = needsInputReset ? `${fieldPathKey}-${state.inputRevision}` : fieldPathKey;
+
 	const children = useMemo(() => (
 		<Component
+			key={componentKey}
 			fieldDef={sanitizedFieldDef}
 			name={sanitizedFieldDef.name}
 			value={value}
@@ -91,6 +95,7 @@ const Field = ({
 		/>
 	), [
 		Component,
+		componentKey,
 		sanitizedFieldDef,
 		value,
 		error,

--- a/containers/mosaic/src/components/Form/useForm/initial.ts
+++ b/containers/mosaic/src/components/Form/useForm/initial.ts
@@ -10,6 +10,7 @@ export function getInitialState(): FormState {
 		submitWarning: { open: false, lead: "", reasons: [] },
 		waits: [],
 		skeleton: false,
+		inputRevision: 0,
 	};
 }
 

--- a/containers/mosaic/src/components/Form/useForm/reducers.ts
+++ b/containers/mosaic/src/components/Form/useForm/reducers.ts
@@ -24,6 +24,7 @@ export function reducer(state: FormState, action: FormAction): FormState {
 			touched: action.touched || state.touched,
 			skeleton: action.skeleton !== undefined ? action.skeleton : state.skeleton,
 			disabled: action.disabled !== undefined ? action.disabled : state.disabled,
+			inputRevision: action.inputRevision !== undefined ? action.inputRevision : state.inputRevision,
 		};
 	}
 	case "SET_FORM_WAITS": {
@@ -38,6 +39,7 @@ export function reducer(state: FormState, action: FormAction): FormState {
 			data: action.data,
 			internalData: action.internalData,
 			disabled: false,
+			inputRevision: action.inputRevision,
 		};
 	}
 	case "FORM_DISABLE": {

--- a/containers/mosaic/src/components/Form/useForm/types.ts
+++ b/containers/mosaic/src/components/Form/useForm/types.ts
@@ -36,6 +36,7 @@ export interface ActionSetFieldValues {
 	touched?: FormState["touched"];
 	skeleton?: boolean;
 	disabled?: boolean;
+	inputRevision?: number;
 }
 
 export interface ActionSetFormWaits {
@@ -47,6 +48,7 @@ export interface ActionReset {
 	type: "RESET";
 	data: MosaicObject<any>;
 	internalData: MosaicObject<any>;
+	inputRevision: number;
 }
 
 export type ActionSetSubmitWarning = FormState["submitWarning"] & {
@@ -92,6 +94,11 @@ export interface SetFormValuesParams {
 	skeleton?: boolean;
 	disabled?: boolean;
 	validate?: boolean;
+	/**
+	 * When true, increments `inputRevision` so section-based date/time pickers
+	 * remount and clear any partially filled internal state.
+	 */
+	resetInputs?: boolean;
 }
 
 export type SetFormValues = (params: SetFormValuesParams) => void;
@@ -201,6 +208,10 @@ export interface FormState {
 	submitWarning: { open: boolean; lead: string; reasons: string[] };
 	waits: FormWait[];
 	skeleton?: boolean;
+	/**
+	 * Incremented when the form is reset or cleared so date/time pickers remount.
+	 */
+	inputRevision: number;
 }
 
 export type UseFormParams = Partial<Pick<FormState, "disabled" | "skeleton" | "data">>;

--- a/containers/mosaic/src/components/Form/useForm/types.ts
+++ b/containers/mosaic/src/components/Form/useForm/types.ts
@@ -153,6 +153,11 @@ export interface MountFieldParams {
 	path?: FieldPath;
 	fieldRef?: HTMLDivElement;
 	inputRef?: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+	/**
+	 * Optional callback invoked before submit validation so fields can sync
+	 * UI-only state (e.g. partially filled date/time sections) into form data.
+	 */
+	flush?: () => void;
 }
 
 export type UnmountField = () => void;
@@ -225,7 +230,11 @@ export interface UseFormReturn {
 export type FormStable = FormState & {
 	initialData: MosaicObject<any>;
 	fields: Record<string, FieldObj>;
-	mounted: Record<string, false | { fieldRef?: HTMLDivElement; inputRef?: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement }>;
+	mounted: Record<string, false | {
+		fieldRef?: HTMLDivElement;
+		inputRef?: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+		flush?: () => void;
+	}>;
 	hasBlurred: Record<string, boolean>;
 	hasSubmitted: boolean;
 	moveToError: boolean;

--- a/containers/mosaic/src/components/Form/useForm/types.ts
+++ b/containers/mosaic/src/components/Form/useForm/types.ts
@@ -239,6 +239,11 @@ export type FormStable = FormState & {
 	hasSubmitted: boolean;
 	moveToError: boolean;
 	hooks: { [T in keyof FormHooks]: FormHooks[T][] };
+	/**
+	 * True while `setFormValues` is in flight. Blocks `setFieldValue` so async
+	 * picker blur handlers cannot undo an in-progress form values write.
+	 */
+	settingFormValues?: boolean;
 };
 
 export type ValidatorFn = (

--- a/containers/mosaic/src/components/Form/useForm/useForm.ts
+++ b/containers/mosaic/src/components/Form/useForm/useForm.ts
@@ -308,6 +308,14 @@ export function useForm(initial: UseFormParams = {}): UseFormReturn {
 
 		stable.current.hasSubmitted = true;
 
+		/**
+		 * Let fields with UI-only state (e.g. partially filled date/time sections)
+		 * sync into form data before validation. Independent of validateOn timing.
+		 */
+		Object.values(stable.current.mounted).forEach((mounted) => {
+			mounted && mounted.flush?.();
+		});
+
 		const { count, errors } = await getFieldErrors({
 			stable: stable.current,
 		});
@@ -399,12 +407,13 @@ export function useForm(initial: UseFormParams = {}): UseFormReturn {
 		};
 	}, [removeWait]);
 
-	const mountField = useCallback<MountField>(({ name, path = [], fieldRef, inputRef }) => {
+	const mountField = useCallback<MountField>(({ name, path = [], fieldRef, inputRef, flush }) => {
 		const key = [...path, name].join(".");
 
 		stable.current.mounted[key] = {
 			fieldRef,
 			inputRef,
+			flush,
 		};
 
 		return {

--- a/containers/mosaic/src/components/Form/useForm/useForm.ts
+++ b/containers/mosaic/src/components/Form/useForm/useForm.ts
@@ -104,8 +104,12 @@ export function useForm(initial: UseFormParams = {}): UseFormReturn {
 		 * so if path is empty, we'll just assign the values instead of "setting"
 		 * them.
 		 */
-		stable.current.data = path.length ? set(path, values, stable.current.data) : values;
-		stable.current.internalData = path.length ? set(path, internalValues, stable.current.internalData) : internalValues;
+		const nextData = path.length ? set(path, values, stable.current.data) : values;
+		const nextInternalData = path.length ? set(path, internalValues, stable.current.internalData) : internalValues;
+
+		stable.current.settingFormValues = true;
+		stable.current.data = nextData;
+		stable.current.internalData = nextInternalData;
 
 		if (resetInputs) {
 			stable.current.inputRevision += 1;
@@ -115,25 +119,35 @@ export function useForm(initial: UseFormParams = {}): UseFormReturn {
 			stable.current.skeleton = skeleton;
 		}
 
-		if (validate) {
-			const { errors } = await getFieldErrors({ stable: stable.current });
+		const inputRevision = resetInputs ? stable.current.inputRevision : undefined;
 
-			stable.current.errors = path.length ? set(path, errors, stable.current.errors) : errors;
+		try {
+			if (validate) {
+				const { errors } = await getFieldErrors({ stable: stable.current });
 
-			dispatch({
-				type: "SET_FIELD_ERRORS",
-				errors: stable.current.errors,
+				stable.current.errors = path.length ? set(path, errors, stable.current.errors) : errors;
+
+				dispatch({
+					type: "SET_FIELD_ERRORS",
+					errors: stable.current.errors,
+				});
+			}
+
+			// Re-assert after await: blur rAF may have raced before the lock took effect.
+			stable.current.data = nextData;
+			stable.current.internalData = nextInternalData;
+
+			return dispatch({
+				type: "SET_FIELD_VALUES",
+				values: nextData,
+				internalValues: nextInternalData,
+				skeleton,
+				disabled,
+				inputRevision,
 			});
+		} finally {
+			stable.current.settingFormValues = false;
 		}
-
-		return dispatch({
-			type: "SET_FIELD_VALUES",
-			values: stable.current.data,
-			internalValues: stable.current.internalData,
-			skeleton,
-			disabled,
-			inputRevision: resetInputs ? stable.current.inputRevision : undefined,
-		});
 	}, []);
 
 	const init = useCallback<FormInit>(({
@@ -192,6 +206,10 @@ export function useForm(initial: UseFormParams = {}): UseFormReturn {
 		validate,
 		path = [],
 	}) => {
+		if (stable.current.settingFormValues) {
+			return;
+		}
+
 		const fullPath = [...path, name];
 		const field = getField({ name, path, stable: stable.current });
 		const { errors, hasBlurred, hasSubmitted } = stable.current;

--- a/containers/mosaic/src/components/Form/useForm/useForm.ts
+++ b/containers/mosaic/src/components/Form/useForm/useForm.ts
@@ -96,6 +96,7 @@ export function useForm(initial: UseFormParams = {}): UseFormReturn {
 		skeleton,
 		disabled,
 		validate,
+		resetInputs,
 	}) => {
 		const internalValues = getFieldInternalValues(values, getFields({ stable: stable.current, path }));
 		/**
@@ -105,6 +106,10 @@ export function useForm(initial: UseFormParams = {}): UseFormReturn {
 		 */
 		stable.current.data = path.length ? set(path, values, stable.current.data) : values;
 		stable.current.internalData = path.length ? set(path, internalValues, stable.current.internalData) : internalValues;
+
+		if (resetInputs) {
+			stable.current.inputRevision += 1;
+		}
 
 		if (skeleton !== undefined) {
 			stable.current.skeleton = skeleton;
@@ -127,6 +132,7 @@ export function useForm(initial: UseFormParams = {}): UseFormReturn {
 			internalValues: stable.current.internalData,
 			skeleton,
 			disabled,
+			inputRevision: resetInputs ? stable.current.inputRevision : undefined,
 		});
 	}, []);
 
@@ -159,6 +165,7 @@ export function useForm(initial: UseFormParams = {}): UseFormReturn {
 		const { initialData, fields } = stable.current;
 		const values = { ...initialData };
 		const internalValues = getFieldInternalValues(initialData, fields);
+		const inputRevision = stable.current.inputRevision + 1;
 
 		stable.current = {
 			...getInitialState(),
@@ -167,12 +174,14 @@ export function useForm(initial: UseFormParams = {}): UseFormReturn {
 			data: values,
 			internalData: internalValues,
 			disabled: false,
+			inputRevision,
 		};
 
 		dispatch({
 			type: "RESET",
 			data: values,
 			internalData: internalValues,
+			inputRevision,
 		});
 	}, []);
 

--- a/containers/mosaic/src/components/Form/useForm/utils.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils.ts
@@ -28,6 +28,7 @@ export function stateFromStable({
 	submitWarning,
 	waits,
 	skeleton,
+	inputRevision,
 }: FormStable): FormState {
 	return {
 		internalData,
@@ -38,6 +39,7 @@ export function stateFromStable({
 		submitWarning,
 		waits,
 		skeleton,
+		inputRevision,
 	};
 }
 

--- a/containers/mosaic/src/components/Form/useForm/utils/getFieldError.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/getFieldError.ts
@@ -34,16 +34,16 @@ async function getFieldError({
 		validators.unshift({ fn: "required", options: {} });
 	}
 
-	if (field.type === "phone") {
-		validators.push({ fn: "validatePhoneNumber", options: {} });
-	}
-
 	if (field.type === "date") {
-		validators.push({ fn: "validateDate", options: {} });
+		validators.unshift({ fn: "validateDate", options: {} });
 	}
 
 	if (field.type === "time") {
-		validators.push({ fn: "validateTime", options: {} });
+		validators.unshift({ fn: "validateTime", options: {} });
+	}
+
+	if (field.type === "phone") {
+		validators.push({ fn: "validatePhoneNumber", options: {} });
 	}
 
 	if (field.inputSettings?.maxCharacters > 0) {

--- a/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
+++ b/containers/mosaic/src/components/Form/useForm/utils/sanitizeFieldDefs.ts
@@ -126,7 +126,6 @@ function sanitizeFieldDefs(fields: FieldDef[], sections?: SectionDef[]): FieldDe
 								maxDate,
 								showTime: false,
 							},
-							validates: ["time"],
 						},
 						{
 							name: "time",

--- a/containers/mosaic/src/utils/form/getFieldConfig.ts
+++ b/containers/mosaic/src/utils/form/getFieldConfig.ts
@@ -114,6 +114,7 @@ function getFieldConfigMapMemo(): () => FieldConfigMap {
 			date: {
 				Component: FormFieldDate,
 				validate: "onBlurAmend",
+				needsInputReset: true,
 				externalToInternalValue: (value: Date | undefined) => {
 					if (!value || !(value instanceof Date)) {
 						return { date: undefined };
@@ -144,6 +145,7 @@ function getFieldConfigMapMemo(): () => FieldConfigMap {
 			time: {
 				Component: FormFieldTime,
 				validate: "onBlurAmend",
+				needsInputReset: true,
 				externalToInternalValue: (value: string | undefined) => {
 					if (!value) {
 						return undefined;

--- a/containers/mosaic/src/utils/form/validators.ts
+++ b/containers/mosaic/src/utils/form/validators.ts
@@ -276,6 +276,10 @@ export async function validatePostcode(value: string, data: any, { countryField 
 }
 
 export async function validateDate(value: any, data: MosaicObject<any>, options: any, internalValue: any) {
+	if (internalValue?.isPartiallyFilled) {
+		return "Date is incomplete. Finish entering MM/DD/YYYY or clear the field";
+	}
+
 	if (!internalValue?.date) {
 		return;
 	}
@@ -291,6 +295,10 @@ export async function validateDate(value: any, data: MosaicObject<any>, options:
 }
 
 export async function validateTime(value: any, data: MosaicObject<any>, options: any, internalValue: any) {
+	if (internalValue?.isPartiallyFilled) {
+		return "Time is incomplete. Finish entering a 12hr time or clear the field";
+	}
+
 	if (!internalValue?.time) {
 		return;
 	}

--- a/containers/mosaic/src/utils/hooks/useRegisterField/useRegisterField.ts
+++ b/containers/mosaic/src/utils/hooks/useRegisterField/useRegisterField.ts
@@ -13,6 +13,7 @@ function useRegisterField(props: MosaicFieldProps & { fieldRef?: React.MutableRe
 		} = {},
 		inputRef,
 		fieldRef,
+		flushRef,
 	} = props;
 
 	useEffect(() => {
@@ -25,10 +26,11 @@ function useRegisterField(props: MosaicFieldProps & { fieldRef?: React.MutableRe
 			path,
 			fieldRef: fieldRef?.current,
 			inputRef: inputRef?.current,
+			flush: flushRef ? () => flushRef.current?.() : undefined,
 		});
 
 		return unmount;
-	}, [mountField, name, path, inputRef, skeleton, fieldRef]);
+	}, [mountField, name, path, inputRef, skeleton, fieldRef, flushRef]);
 }
 
 export default useRegisterField;

--- a/containers/sb-8/stories/components/Field/FormFieldDate/DateField.stories.tsx
+++ b/containers/sb-8/stories/components/Field/FormFieldDate/DateField.stories.tsx
@@ -111,7 +111,7 @@ export const KitchenSink = (): ReactElement => {
 	const helperText = "Helper text";
 	const instructionText = "Instruction text";
 
-	const fields: FieldDef[] = useMemo(
+	const fields = useMemo<FieldDef[]>(
 		() =>
 			[
 				{
@@ -156,6 +156,18 @@ export const KitchenSink = (): ReactElement => {
 					label: "Required Single Date Calendar",
 					required: true,
 					disabled: false,
+					helperText,
+					instructionText,
+					inputSettings: {
+						showTime: true,
+					},
+				},
+				{
+					name: "disabledDateTime",
+					type: "date",
+					label: "Disabled Date and Time",
+					required: true,
+					disabled: true,
 					helperText,
 					instructionText,
 					inputSettings: {


### PR DESCRIPTION
After the MUI X v8 date/time picker upgrade, section-based pickers could keep partially typed text in the DOM even when form values were reset or cleared programmatically. This adds an `inputRevision` counter to form state so date and time fields can remount and drop stale picker input.

- Increment `inputRevision` on form reset and when `setFormValues` is called with `resetInputs: true`
- Mark date and time fields with `needsInputReset` so they remount when the revision changes
- Apply `resetInputs: true` when the DataView date filter applies a preset
- Add reducer unit tests for revision behavior on set values and reset