### PR TITLE
MOS-1937 Rework

### DIFF
--- a/containers/mosaic/src/components/Field/utils/createContainedBlurHandler.ts
+++ b/containers/mosaic/src/components/Field/utils/createContainedBlurHandler.ts
@@ -21,7 +21,7 @@ export function isFocusInPickerOverlay(activeElement: Element | null = document.
 
 	// MUI X renamed the popper root from MuiPickersPopper-root to MuiPickerPopper-root;
 	// keep both so focus-in-overlay detection works across versions.
-	return Boolean(activeElement.closest(".MuiPickerPopper-root, .MuiPickersPopper-root, .MuiModal-root"));
+	return Boolean(activeElement.closest(".MuiPickerPopper-root, .MuiPickersPopper-root"));
 }
 
 export interface ContainedBlurHandlerOptions {


### PR DESCRIPTION
fix(Form): stop treating Drawer/modal focus as a date picker overlay

Omit `.MuiModal-root` from picker overlay detection so blur (and date validation) still runs when the field lives inside a Drawer or other Modal.